### PR TITLE
ci: split dev and prod concurrency groups (#444)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,12 @@
 #
 # With a timer the lock is held 30 minutes at most, and every merge reaches prod.
 #
+# Concurrency is per-environment (`deploy-dev` / `deploy-prod`) rather than one
+# group for the whole workflow, so a prod job waiting out its timer no longer
+# blocks a later run's dev deploy. Neither group cancels in-flight runs: these
+# are `sam deploy` calls, and killing one mid-flight can strand the stack in
+# UPDATE_IN_PROGRESS.
+#
 # Required GitHub Secrets:
 #   AWS_ROLE_ARN           — IAM role ARN for OIDC (e.g. arn:aws:iam::123456789012:role/mergewatch-github-deploy)
 #   AWS_REGION             — Target region (e.g. us-west-2)
@@ -54,10 +60,6 @@ on:
 env:
   # aws-actions/setup-sam@v2 still runs on Node.js 20; opt into Node.js 24
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
-concurrency:
-  group: deploy-pipeline
-  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -116,6 +118,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     environment: development
+    # Serialized against other DEV deploys only. Previously dev and prod shared
+    # one workflow-level group, so a prod job sitting in its gate blocked every
+    # later run's dev deploy too — dev fell ~9.5 hours behind main for a reason
+    # that had nothing to do with dev.
+    #
+    # cancel-in-progress stays false: these run `sam deploy`, and cancelling one
+    # mid-flight can leave the CloudFormation stack in UPDATE_IN_PROGRESS, which
+    # is worse than waiting.
+    concurrency:
+      group: deploy-dev
+      cancel-in-progress: false
 
     steps:
       - name: Checkout code
@@ -257,6 +270,13 @@ jobs:
     needs: deploy-dev
     if: github.event_name == 'push' || github.event.inputs.deploy_prod == 'true'
     environment: production
+    # Serialized against other PROD deploys only. A job waiting out the
+    # environment's 30-minute timer holds this group, so back-to-back merges
+    # still reach prod in order — but they no longer hold up anyone's dev
+    # deploy. Same reason as above for not cancelling in-flight deploys.
+    concurrency:
+      group: deploy-prod
+      cancel-in-progress: false
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Closes #444. Phase 1 of #445 — this is the blocker in front of everything else there.

## What happened

PR #428 is titled *"30-minute prod wait timer, **and split dev/prod concurrency**"* and is merged. Only the first half landed.

Commit `a9540eb` was pushed to `chore/prod-gate-wait-timer` **after** the squash-merge, so the merge never contained it:

```
$ git merge-base --is-ancestor a9540eb main ; echo $?
1                                   # NOT IN MAIN
```

`main` still had a single workflow-level `concurrency: deploy-pipeline`, and the file's own header comment still described the problem the split was meant to fix.

## Why it matters

Prod is gated by a 30-minute wait timer, and that job held the shared lock for the whole window — so **every merge in those 30 minutes queued behind it, including its dev deploy.** A milder version of the exact failure #428 set out to fix, where a parked run held the lock 9.5 hours and GitHub cancelled the next run outright.

It also blocks #445: an E2E verification job between dev and prod would extend the lock hold from 30 minutes to 30 minutes plus a suite run. With per-environment groups, that job serializes against prod only and leaves dev deploys alone — which is what makes the gate viable at all.

## The change

This cherry-picks `a9540eb` unchanged, preserving its authorship and reasoning, plus one cosmetic fix: removing the workflow-level block left a stray double blank line.

- Workflow-level `concurrency:` removed
- `deploy-dev` → `group: deploy-dev`
- `deploy-prod` → `group: deploy-prod`
- Neither sets `cancel-in-progress` — these run `sam deploy`, and killing one mid-flight can strand the stack in `UPDATE_IN_PROGRESS`, which is worse than waiting behind it

Verified by parsing the YAML rather than by eye:

```
top-level concurrency: ABSENT
  deploy-dev:  {'group': 'deploy-dev',  'cancel-in-progress': False}
  deploy-prod: {'group': 'deploy-prod', 'cancel-in-progress': False}
```

## Worth keeping

A merged PR's **title** is not evidence that all of its commits landed. #428 claimed two changes and shipped one, and nothing surfaced the gap for a day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp