### PR TITLE
ci: let the E2E gate be self-tested without pushing to main (#451)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,6 +70,11 @@ on:
         required: false
         type: boolean
         default: false
+      changed_paths:
+        description: 'E2E gate self-test: space-separated paths to use instead of the commit diff'
+        required: false
+        type: string
+        default: ''
 
 env:
   # aws-actions/setup-sam@v2 still runs on Node.js 20; opt into Node.js 24
@@ -315,11 +320,22 @@ jobs:
 
       - name: Compute changed paths
         id: changed
+        env:
+          # Passed through the environment rather than interpolated into the
+          # script: `${{ }}` of a user-supplied dispatch input lands inside the
+          # shell as text, which is a command-injection hole.
+          PATHS_OVERRIDE: ${{ github.event.inputs.changed_paths }}
+          BEFORE: ${{ github.event.before }}
+          SHA: ${{ github.sha }}
         run: |
-          BEFORE="${{ github.event.before }}"
-          if [ -n "$BEFORE" ] && [ "$BEFORE" != "0000000000000000000000000000000000000000" ] \
+          if [ -n "${PATHS_OVERRIDE:-}" ]; then
+            # The gate is otherwise only exercisable by pushing to main, which
+            # means it cannot be tested without polluting the branch it guards.
+            printf '%s\n' $PATHS_OVERRIDE | grep -v '^$' > /tmp/changed.txt
+            echo "::warning::Using changed_paths override — this run is a gate self-test, not the real commit diff."
+          elif [ -n "$BEFORE" ] && [ "$BEFORE" != "0000000000000000000000000000000000000000" ] \
              && git cat-file -e "$BEFORE^{commit}" 2>/dev/null; then
-            git diff --name-only "$BEFORE" "${{ github.sha }}" > /tmp/changed.txt
+            git diff --name-only "$BEFORE" "$SHA" > /tmp/changed.txt
           else
             git diff --name-only HEAD~1 HEAD > /tmp/changed.txt
           fi


### PR DESCRIPTION
Part of #451 — the gate's execution path has never run, and there was no way to run it deliberately.

## Why

The gate computes its selection from the commit diff. So the only way to exercise it was to **push a change to the branch it guards** — which makes the one thing worth rehearsing (a real fixture run that blocks prod) impossible to rehearse.

Adds a `changed_paths` dispatch input that substitutes for the diff:

```bash
gh workflow run deploy.yml \
  -f deploy_prod=false \
  -f changed_paths=packages/core/src/stage.ts
```

The run warns loudly when the override is in use, so a self-test can never be mistaken for a real verification.

## Injection hole closed while I was in there

The existing step interpolated `${{ github.event.before }}` and `${{ github.sha }}` directly into the shell script. Those particular values are trustworthy — but `${{ }}` is substituted as **text before bash sees it**, and a user-supplied dispatch input absolutely is not trustworthy. Adding `changed_paths` the same way would have been a command-injection hole.

All three now arrive through `env:` and are referenced as shell variables. Verified no `${{` remains in that step's `run:` block.

## Next

With this merged, the first deliberate exercise is `packages/core/src/stage.ts` → **5 fixtures**: `01-clean-pr`, `02-info-only`, `03-critical-finding`, `28a`, `28b`. That mix spans APPROVED and CHANGES_REQUESTED, so `reset-env.sh`, `run-suite.sh`, the settle wait and `grade-run.mjs` all get exercised on outcomes that actually differ — at a cost of 5 PRs and 5 LLM reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp