### PR TITLE
ci: give the E2E gate a git identity (#451)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -354,6 +354,16 @@ jobs:
         with:
           node-version: 20
 
+      - name: Configure git identity for the fixture commits
+        working-directory: fixtures-repo
+        run: |
+          # run-suite.sh commits each fixture overlay. A fresh runner has no
+          # git identity, and `bootstrap.sh` does not set one — it assumes a
+          # developer's local config. Without this the very first fixture dies
+          # with "empty ident name" (exit 128) before opening any PR.
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Resolve the selection
         id: select
         working-directory: fixtures-repo


### PR DESCRIPTION
The gate's first real fixture run — the deliberate exercise from #451 — died before opening a single PR.

```
→ Creating fixture/01-clean-pr from e2e-baseline.
→ Applying overlay...
    + src/utils.ts
Author identity unknown
fatal: empty ident name (for <runner@runnervm...internal.cloudapp.net>)
✗ 01-clean-pr failed (exit 128)
```

## Cause

`run-suite.sh` commits each fixture overlay. A fresh runner has **no git identity**, and `bootstrap.sh` doesn't set one — it assumes a developer's local config. That assumption is invisible until the suite runs somewhere that has none, which had never happened.

This is precisely the class of failure #451 predicted. Worth noting the prediction was wrong about *which* thing would break: I expected the 120s settle wait. The run never got far enough to reach it.

## The cascade matters as much as the cause

Fixture 1 died mid-apply and left the working tree dirty. `apply-fixture.sh` then refused fixtures 2–5 with `Working tree has uncommitted changes` — each after a 45-second sleep.

**Five failures, one cause.** In a blocking gate that reads as a broad product regression rather than a missing config, and it scales badly: at the full correctness set that's 50-odd guaranteed failures and ~40 minutes of sleeping. Fixed separately in the fixtures repo so a failed fixture can't poison the ones after it.

## This change

Configures the standard Actions bot identity in the fixtures checkout before the suite runs.

Nothing was left behind — teardown ran and the fixtures repo is back to 0 open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp