### PR TITLE
ci: gate waits on review status, not a 120s timer (#451)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -420,6 +420,25 @@ jobs:
         run: |
           xargs scripts/run-suite.sh < /tmp/sel.txt
 
+      - name: Return the checkout to main
+        if: steps.select.outputs.count != '0'
+        working-directory: fixtures-repo
+        run: |
+          # run-suite leaves the repo on the LAST fixture branch, which is cut
+          # from the e2e-baseline tag — and that tag predates the tooling. It
+          # has no grade-run.mjs, no select-fixtures.sh, and none of the 17
+          # expect.json files.
+          #
+          # The visible symptom was `grade-run.mjs: No such file or directory`
+          # (exit 127). The dangerous one was invisible: had the script been
+          # found, every fixture would have been UNGRADED for want of an
+          # expect.json, and grade-run exits 0 on UNGRADED — a green gate that
+          # verified nothing.
+          #
+          # .e2e/ is gitignored, so the run manifest survives the switch.
+          git checkout -f main
+          git log -1 --oneline
+
       - name: Wait for every review to complete
         if: steps.select.outputs.count != '0'
         working-directory: fixtures-repo

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -420,13 +420,18 @@ jobs:
         run: |
           xargs scripts/run-suite.sh < /tmp/sel.txt
 
-      - name: Let the last reviews settle
+      - name: Wait for every review to complete
         if: steps.select.outputs.count != '0'
+        working-directory: fixtures-repo
         run: |
-          # run-suite only sleeps BETWEEN fixtures, so the final PR has had no
-          # time at all when it returns. Grading early reads a missing review as
-          # a failure.
-          sleep 120
+          # Was `sleep 120`. A timer cannot tell "the review is still working"
+          # from "the review never started", and grading either one early
+          # reports a missing comment as a product failure — so a dead-lettered
+          # queue looked identical to a broken product in a gate that blocks
+          # prod. This polls each PR's stage check run until it is completed,
+          # and on timeout reports whether each PR is absent (webhook never
+          # handled) or queued (accepted but stalled).
+          scripts/await-reviews.mjs --stage "$MW_STAGE" --timeout 900
 
       - name: Grade
         id: grade


### PR DESCRIPTION
Replaces the gate's `sleep 120` with `scripts/await-reviews.mjs` (fixtures#719), which polls each fixture PR's stage check run until it completes.

## Why the timer was wrong

It cannot distinguish the two states that matter — **"still working"** and **"never started"**. Both present as "no comment yet", and grading either early reports it as a product failure.

In a gate that blocks production that's a real problem: a dead-lettered queue and a broken product look identical, and they need opposite responses. One is "retry the review", the other is "revert the merge".

## What replaces it

Polls the stage check run, which MergeWatch opens on pickup and completes on verdict:

| state | meaning |
|---|---|
| `absent` | webhook never handled it |
| `queued` / `in_progress` | accepted but not finished |
| `completed` | ready to grade |

Returns as soon as every review is done. The 900s ceiling is a backstop, not a target, and on timeout it prints **each PR's actual state** rather than a bare "timed out".

## Also: it scales

The 120s happened to be survivable for 5 fixtures — the run in flight while I wrote this got all five reviewed inside it. It would not have been for 55, where the last PR opens ~40 minutes after the first. The wait is now proportional to the work instead of a guess.

Verified against the gate's own live fixture PRs (fixtures#719 has the output): 5/5 completed with exit 0, and the timeout path reports every PR as `absent` with exit 1.

**Merge fixtures#719 first** — the script has to exist in the fixtures checkout before the workflow calls it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp