### PR TITLE
fix(core): stop treating CI and build config as trivial (#455)

### DIFF
--- a/packages/core/src/skip-logic.test.ts
+++ b/packages/core/src/skip-logic.test.ts
@@ -23,11 +23,30 @@ describe('shouldSkipPR', () => {
     expect(result).toContain('lock files');
   });
 
-  it('skips a single CI config file (.github/workflows/ci.yml)', () => {
-    const result = shouldSkipPR(['.github/workflows/ci.yml']);
-    expect(result).not.toBeNull();
-    // .github/** is matched by SKIP_PATTERNS; categorization may vary
-    expect(result).toMatch(/config|generated\/trivial/);
+  // #455 — this test previously asserted the OPPOSITE, that a workflow-only PR
+  // is skipped. It was inverted deliberately, not relaxed: a GitHub Actions
+  // workflow is executable configuration running with repository credentials,
+  // and treating it as a "CI tweak" meant the file that deploys to production
+  // was the one file never reviewed.
+  it('REVIEWS a workflow-only PR — executable config is not trivial (#455)', () => {
+    expect(shouldSkipPR(['.github/workflows/ci.yml'])).toBeNull();
+    expect(shouldSkipPR(['.github/workflows/deploy.yml'])).toBeNull();
+    expect(shouldSkipPR(['.github/actions/setup/action.yml'])).toBeNull();
+  });
+
+  it('REVIEWS other automation config that decides what runs or merges (#455)', () => {
+    // dependabot can enable automerge; CODEOWNERS decides who must approve;
+    // renovate.json can turn on automerge for dependency PRs.
+    expect(shouldSkipPR(['.github/dependabot.yml'])).toBeNull();
+    expect(shouldSkipPR(['.github/CODEOWNERS'])).toBeNull();
+    expect(shouldSkipPR(['renovate.json'])).toBeNull();
+    expect(shouldSkipPR(['.renovaterc.json'])).toBeNull();
+  });
+
+  it('still skips inert GitHub metadata — prose and forms (#455)', () => {
+    expect(shouldSkipPR(['.github/ISSUE_TEMPLATE/bug.md'])).not.toBeNull();
+    expect(shouldSkipPR(['.github/PULL_REQUEST_TEMPLATE.md'])).not.toBeNull();
+    expect(shouldSkipPR(['.github/FUNDING.yml'])).not.toBeNull();
   });
 
   // ─── Non-trivial files ───────────────────────────────────────────────────
@@ -60,10 +79,20 @@ describe('shouldSkipPR', () => {
     expect(result).not.toBeNull();
   });
 
-  it('skips config files (tsconfig.json)', () => {
-    const result = shouldSkipPR(['tsconfig.json']);
-    expect(result).not.toBeNull();
-    expect(result).toContain('config');
+  // #455 — also inverted. tsconfig.json changes compilation semantics: turning
+  // off `strict`, or repointing `paths`, weakens type safety across every file
+  // in the repo while showing up as a one-line diff in none of them.
+  it('REVIEWS tsconfig.json — it changes what the compiler enforces (#455)', () => {
+    expect(shouldSkipPR(['tsconfig.json'])).toBeNull();
+    expect(shouldSkipPR(['packages/core/tsconfig.json'])).toBeNull();
+  });
+
+  it('still skips editor and formatter preferences (#455)', () => {
+    // The surviving test for "trivial": changing one cannot change what
+    // executes, what CI enforces, or what merges without review.
+    expect(shouldSkipPR(['.editorconfig'])).not.toBeNull();
+    expect(shouldSkipPR(['.vscode/settings.json'])).not.toBeNull();
+    expect(shouldSkipPR(['.prettierrc'])).not.toBeNull();
   });
 
   it('skips prettierrc config files', () => {

--- a/packages/core/src/skip-logic.ts
+++ b/packages/core/src/skip-logic.ts
@@ -45,8 +45,11 @@ export const SKIP_PATTERNS = [
   '**/node_modules/**',
   '**/.gitignore',
   '**/.gitattributes',
-  // Config-only files (version bumps, CI tweaks)
-  '**/.github/**',
+  // Editor and formatting preferences.
+  //
+  // These are the only config files still treated as trivial, and the test is
+  // narrow: changing one cannot change what executes, what is enforced in CI,
+  // or what merges without review. They alter how a human's editor behaves.
   '**/.vscode/**',
   '**/.idea/**',
   '**/.editorconfig',
@@ -54,9 +57,17 @@ export const SKIP_PATTERNS = [
   '**/.prettierignore',
   '**/.prettierrc*',
   '**/.eslintrc*',
-  '**/tsconfig.json',
-  '**/renovate.json',
-  '**/.renovaterc*',
+
+  // Inert GitHub metadata — prose and forms, not automation.
+  //
+  // `.github/**` as a whole used to be here under the heading "version bumps,
+  // CI tweaks". That comment described the intent; the pattern was far wider,
+  // and it exempted `.github/workflows/**` — executable configuration that runs
+  // with repository credentials, and the single most valuable file in most
+  // repositories to review. See #455.
+  '**/.github/ISSUE_TEMPLATE/**',
+  '**/.github/PULL_REQUEST_TEMPLATE*',
+  '**/.github/FUNDING.yml',
 ];
 
 /**


### PR DESCRIPTION
Closes #455.

## The bug

`SKIP_PATTERNS` exempted `**/.github/**` under the heading *"Config-only files (version bumps, CI tweaks)"*. The comment described the **intent**; the pattern was far wider. A PR touching only `.github/` was smart-skipped and never reviewed.

## Evidence from this repo, today

| PR | Files | MergeWatch |
|---|---|---|
| #446 | `.github/workflows/deploy.yml` | `skipping` |
| #448 | `.github/workflows/deploy.yml` | `skipping` |
| #450 | `.github/workflows/deploy.yml` | `skipping` |
| #452 | `.github/workflows/deploy.yml` | `skipping` |
| #454 | `.github/workflows/deploy.yml` | `skipping` |

Those diffs added a job that **blocks production deploys**, wired in a **cross-repo write token**, and fixed a **command-injection hole** — a `workflow_dispatch` input interpolated through `${{ }}` straight into a `run:` block.

The file that deploys to production was the one file the reviewer was configured to ignore. I caught that injection by hand; the reviewer never saw the PR.

## The test that survives

A GitHub Actions workflow isn't documentation — it's executable configuration running with repository credentials, and it's where template injection, secret exfiltration, permission widening and silently-disabled gates live.

So the remaining bar for "trivial config" is narrow: **changing the file cannot change what executes, what CI enforces, or what merges without review.**

**Removed** — fails that test:

| | |
|---|---|
| `**/.github/**` | workflows, actions, `dependabot.yml`, `CODEOWNERS` |
| `**/tsconfig.json` | turning off `strict` weakens every file and shows in none |
| `**/renovate.json`, `**/.renovaterc*` | can enable automerge |

**Kept** — genuinely prose and forms: `ISSUE_TEMPLATE/**`, `PULL_REQUEST_TEMPLATE*`, `FUNDING.yml`. Editor and formatter preferences (`.vscode/**`, `.editorconfig`, `.prettierrc*`) also stay skipped.

## Two tests were inverted, not relaxed

`skips a single CI config file` and `skips config files (tsconfig.json)` asserted the old behaviour. Both now assert the opposite, and **each says so at the call site** so a future reader doesn't mistake a deliberate inversion for a weakened assertion.

## Also checked

- Default `excludePatterns` — no `.github`, `tsconfig` or `renovate` entries, so no matching change needed.
- No doc or RUNBOOK described `.github/**` as skippable.

## Deliberately not included

A fixture asserting *"a workflow-only PR is reviewed"*. It lives in `mergewatch/fixtures`, and nothing currently catches a regression of this — tracked on #455.

## Verified

`pnpm run build`, `typecheck`, and `test` all green — **1031 core tests**, 21/21 turbo tasks.

One nice property: this PR touches `packages/core`, so MergeWatch will review it. The next workflow PR will be reviewed too, which it wouldn't have been an hour ago.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp