### PR TITLE
fix(core): grounding demotes unanchorable criticals instead of deleting them (#459)

### DIFF
--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -2096,12 +2096,22 @@ describe('groundFinding', () => {
     expect(result!.line).toBe(11);
   });
 
-  it('drops a critical finding when the identifier nowhere appears in the file', () => {
-    // Reproduces the prod hallucination: line 89-91 are comments, file
-    // never even calls createChatSession() — drop the critical.
+  // #459 — INVERTED, not relaxed. This asserted `toBeNull()`: an unanchorable
+  // critical was deleted outright. It is now demoted to `unverified`, the same
+  // lane #385 chose for a refuted critical ("demotes to advisory, never
+  // deletes"). The finding still does not block — FP-L keeps it out of the
+  // action-items table and W7 clamps the score — but it renders under
+  // "Unverified concerns" instead of disappearing.
+  //
+  // The deletion was wrong for a whole class of TRUE finding: when the defect
+  // is the ABSENCE of code, its identifiers are absent from the file by
+  // definition. "No auth check", "missing await", "no null guard".
+  it('demotes rather than deletes a critical whose identifier is absent (#459)', () => {
     const file = ['// only comments here', 'const x = 1;', 'export default x;'].join('\n');
     const result = groundFinding(baseFinding, file);
-    expect(result).toBeNull();
+    expect(result).not.toBeNull();
+    expect(result!.severity).toBe('critical');
+    expect(result!.verification).toBe('unverified');
   });
 
   it('downgrades a warning to info when the identifier is missing (less destructive than dropping)', () => {
@@ -2117,11 +2127,25 @@ describe('groundFinding', () => {
     expect(groundFinding(info, file)).toBeNull();
   });
 
-  it('drops a critical when the anchor is past EOF', () => {
+  // #459 — INVERTED for the same reason as above.
+  it('demotes rather than deletes a critical anchored past EOF (#459)', () => {
     const file = 'one\ntwo\nthree';
-    expect(groundFinding({ ...baseFinding, line: 999 }, file)).toBeNull();
+    const result = groundFinding({ ...baseFinding, line: 999 }, file);
+    expect(result).not.toBeNull();
+    expect(result!.verification).toBe('unverified');
   });
 
+  it('leaves warning and info handling unchanged (#459)', () => {
+    const file = ['// only comments here', 'const x = 1;'].join('\n');
+    const warn = groundFinding({ ...baseFinding, severity: 'warning' }, file);
+    expect(warn?.severity).toBe('info');
+    expect(groundFinding({ ...baseFinding, severity: 'info' }, file)).toBeNull();
+  });
+
+  // #459 scope note: the no-op guard is deliberately UNCHANGED and still
+  // deletes. Demotion is for "could not confirm the anchor", not for
+  // "demonstrably not a problem" — here the suggested fix is already in the
+  // file, so there is no defect to be advisory about.
   it('drops a finding whose suggested code already exists (no-op guard, W1)', () => {
     // The PR #31 false positive: "missing await" flagged on a line that
     // already reads `const run = await migrationRunner({`, with a suggestion

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -2901,8 +2901,16 @@ export async function runReviewPipeline(
     orchestratorResult.findings,
     groundingContext,
   );
-  const structurallyGrounded = orchestratorResult.findings
-    .map((f) => groundFinding(f, groundingFileContents[f.file]))
+  // Keep each grounded result paired with the finding it came from. Counting
+  // from the FILTERED array against the original by index is wrong the moment
+  // anything is dropped — the indices shift — and it is wrong precisely in the
+  // case this logging exists to explain.
+  const groundedPairs = orchestratorResult.findings.map((original) => ({
+    original,
+    grounded: groundFinding(original, groundingFileContents[original.file]),
+  }));
+  const structurallyGrounded = groundedPairs
+    .map((p) => p.grounded)
     .filter((f): f is OrchestratedFinding => f !== null);
   // #459 — grounding was the ONLY deleting filter that logged nothing.
   // confidence-floor, min-severity, fp-c, clustering and finding-verify all
@@ -2910,12 +2918,11 @@ export async function runReviewPipeline(
   // CloudWatch, which is why diagnosing one cost a three-hypothesis dig
   // through the source. Announce drops and demotions the same way.
   {
-    const dropped = orchestratorResult.findings.length - structurallyGrounded.length;
-    const demoted = structurallyGrounded.filter(
-      (f, i) => f.severity === 'critical'
-        && f.verification === 'unverified'
-        && orchestratorResult.findings[i]?.verification !== 'unverified',
-    ).length;
+    const dropped = groundedPairs.filter((p) => p.grounded === null).length;
+    const demoted = groundedPairs.filter((p) => p.grounded !== null
+      && p.grounded.severity === 'critical'
+      && p.grounded.verification === 'unverified'
+      && p.original.verification !== 'unverified').length;
     if (dropped > 0) {
       console.warn('[grounding] dropped %d finding%s whose anchor did not survive',
         dropped, dropped === 1 ? '' : 's');

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -1730,7 +1730,17 @@ export function groundFinding(
   // Out-of-range anchor — definitely wrong. Drop critical, downgrade
   // warning to info, drop info outright.
   if (zeroBased < 0 || zeroBased >= lines.length) {
-    if (f.severity === 'critical') return null;
+    // #459 — a critical is DEMOTED, never deleted. #385 already settled this
+    // for the verifier ("a refuted CRITICAL demotes to advisory, never
+    // deletes") because a silently-vanished critical is the failure that let
+    // an unauthenticated admin endpoint through at 5/5. Grounding was still
+    // deleting them, and unlike every sibling filter it logged nothing, so the
+    // loss left no trace anywhere. Route into the same `unverified` lane the
+    // verifier uses: FP-L renders it under "Unverified concerns" and W7 clamps
+    // the score, so it is visible and advisory rather than absent.
+    if (f.severity === 'critical') {
+      return { ...f, verification: 'unverified' as const };
+    }
     if (f.severity === 'warning') return { ...f, severity: 'info' };
     return null;
   }
@@ -1755,8 +1765,15 @@ export function groundFinding(
 
   // Identifier nowhere in file. The orchestrator likely hallucinated the
   // finding (e.g. described `createChatSession()` on a file that doesn't
-  // call it). Drop critical, downgrade warning, drop info.
-  if (f.severity === 'critical') return null;
+  // call it) — but "likely" is doing real work here, and it is wrong for a
+  // whole class of true finding: when the defect is the ABSENCE of something,
+  // its identifiers are absent from the file by definition. "No auth check",
+  // "missing await", "no null guard" all name code that is not there.
+  //
+  // #459 — demote criticals instead of deleting them, same lane as above.
+  if (f.severity === 'critical') {
+    return { ...f, verification: 'unverified' as const };
+  }
   if (f.severity === 'warning') return { ...f, severity: 'info' };
   return null;
 }
@@ -2887,6 +2904,27 @@ export async function runReviewPipeline(
   const structurallyGrounded = orchestratorResult.findings
     .map((f) => groundFinding(f, groundingFileContents[f.file]))
     .filter((f): f is OrchestratedFinding => f !== null);
+  // #459 — grounding was the ONLY deleting filter that logged nothing.
+  // confidence-floor, min-severity, fp-c, clustering and finding-verify all
+  // announce their drops; a finding that vanished here left no trace in
+  // CloudWatch, which is why diagnosing one cost a three-hypothesis dig
+  // through the source. Announce drops and demotions the same way.
+  {
+    const dropped = orchestratorResult.findings.length - structurallyGrounded.length;
+    const demoted = structurallyGrounded.filter(
+      (f, i) => f.severity === 'critical'
+        && f.verification === 'unverified'
+        && orchestratorResult.findings[i]?.verification !== 'unverified',
+    ).length;
+    if (dropped > 0) {
+      console.warn('[grounding] dropped %d finding%s whose anchor did not survive',
+        dropped, dropped === 1 ? '' : 's');
+    }
+    if (demoted > 0) {
+      console.warn('[grounding] demoted %d critical%s to unverified (anchor unconfirmed, not deleted)',
+        demoted, demoted === 1 ? '' : 's');
+    }
+  }
   const groundedFindings = await verifyFindings(
     structurallyGrounded,
     groundingFileContents,


### PR DESCRIPTION
Refs #459 — fixes the silent-loss half. See *Scope* below for what it deliberately doesn't do.

## What happened

The E2E gate's first graded run flagged `28b`: an admin endpoint returning every user with no auth check rendered as **3/5, "nothing to render"**. The orchestrator flagged the critical; something downstream deleted it.

## Diagnosis, and why it was hard

CloudWatch for that exact invocation:

```
[fp-c] merged 6 cross-agent findings at the same (file, line)
[clustering] merged 1 related finding into existing clusters
Review complete for mergewatch/fixtures#730: 0 findings
```

No `[confidence-floor]`. No `[min-severity]`. No `[finding-verify]`. Every deleting filter that *logs* did not fire — which pointed at the one that doesn't:

| filter | log sites |
|---|---|
| confidence-floor | 1 |
| min-severity | 1 |
| fp-c | 1 |
| clustering | 1 |
| finding-verify | 7 |
| **grounding** | **0** |

I was wrong twice on the way here — first blaming grounding's identifier matching (disproved by running `groundFinding` against the real file), then the confidence floor (disproved by its absence from the logs). The silence is the actual defect that made both detours possible.

## The two changes

**1. Demote, don't delete.** `groundFinding` now returns `verification: 'unverified'` for criticals on both the out-of-range-anchor and identifier-absent paths.

#385 already settled this policy for the verifier — *"a refuted CRITICAL demotes to advisory, never deletes"* — precisely because an unauthenticated admin endpoint once shipped at 5/5. Grounding was still deleting them, contradicting its neighbour.

And the identifier-absent path was wrong for a whole class of **true** finding: **when the defect is the ABSENCE of code, its identifiers are absent from the file by definition.** "No auth check", "missing await", "no null guard".

**2. Grounding logs.** Drops and demotions both, like every sibling.

## Scope — this does not make 28b pass

The finding is now **visible** (FP-L renders it under "Unverified concerns", W7 clamps the score to 3). It is **not blocking**, so `28b`'s expectations — critical ≥ 1 in action items, `CHANGES_REQUESTED`, inline ≥ 1 — still fail.

Whether a grounding-unconfirmable critical *should* block is a real product decision, not something to smuggle in behind a bug fix. Left open on #459.

## Deliberately unchanged

The no-op-suggestion guard still deletes. Demotion is for *"could not confirm the anchor"*, not *"demonstrably not a problem"* — there the model proposed code already in the file, so there is no defect to be advisory about.

## Verified

Behavioural probe against 28b's real file, with a finding phrased purely in terms of what is absent:

```
before: DELETED
after:  kept · severity=critical verification=unverified
```

Two tests asserted the deletion and are **inverted, not relaxed** — each annotated at the call site. `pnpm build`, `typecheck`, `test` green: **1032 core tests**, 21/21 turbo tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp