### PR TITLE
fix(core): absence-of-code findings survive grounding intact (#459)

### DIFF
--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -20,6 +20,7 @@ import {
   runReviewPipeline,
   extractFindingIdentifiers,
   groundFinding,
+  describesAbsence,
   suggestionAlreadyApplied,
   suggestionMatchesExistingCode,
   verifyFindings,
@@ -2096,6 +2097,59 @@ describe('groundFinding', () => {
     expect(result!.line).toBe(11);
   });
 
+  // #459 — an absence-of-code finding survives grounding intact. The identifier
+  // check cannot see these: a missing `requireAdmin` call is absent from the
+  // file precisely because it is missing, so "identifier not found" is the
+  // finding restating itself, not evidence against it. This is the shape that
+  // deleted a live authorization bypass on fixtures#730.
+  it('keeps an absence-of-code critical intact, not demoted (#459)', () => {
+    const file = [
+      "import type { NextRequest } from 'next/server';",
+      'export async function GET(_req: NextRequest): Promise<Response> {',
+      '  const allUsers = await fetchAllUsers();',
+      '  return Response.json({ users: allUsers });',
+      '}',
+    ].join('\n');
+    const f = {
+      ...baseFinding,
+      line: 2,
+      title: 'Missing authorization guard',
+      description: 'No requireAdmin check protects this admin route.',
+    };
+    const r = groundFinding(f, file);
+    expect(r).not.toBeNull();
+    expect(r!.severity).toBe('critical');
+    // Intact — NOT demoted. It can still block on its own merits.
+    expect(r!.verification).toBeUndefined();
+  });
+
+  it('recognises the absence phrasings that matter (#459)', () => {
+    const yes = [
+      'Missing await on async call',
+      'Handler lacks input validation',
+      'Endpoint without any authentication',
+      'No null check before dereference',
+      'User input is not sanitized before the query',
+      'Unauthenticated admin endpoint',
+      'Fails to close the file handle',
+      'Never validates the signature',
+      'Omits the CSRF token',
+    ];
+    for (const t of yes) expect(describesAbsence(t)).toBe(true);
+  });
+
+  it('does not treat ordinary present-code findings as absences (#459)', () => {
+    // These assert something IS there and wrong — identifier absence really is
+    // evidence of hallucination for them, so they must still demote.
+    const no = [
+      'SQL injection in the user query',
+      'createChatSession() is called with an unbounded loop',
+      'Race condition between the two writers',
+      'Hardcoded credential in the config object',
+    ];
+    for (const t of no) expect(describesAbsence(t)).toBe(false);
+  });
+
   // #459 — INVERTED, not relaxed. This asserted `toBeNull()`: an unanchorable
   // critical was deleted outright. It is now demoted to `unverified`, the same
   // lane #385 chose for a refuted critical ("demotes to advisory, never
@@ -2114,16 +2168,27 @@ describe('groundFinding', () => {
     expect(result!.verification).toBe('unverified');
   });
 
+  // #459 — these two use `presentCodeFinding`, not `baseFinding`. baseFinding
+  // describes an ABSENCE ("is not awaited"), and absence findings now survive
+  // grounding intact by design. The hallucination path they exercise needs a
+  // finding that asserts something IS present and wrong.
+  const presentCodeFinding = {
+    ...baseFinding,
+    title: 'SQL injection in the user query',
+    description: 'The `createChatSession()` call interpolates user input directly into SQL.',
+    suggestion: 'Use a parameterised query.',
+  };
+
   it('downgrades a warning to info when the identifier is missing (less destructive than dropping)', () => {
     const file = 'const a = 1;\nconst b = 2;';
-    const warning = { ...baseFinding, severity: 'warning' as const, line: 1 };
+    const warning = { ...presentCodeFinding, severity: 'warning' as const, line: 1 };
     const result = groundFinding(warning, file);
     expect(result?.severity).toBe('info');
   });
 
   it('drops an info finding when the identifier is missing', () => {
     const file = 'const a = 1;';
-    const info = { ...baseFinding, severity: 'info' as const, line: 1 };
+    const info = { ...presentCodeFinding, severity: 'info' as const, line: 1 };
     expect(groundFinding(info, file)).toBeNull();
   });
 
@@ -2137,9 +2202,9 @@ describe('groundFinding', () => {
 
   it('leaves warning and info handling unchanged (#459)', () => {
     const file = ['// only comments here', 'const x = 1;'].join('\n');
-    const warn = groundFinding({ ...baseFinding, severity: 'warning' }, file);
+    const warn = groundFinding({ ...presentCodeFinding, severity: 'warning' }, file);
     expect(warn?.severity).toBe('info');
-    expect(groundFinding({ ...baseFinding, severity: 'info' }, file)).toBeNull();
+    expect(groundFinding({ ...presentCodeFinding, severity: 'info' }, file)).toBeNull();
   });
 
   // #459 scope note: the no-op guard is deliberately UNCHANGED and still

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -1715,6 +1715,43 @@ export function suggestionAlreadyApplied(
  * at the first occurrence. This salvages findings the orchestrator got
  * mostly right but anchored to a comment line near the actual code.
  */
+/**
+ * #459 — does this finding describe something that is MISSING?
+ *
+ * The identifier check below concludes "identifier nowhere in the file →
+ * probably hallucinated". That is sound for a finding asserting something is
+ * present and wrong ("you call `createChatSession()` without awaiting") and
+ * exactly backwards for one asserting something is absent ("there is no auth
+ * check"). In the second case the identifier's absence IS the finding: a
+ * missing `requireAdmin` call cannot be found in a file precisely because it
+ * is missing.
+ *
+ * That blind spot hits the highest-value findings there are — missing auth,
+ * missing await, missing null guard, missing validation — and it deleted a
+ * live authorization bypass on fixtures#730 (mergewatch.ai#459).
+ *
+ * Deliberately matched on phrasing rather than semantics. A hallucinated
+ * "missing X" still slips through here, and that is acceptable: W2's
+ * verification pass reads the actual file and judges the claim, which is the
+ * layer equipped to make that call. This function only decides whether
+ * *string absence* counts as evidence — and for an absence claim it does not.
+ */
+export function describesAbsence(text: string): boolean {
+  return ABSENCE_PATTERNS.some((re) => re.test(text));
+}
+
+const ABSENCE_PATTERNS: RegExp[] = [
+  /\bmissing\b/i,
+  /\blacks?\b|\blacking\b/i,
+  /\bwithout\s+(any\s+)?\w+/i,
+  /\bno\s+\w+\s*(check|guard|validation|validating|handling|handler|verification|auth\w*|sanitiz\w*|escap\w*|limit|timeout|retry|fallback)\b/i,
+  /\bnot\s+(validated|checked|verified|sanitized|escaped|authenticated|authorized|awaited|handled|closed|released)\b/i,
+  /\bun(authenticated|authorized|validated|checked|handled|sanitized|escaped)\b/i,
+  /\bfails?\s+to\s+\w+/i,
+  /\bnever\s+(checks?|validates?|verifies|awaits?|closes?|releases?)\b/i,
+  /\bomits?\b|\bomitted\b/i,
+];
+
 export function groundFinding(
   f: OrchestratedFinding,
   fileContent: string | undefined,
@@ -1765,12 +1802,15 @@ export function groundFinding(
 
   // Identifier nowhere in file. The orchestrator likely hallucinated the
   // finding (e.g. described `createChatSession()` on a file that doesn't
-  // call it) — but "likely" is doing real work here, and it is wrong for a
-  // whole class of true finding: when the defect is the ABSENCE of something,
-  // its identifiers are absent from the file by definition. "No auth check",
-  // "missing await", "no null guard" all name code that is not there.
+  // call it) — but "likely" is doing real work here.
   //
-  // #459 — demote criticals instead of deleting them, same lane as above.
+  // #459 — when the finding describes an ABSENCE, the identifier being absent
+  // is not evidence against it; it is the finding. Pass those through intact
+  // so a real "no auth check" reaches the verifier and can still block, rather
+  // than being demoted to advisory for a structural reason.
+  if (describesAbsence(`${f.title} ${f.description}`)) return f;
+
+  // Otherwise demote criticals rather than deleting them, same lane as above.
   if (f.severity === 'critical') {
     return { ...f, verification: 'unverified' as const };
   }


### PR DESCRIPTION
Refs #459. Follows #460 — that stopped the *deletion*; this addresses *why it was unanchorable*.

## The decision behind it

The open question was "should a grounding-unconfirmable critical block?" Both answers are bad:

- **Block all unverified criticals** → reintroduces exactly the false-positive class grounding and W7 exist to suppress
- **Leave 28b advisory** → a live auth bypass renders amber with a passing check

The question was the wrong one. The defect is upstream of the policy: **grounding fails structurally on absence-of-code findings.**

`groundFinding` concludes *"identifier nowhere in the file → probably hallucinated"*. That's sound for a finding asserting something is **present and wrong** — *"you call `createChatSession()` without awaiting"* — and exactly backwards for one asserting something is **absent** — *"there is no auth check"*.

**In the second case the identifier's absence IS the finding.** A missing `requireAdmin` call cannot be found in the file precisely because it is missing.

That blind spot hits the highest-value findings there are: missing auth, missing await, missing null guard, missing validation. It deleted a real authorization bypass on fixtures#730.

## What changes

Absence-phrased findings pass through grounding intact and can block on their own merits. No change to the blocking policy.

## Layering, stated deliberately

Matched on **phrasing, not semantics**. A hallucinated "missing X" still slips through here — and that's correct: **W2's verification pass reads the actual file and judges the claim.** That's the layer equipped to make the call. `groundFinding` only decides whether *string absence* counts as evidence, and for an absence claim it does not.

## Verified

28b's real file, across all three states:

| | result |
|---|---|
| before #460 | **DELETED** |
| after #460 | kept · `unverified` (advisory) |
| now | kept · **intact** |

Also confirmed at the formatter, since I'd asserted #460's rendering without checking it: an unverified critical does render under "Unverified concerns", is correctly excluded from "Requires your attention", and produces no "Nothing rendered".

## Two test changes worth flagging

**Two existing tests moved from `baseFinding` to a new `presentCodeFinding`.** `baseFinding` says *"is not awaited"* — itself an absence claim — so it no longer suits tests exercising the hallucination path. The assertions are unchanged; only the vehicle was wrong. That's the detector working, not a regression.

**Dropped `unbounded`** from the pattern set — reads as a missing limit in some contexts and as present-code in others. Too ambiguous to carry, and it produced a false positive in my own test.

## Scope

This removes the structural reason 28b's finding couldn't anchor. It does not *guarantee* 28b goes green — the finding still has to survive W2 and the rest of the pipeline on its merits, which is the point. Worth re-running the gate against `stage.ts` after merge to see where it actually lands.

`pnpm build`, `typecheck`, `test` green: **1035 core tests**, 21/21 turbo tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp