### PR TITLE
ci: setup-sam v2 → v3, drop the Node 20 forcing flag (#453)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,10 +76,6 @@ on:
         type: string
         default: ''
 
-env:
-  # aws-actions/setup-sam@v2 still runs on Node.js 20; opt into Node.js 24
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 permissions:
   contents: read
   id-token: write # Required for OIDC authentication
@@ -119,7 +115,7 @@ jobs:
         run: pnpm run migrations:check
 
       - name: Setup AWS SAM CLI
-        uses: aws-actions/setup-sam@v2
+        uses: aws-actions/setup-sam@v3
         with:
           use-installer: true
 
@@ -169,7 +165,7 @@ jobs:
         run: pnpm run build
 
       - name: Setup AWS SAM CLI
-        uses: aws-actions/setup-sam@v2
+        uses: aws-actions/setup-sam@v3
         with:
           use-installer: true
 
@@ -552,7 +548,7 @@ jobs:
         run: pnpm run build
 
       - name: Setup AWS SAM CLI
-        uses: aws-actions/setup-sam@v2
+        uses: aws-actions/setup-sam@v3
         with:
           use-installer: true
 


### PR DESCRIPTION
Closes #453.

## What the warning actually was

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are
being forced to run on Node.js 24: aws-actions/setup-sam@v2.
```

Not a new problem surfacing — **our own workaround announcing itself.** `setup-sam@v2` declares `using: "node20"`, and `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` overrode it. The runner was reporting the override we asked for.

## Why fix it now

The flag is an opt-in to something that becomes mandatory. When GitHub removes the Node 20 runtime, forcing stops being a choice and an action still targeting `node20` **fails rather than warns**. What breaks is deploys, at the moment someone is trying to ship.

## The upstream fix

`aws-actions/setup-sam@v3` (2026-05-01) declares `using: node24`. Its complete release note:

> This release tracks the v2 tag.
> **Breaking changes**: Update action to use node 24

One upstream PR between the tags. Verified rather than inferred — the input surface is **identical** (`python, token, use-installer, version`), and we pass only `use-installer`.

## All three sites together

`build`, `deploy-dev`, `deploy-prod`. #444 is the precedent: a `deploy.yml` change that landed in some places and not others left a confusing partial state nobody noticed for a day.

## Verification

No unit tests — this is CI configuration with no importable behaviour, and saying so beats inventing a test that asserts nothing. Instead, checked by parsing the resulting YAML:

```
v2 remaining: 0 · v3 call sites: 3 · forcing flag: 0
jobs: build, deploy-dev, e2e-gate, deploy-prod
top-level env: ABSENT
  build:       setup-sam@v3  with={'use-installer': True}
  deploy-dev:  setup-sam@v3  with={'use-installer': True}
  deploy-prod: setup-sam@v3  with={'use-installer': True}
```

Plus: nothing else in the repo references the removed flag. `build`/`typecheck`/`test` green (21/21 turbo tasks, unchanged — no TS touched).

The real proof is the next dev deploy running `sam build` and `sam deploy` cleanly with the warning gone. I'll report that rather than assume it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp