### PR TITLE
ci: production wait timer 30 min → 10 min (#445)

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -71,7 +71,7 @@ If `$ARGUMENTS` is empty, ask what to ship and stop.
 Merging is not the end of the pipeline. `main` deploys on its own:
 
 ```
-push to main -> build & test -> deploy-dev -> [E2E gate] -> [30 min timer] -> deploy-prod
+push to main -> build & test -> deploy-dev -> [E2E gate] -> [10 min timer] -> deploy-prod
 ```
 
 Nobody clicks approve (#428 replaced required reviewers with a wait timer), so a merged change reaches production whether or not anyone is watching. That is exactly why the tail has to be followed rather than assumed.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,10 +3,10 @@
 # =============================================================================
 #
 # Pipeline:
-#   push to main → build & test → deploy to dev → [30 min] → deploy to prod
+#   push to main → build & test → deploy to dev → [E2E gate] → [10 min] → deploy to prod
 #   (prod also deployable on-demand via workflow_dispatch with deploy_prod=true)
 #
-# The production gate is a 30-minute WAIT TIMER, not an approval requirement.
+# The production gate is a 10-minute WAIT TIMER, not an approval requirement.
 # Prod deploys on its own once the timer elapses; the window exists so a bad
 # merge can be stopped by cancelling the run, not so someone has to click
 # approve on every deploy.
@@ -18,7 +18,15 @@
 # pending per group). That very nearly shipped a merged-but-never-deployed
 # change: nothing anywhere reports "this landed on main but not in prod".
 #
-# With a timer the lock is held 30 minutes at most, and every merge reaches prod.
+# With a timer the lock is held 10 minutes at most, and every merge reaches prod.
+#
+# It was 30 until the E2E gate landed (#445). The window exists to catch what
+# nothing else does — and the gate now verifies dev before prod, so most of
+# that job is done before the timer starts. Shortened, not removed: the gate
+# selects fixtures by impact, so a docs-or-CI-only merge selects ZERO and
+# passes without checking anything. For those the timer is still the only
+# safety net. Revisit removing it when #447 makes a green gate reliably mean
+# something was verified.
 #
 # Concurrency is per-environment (`deploy-dev` / `deploy-prod`) rather than one
 # group for the whole workflow, so a prod job waiting out its timer no longer
@@ -45,7 +53,7 @@
 #
 # Required GitHub Environments:
 #   development            — no protection rules needed
-#   production             — "Wait timer" of 30 minutes, NO required reviewers.
+#   production             — "Wait timer" of 10 minutes, NO required reviewers.
 #                            Adding required reviewers back reintroduces the
 #                            parked-gate problem described above.
 #
@@ -275,7 +283,7 @@ jobs:
   # Stage 3: E2E gate against dev (#445)
   # =========================================================================
   # Runs the fixture suite against the just-deployed DEV app and blocks prod on
-  # the result. Before this, nothing verified dev before prod — the 30-minute
+  # the result. Before this, nothing verified dev before prod — the
   # timer was a window for a human to notice and cancel, not a gate.
   #
   # Selection is impact-scoped (`--changed-files`), automated-only, and
@@ -500,7 +508,7 @@ jobs:
   # =========================================================================
   # Runs after a successful dev deploy on every push to main, AND on a manual
   # workflow_dispatch with deploy_prod=true. It then waits out the "production"
-  # environment's 30-minute timer (#428 replaced required reviewers with a
+  # environment's 10-minute timer (#428 replaced required reviewers with a
   # timer; see the header for why).
   #
   # It is additionally gated on the E2E suite passing against dev. A skipped
@@ -521,7 +529,7 @@ jobs:
       && (github.event_name == 'push' || github.event.inputs.deploy_prod == 'true')
     environment: production
     # Serialized against other PROD deploys only. A job waiting out the
-    # environment's 30-minute timer holds this group, so back-to-back merges
+    # environment's 10-minute timer holds this group, so back-to-back merges
     # still reach prod in order — but they no longer hold up anyone's dev
     # deploy. Same reason as above for not cancelling in-flight deploys.
     concurrency:


### PR DESCRIPTION
The environment setting is **already changed** (verified: `wait_timer: 10 min`). This makes the documentation match — the half that rots.

## Why shorten

The 30-minute window was a *cancellation* window: time for a human to notice a bad merge and kill the run, because **nothing verified dev before prod**. The E2E gate now does, so most of that job is finished before the timer even starts.

## Why not remove it

The gate selects fixtures by impact, and **a docs-or-CI-only merge selects ZERO and passes without checking anything.**

#462's own merge is the example — `.github/**` maps to no fixtures, so the gate went green having verified nothing. For those merges the timer remains the only safety net.

Two further reasons:

- **The gate tests dev, not prod.** #264 was a prod-only parameter drift that dev never showed.
- **Coverage is 17 graded fixtures**, not the product. Green means those 17 held.

## Why an environment timer, not a conditional sleep

The appealing design is a wait *proportional to what was verified* — short when the gate checked something, full when it selected 0. GitHub's environment timer is static per environment, so that would need a `sleep` step instead.

There's a cost asymmetry that settles it: a job **waiting on an environment hasn't started and bills no runner minutes**, while a `sleep` bills the full wait on `ubuntu-latest` every single deploy. The flexible version costs real money the static one doesn't.

## When to revisit

Removing it becomes defensible once #447 makes a green gate reliably mean *something was verified*. Right now "the E2E tests pass" is frequently vacuous, and shortening to 10 minutes is the honest middle.

Also updates the pipeline diagram in `deploy.yml` and `ship.md` to show the gate — it landed after the diagram was written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp