### PR TITLE
ci: the E2E gate tears down only what it set up (#442)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -495,7 +495,18 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Tear down
-        if: always()
+        # always() so a FAILED run still cleans up — but only when the suite
+        # actually set something up. Without the count gate this ran on every
+        # gate invocation, including ones that selected zero fixtures and
+        # touched nothing, and reset-env.sh then closed every open PR in the
+        # shared fixtures repo. That is how a docs-only merge closed
+        # fixtures#763, a human's fixture-authoring PR, four seconds into a
+        # gate run that did no work at all (#442).
+        #
+        # The blast radius is fixed at source in fixtures#765 (reset-env now
+        # only touches `fixture/*`). This is the other half: do not tear down
+        # what you did not set up.
+        if: always() && steps.select.outputs.count != '0'
         working-directory: fixtures-repo
         run: |
           # Always, including on failure: leaving ~10 open PRs behind would make


### PR DESCRIPTION
`Tear down` was `if: always()` with **no count gate**, so it ran `reset-env.sh` on every gate invocation — including ones that selected **zero** fixtures and did no work at all.

`reset-env.sh` closes every open PR in the shared fixtures repo. So a docs-only merge destroyed a human's fixture-authoring PR.

## Evidence from the gate's own step timings

```
Resolve the selection:           0 fixtures
Reset the fixtures environment:  skipped   (already count-gated)
Run the suite / restore / grade: skipped
Tear down:                       21:24:39 → 21:24:43

fixtures#763 closed at           21:24:40Z
```

Closed with `--delete-branch`, so the PR couldn't even be reopened until the branch was re-pushed.

## My bug, and how it happened

I wrote that `always()` deliberately — to stop a *failed* run orphaning ~10 fixture PRs and leaving the next run's reset to clean them up.

The intent was right and the condition was too wide. **The safety mechanism became the hazard.** `always()` is kept, so a failed run still cleans up; the count gate adds the part that was missing.

## Two fixes, deliberately

The blast radius is corrected at source in **fixtures#765** — `reset-env.sh` now only touches `fixture/*` branches, so even a *legitimate* gate run can no longer close a person's PR.

Either fix alone would have prevented this incident. Both are worth having because they fail differently: this one stops needless teardown, that one stops teardown from reaching things it doesn't own.

## Resulting conditions

```
Reset the fixtures environment     count != '0'
Run the suite against dev          count != '0'
Restore the tooling checkout       count != '0'
Wait for every review to complete  count != '0'
Grade                              count != '0'
Summary                            always()
Tear down                          always() && count != '0'
```

`Summary` stays unconditional — reporting "nothing impacted" is exactly when the summary matters most.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp