### PR TITLE
fix(core): cluster findings before the filters that delete them (#385)

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -1333,6 +1333,7 @@ The bait: bug / security / style / error-handling agents each have a distinct an
 
 **Failure modes**
 - ❌ All N findings still appear separately in the table (clustering didn't fire — probable cause: no shared significant token after stop-word filtering; check `extractSignificantTokens` on the actual titles)
+- ❌ Fewer findings than planted and **no** "and N related concerns" row — the siblings were filtered before consolidation saw them. W10 runs BEFORE the FP-A confidence floor and the min-severity filter for exactly this reason (#385); if that ordering is ever reversed, a region-spread cluster is dismantled before it can form, while an exact-line duplicate still survives via FP-C upstream. That asymmetry between E2E-29 and E2E-32 is the tell.
 - ❌ Two findings on the same file in **different code regions** got merged into one (over-cluster — `maxLineSpan` may have been widened too far, or the token-overlap heuristic accepted a coincidental match)
 - ❌ The merged finding's severity is NOT the strongest in the cluster (severity-rank tie-break bug)
 - ❌ The merged finding's body lost the audit trail (the "Related concerns" list is missing or truncated)

--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -1152,6 +1152,77 @@ describe('runReviewPipeline', () => {
     expect(result.mergeScoreReason).toContain('No issues');
   });
 
+  // #385 — W10 clustering runs BEFORE the FP-A confidence floor.
+  //
+  // The reported symptom: E2E-29's region-spread findings were filter-dropped
+  // before consolidation saw them, so no "and N related concerns" row survived
+  // — while E2E-32, the same shape sharing one exact line, came through fine
+  // via FP-C upstream. The asymmetry was ordering, not the findings.
+  it('clusters a region-spread group before the confidence floor can dismantle it (#385)', async () => {
+    // The security agent emits the pair; the rest are empty. Agents must
+    // actually produce findings or the orchestrator never runs.
+    const securityResponse = validFindingsJson([
+      {
+        line: 2, severity: 'critical', confidence: 40,
+        title: 'Import validation missing on bar payload',
+      },
+      {
+        line: 3, severity: 'warning', confidence: 95,
+        title: 'Payload validation needs a schema check',
+      },
+    ]);
+    const agentResponse = JSON.stringify({ findings: [] });
+    const summaryResponse = JSON.stringify({ summary: 'Refactor.' });
+    const diagramResponse = '%% overview\nflowchart TD\n  A-->B';
+    const orchestratorResponse = JSON.stringify({
+      findings: [
+        {
+          file: 'foo.ts', line: 2, severity: 'critical', category: 'security',
+          confidence: 40,
+          title: 'Import validation missing on bar payload',
+          description: '…', suggestion: '…',
+        },
+        {
+          file: 'foo.ts', line: 3, severity: 'warning', category: 'security',
+          confidence: 95,
+          title: 'Payload validation needs a schema check',
+          description: '…', suggestion: '…',
+        },
+      ],
+      mergeScore: 2,
+      mergeScoreReason: 'Critical present.',
+    });
+    const llm = createMockLLM([
+      securityResponse, agentResponse, agentResponse,
+      agentResponse, agentResponse, agentResponse,
+      summaryResponse, diagramResponse, orchestratorResponse,
+    ]);
+
+    const result = await runReviewPipeline(
+      {
+        diff: sampleDiff,
+        context: sampleContext,
+        modelId: 'heavy-model',
+        lightModelId: 'light-model',
+        maxFindings: 25,
+        enabledAgents: allAgentsEnabled,
+        minConfidence: 75,
+      },
+      { llm },
+    );
+
+    // Both survive as ONE finding carrying the audit trail. Under the old
+    // ordering the floor ran first: the 40-confidence critical was deleted
+    // outright and the survivor had nothing left to cluster with, so the
+    // "related concerns" block never existed.
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].title).toMatch(/and 1 related concern/);
+    expect(result.findings[0].description).toMatch(/Related concerns clustered into this finding/);
+    // Severity is the strongest; confidence is now ALSO the strongest, which is
+    // what carries the merged finding over the floor rather than under it.
+    expect(result.findings[0].severity).toBe('critical');
+  });
+
   it('preserves the orchestrator mergeScore when there are visible findings post-filter', async () => {
     // Orchestrator returns a finding on a CHANGED line (line 3 — within
     // sampleDiff's range) with score 3. Filter keeps it. Score stays.

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -2830,6 +2830,41 @@ export async function runReviewPipeline(
     agentAuthored,
   );
 
+  // #385 — W10 runs BEFORE the deleting filters below.
+  //
+  // It used to run after, so a region-spread cluster could be dismantled by
+  // the confidence floor before consolidation ever saw it: E2E-29 lost every
+  // sibling and rendered no "and N related concerns" row, while E2E-32 -- the
+  // same shape but sharing one exact line -- survived via FP-C upstream. The
+  // asymmetry was an artifact of ordering, not of the findings.
+  //
+  // Safe only because a merged finding now carries the MAX confidence of its
+  // members (finding-clustering.ts). Reordering without that would let a
+  // low-confidence critical absorb well-evidenced warnings and take the whole
+  // cluster below the floor -- worse than the behaviour being fixed.
+
+  // W10 — finding consolidation: cluster fragmented findings about the
+  // same code region (same file, lines within ±maxLineSpan, ≥1 shared
+  // significant token across title+description) into one finding with
+  // the strongest severity. Canonical case is voice-bot PR #37 where one
+  // "validate parsed S3 chunk file structure" concern was emitted as
+  // three separate findings at lines 82 / 130 / 150. Conservative defaults
+  // and a cluster-size cap keep over-clustering risk low. The absorbed
+  // count rolls into the downstream suppressedCount math.
+  {
+    const { findings: clustered, clusteredCount } = clusterFindings(
+      orchestratorResult.findings,
+    );
+    if (clusteredCount > 0) {
+      console.warn(
+        '[clustering] merged %d related finding%s into existing clusters',
+        clusteredCount,
+        clusteredCount === 1 ? '' : 's',
+      );
+      orchestratorResult.findings = clustered;
+    }
+  }
+
   // FP-A — Hard confidence-floor filter.
   // The orchestrator's prompt (rule #5) tells the model to drop findings with
   // confidence < 75, but nothing in code enforces it. This deterministic post-
@@ -2895,28 +2930,6 @@ export async function runReviewPipeline(
         suppressedCount === 1 ? '' : 's',
       );
       orchestratorResult.findings = collapsed;
-    }
-  }
-
-  // W10 — finding consolidation: cluster fragmented findings about the
-  // same code region (same file, lines within ±maxLineSpan, ≥1 shared
-  // significant token across title+description) into one finding with
-  // the strongest severity. Canonical case is voice-bot PR #37 where one
-  // "validate parsed S3 chunk file structure" concern was emitted as
-  // three separate findings at lines 82 / 130 / 150. Conservative defaults
-  // and a cluster-size cap keep over-clustering risk low. The absorbed
-  // count rolls into the downstream suppressedCount math.
-  {
-    const { findings: clustered, clusteredCount } = clusterFindings(
-      orchestratorResult.findings,
-    );
-    if (clusteredCount > 0) {
-      console.warn(
-        '[clustering] merged %d related finding%s into existing clusters',
-        clusteredCount,
-        clusteredCount === 1 ? '' : 's',
-      );
-      orchestratorResult.findings = clustered;
     }
   }
 

--- a/packages/core/src/finding-clustering.test.ts
+++ b/packages/core/src/finding-clustering.test.ts
@@ -168,6 +168,53 @@ describe('clusterFindings', () => {
 
 // ─── FP-C: pre-orchestrator cross-agent dedup ───────────────────────────────
 
+// ─── #385 — a cluster is as well-evidenced as its strongest member ──────────
+//
+// These matter because W10 now runs BEFORE the FP-A confidence floor. The
+// merged finding is what the floor sees, so inheriting only the primary's
+// score would let a weak critical delete well-evidenced siblings.
+describe('#385 — merged confidence is the max across members', () => {
+  it('takes the highest confidence, not the primary severity holder\'s', () => {
+    const findings = [
+      // primary by severity, but poorly evidenced
+      f({ line: 10, severity: 'critical', confidence: 40, title: 'Input validation missing on payload' }),
+      f({ line: 12, severity: 'warning', confidence: 95, title: 'Payload validation needs schema check' }),
+    ];
+    const { findings: out, clusteredCount } = clusterFindings(findings);
+    expect(clusteredCount).toBe(1);
+    expect(out[0].severity).toBe('critical');   // severity still the strongest
+    expect(out[0].confidence).toBe(95);         // confidence now also the strongest
+  });
+
+  it('survives the FP-A floor it would previously have failed', () => {
+    // The regression this guards: with the primary's 40, a >=75 floor would
+    // drop the merged finding and take the 95-confidence sibling with it.
+    const [merged] = clusterFindings([
+      f({ line: 10, severity: 'critical', confidence: 40, title: 'Input validation missing on payload' }),
+      f({ line: 12, severity: 'warning', confidence: 95, title: 'Payload validation needs schema check' }),
+    ]).findings;
+    expect((merged.confidence ?? 100) >= 75).toBe(true);
+  });
+
+  it('leaves confidence absent when no member carries one', () => {
+    // Unscored findings default to 100 at the floor; inventing a number here
+    // would be a silent behaviour change for callers that never set it.
+    const { findings: out } = clusterFindings([
+      f({ line: 10, title: 'Input validation missing on payload' }),
+      f({ line: 12, title: 'Payload validation needs schema check' }),
+    ]);
+    expect(out[0].confidence).toBeUndefined();
+  });
+
+  it('ignores members with no confidence when taking the max', () => {
+    const { findings: out } = clusterFindings([
+      f({ line: 10, title: 'Input validation missing on payload' }),
+      f({ line: 12, confidence: 80, title: 'Payload validation needs schema check' }),
+    ]);
+    expect(out[0].confidence).toBe(80);
+  });
+});
+
 describe('dedupeCrossAgentByLine', () => {
   function cf(partial: Partial<ClusterableFinding> & { line: number; title: string }): ClusterableFinding {
     return { file: 'src/x.ts', severity: 'warning', description: '', ...partial };

--- a/packages/core/src/finding-clustering.ts
+++ b/packages/core/src/finding-clustering.ts
@@ -32,6 +32,12 @@ export interface ClusterableFinding {
   severity: 'critical' | 'warning' | 'info';
   title: string;
   description: string;
+  /**
+   * #385 — read so a merged finding can carry the STRONGEST confidence in its
+   * cluster, mirroring the strongest-severity rule. Absent means "unscored",
+   * which the FP-A floor already treats as 100.
+   */
+  confidence?: number;
 }
 
 const SEVERITY_RANK: Record<ClusterableFinding['severity'], number> = {
@@ -204,8 +210,24 @@ export function clusterFindings<T extends ClusterableFinding>(
     const relatedList = others
       .map((o) => `- \`${o.file}:${o.line}\` (${o.severity}) — ${o.title}`)
       .join('\n');
+    // #385 — confidence is the MAX across members, not the primary's.
+    //
+    // `primary` is chosen by severity alone, so without this a
+    // low-confidence critical absorbs higher-confidence warnings and inherits
+    // only its own weak score. Once clustering runs BEFORE the FP-A floor
+    // (which it now does), that would let one weak critical drag a whole
+    // cluster of well-evidenced findings below the threshold and delete them
+    // together — strictly worse than the pre-clustering behaviour.
+    //
+    // Taking the max mirrors the rule already applied to severity: a cluster
+    // is as serious, and as well-evidenced, as its strongest member.
+    const maxConfidence = members.reduce<number | undefined>((acc, m) => {
+      if (m.confidence == null) return acc;
+      return acc == null ? m.confidence : Math.max(acc, m.confidence);
+    }, undefined);
     const merged: T = {
       ...primary,
+      ...(maxConfidence != null ? { confidence: maxConfidence } : {}),
       title: `${primary.title} — and ${others.length} related concern${others.length === 1 ? '' : 's'}`,
       description: `${primary.description}\n\n**Related concerns clustered into this finding (W10):**\n${relatedList}`,
     };


### PR DESCRIPTION
Part of #385 — the remaining half. Its other two asks are already shipped: the false-green disclosure (#404/#406) and custom-agent findings being exempted from FP-C.

## The reported asymmetry

E2E-29's region-spread findings were filter-dropped **before** W10 consolidation saw them — no *"and N related concerns"* row, audit trail gone. E2E-32, the same shape but sharing one exact line, came through fine because FP-C merges exact-line doubles upstream of everything.

That difference was **ordering, not findings**. W10 now runs ahead of the FP-A confidence floor and the #310 min-severity filter.

## The reorder is unsafe alone — which is the more interesting half

The merged finding inherits `...primary`, and `primary` is chosen by **severity alone**:

```ts
members.sort((a, b) => SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity] || a.line - b.line);
const primary = members[0];
const merged = { ...primary, title, description };
```

So a low-confidence critical absorbs well-evidenced warnings and carries only *its own* weak score into the floor — deleting the whole cluster. **Strictly worse than the behaviour being fixed.**

A merged finding now carries the **max confidence across its members**, mirroring the strongest-severity rule already there: a cluster is as serious, *and as well-evidenced*, as its strongest member.

## Both halves demonstrated, not asserted

Reverting either one fails the new pipeline test — in a different way each time:

| reverted | failure |
|---|---|
| **the reorder** | `"Payload validation…" does not match /and 1 related concern/` — the floor ate the critical first, nothing left to cluster. **The original #385 symptom.** |
| **max-confidence** | `expected [] to have a length of 1` — the cluster merged at confidence 40 and the floor deleted *all* of it, including the 95-confidence warning. **The predicted regression.** |
| **both present** | passes |

## A judgement call worth flagging

Findings with **no** confidence stay unscored rather than being assigned a number. The floor already defaults them to 100, and inventing one here would be a silent behaviour change for every caller that never sets the field.

## Tests

4 in `finding-clustering.test.ts` for the merge rule (including the no-confidence and mixed cases), 1 pipeline test in `reviewer.test.ts` locking the ordering end to end. Workspace green: **1040 tests**, 21/21 turbo tasks.

`RUNBOOK` records the failure mode on E2E-29's card — the 29-vs-32 asymmetry is the diagnostic tell if this ordering is ever reversed.

## Scope

This does **not** change FP-A's policy of deleting low-confidence criticals outright. That inconsistency is real — W2 and grounding both demote rather than delete — but it's a separate behavioural decision with its own noise trade-off, and bundling it behind an ordering fix would be the wrong way to make it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp