### PR TITLE
feat(core): per-finding evidence in the PR comment

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -252,6 +252,7 @@ The 20 fixtures deliberately left out are model-judgment (E2E-20, -36, -48, -54)
 | [E2E-87](#e2e-87-337--date-only-range-bounds-include-their-whole-day) | `/api/analytics` date-only `start_date`/`end_date` expand to the UTC day's edge instants at the boundary (`end_date=2026-08-16` includes the whole 16th); full timestamps pass through untouched; identical on both backends; UTC bucketing documented in the route (#337) | 2m | 30s | #337 | `rollup`, `correctness` |
 | [E2E-88](#e2e-88-355--pr-burst-resilience) | A PR burst never silently loses reviews: throttles park the review (`pending` + in_progress "rate limited" check, never terminal FAILURE) and admission control paces the backlog — SQS `MaximumConcurrency` on SaaS, Postgres `SKIP LOCKED` worker at `REVIEW_CONCURRENCY` on self-hosted; exhaustion lands in a DLQ/`status='dead'`, visibly (#355) | 20m | n/a | #355 | — |
 | [E2E-95](#e2e-95-416--selective-suite-runs-by-tag-mode-or-changed-paths) | `TAGS`/`MODE` on every fixture; `--tag` / `--mode` / `--changed-files` resolve a subset; unmapped paths and unknown tags fail loudly rather than silently running nothing (#416) | 2m | n/a | fixtures#705 | `tooling` · _script-verified, no fixture_ |
+| [E2E-101](#e2e-101-469--every-finding-carries-proof-a-reader-can-check) | Each critical renders cited code, the verifier's one-sentence reason, and cross-agent convergence inline; warnings show the reason only and info shows nothing; `ux.showEvidence: false` opts out (#469) | 2m | 60s | #476 | `output`, `review-core` · _unit-test-gated_ |
 | [E2E-100](#e2e-100-468--an-oversized-review-truncates-visibly-never-vanishes) | A review body over GitHub's 65,536-char comment limit truncates with a notice naming what was dropped, instead of failing the POST and vanishing from the PR; verdict, summary and all criticals never shed, and inline `mw-fp` fingerprints survive truncation (#468) | 3m | 60s | #474 | `output`, `review-core` · _unit-test-gated, no fixture_ |
 | [E2E-99](#e2e-99-401--malformed-agent-output-is-disclosed-not-counted-as-suppression) | Agent responses that parse but return unusable findings no longer inflate the suppressed counter; they surface as a distinct "Malformed agent output" warning (#401) | 2m | 60s | #429 | `agents`, `output` · _unit-test-gated, no fixture_ |
 | [E2E-98](#e2e-98-423--oversized-diffs-skip-with-a-reason-never-hard-fail) | Build artifacts excluded by default and oversized files dropped by size; a diff still over the model's context budget yields a neutral "diff too large" skip naming sizes and remedy, never a raw ValidationException (#423) | 4m | 60s | #426 | `skip`, `config`, `correctness` |
@@ -3511,6 +3512,47 @@ The verdict, the summary, and **every critical** are never droppable. Whatever s
 - ❌ The notice links to a dashboard that does not exist on a self-hosted deploy
 - ❌ `/resolve` stops matching a previously reported finding — the fingerprint was truncated away
 - ❌ An ordinary review changes shape — the section refactor was supposed to be output-neutral
+
+---
+
+### E2E-101: #469 — every finding carries proof a reader can check
+
+**Status:** 🆕 NEW (#469) — unit-gated; verify opportunistically on any PR with a real critical.
+
+**Behavior:** a finding used to be four pieces of model prose — title, description, suggestion, confidence — with nothing showing the code it was about or that anything had checked it. The W2/FP-E verifier was already producing exactly that confirmation, one sentence citing specific code, and formatting it into a `console.warn` before throwing it away. Evidence is that sentence, plus the cited code, plus cross-agent convergence, routed to the developer instead of CloudWatch. No new inference: every element already existed.
+
+Rendering is **severity-asymmetric because the data is**. `verifyFindings` skips info entirely, so info findings have no verifier reason to show:
+
+| severity | renders |
+|---|---|
+| critical | cited code (≤ 3 lines) + reason + convergence, **inline, uncollapsed** |
+| warning | the reason only, one `↳` line, no code block |
+| info | **nothing** |
+
+This also repairs the **Unverified concerns** section, which explained every item with one blanket sentence; each demoted critical now shows its own reason.
+
+**Setup.** A PR with a genuine critical on a file the reviewer can fetch. `03-critical-finding` is the natural fixture.
+
+**Expected outcomes.**
+- [ ] A critical renders the cited code inline, not behind a `<details>`
+- [ ] The cited code is at most 3 lines and is the anchor line ±1
+- [ ] The verifier's sentence appears under the finding, capped at 200 chars
+- [ ] Two agents on one line render `security + bugs agreed independently`; a lone agent renders **no** attribution
+- [ ] A warning shows the reason with **no** code block
+- [ ] An info finding shows **no** evidence affordance at all
+- [ ] Each item under "Unverified concerns" carries its own reason
+- [ ] The "Requires your attention" table is unchanged — no new column
+- [ ] Grounding result and confidence-vs-floor do **not** appear
+- [ ] `ux.showEvidence: false` removes evidence entirely, leaving findings otherwise identical
+- [ ] Evidence survives a re-review — it round-trips through storage (`findings` is jsonb; no migration)
+
+**Failure modes.**
+- ❌ Evidence on an info finding — an empty shell implying a check that never ran, which is the coverage illusion this exists to remove
+- ❌ A single agent named as if it were convergence — restates the category and dilutes the real signal
+- ❌ Evidence collapsed behind a click on a critical — hiding proof on the highest-stakes finding is backwards
+- ❌ The reason runs to a paragraph — a finding needing a paragraph to justify itself has failed to justify itself
+- ❌ Comment growth is noticeably larger than ~350 chars per critical
+- ❌ A pre-#469 stored review fails to render — evidence is optional and its absence must be silent
 
 ---
 

--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -30,6 +30,10 @@ import {
   type PreviousFinding,
   type ReviewPipelineOptions,
   isIntentClaimDismissal,
+  withEvidenceCode,
+  normalizeEvidenceReason,
+  EVIDENCE_REASON_MAX,
+  type OrchestratedFinding,
 } from './reviewer.js';
 import { AGENT_MODE_SUFFIX, AGENT_MODE_PLACEHOLDER, FINDING_VERIFICATION_PROMPT } from './prompts.js';
 
@@ -2488,7 +2492,7 @@ describe('verifyFindings', () => {
       '{"valid": false, "confidence": 0.95, "reason": "line 1 already awaits searchViaPostgres"}',
     ]);
     const result = await verifyFindings([critical], fileContents, 'light', llm);
-    expect(result).toEqual([{ ...critical, verification: 'unverified' }]);
+    expect(result).toEqual([{ ...critical, verification: 'unverified', evidence: { reason: 'line 1 already awaits searchViaPostgres' } }]);
   });
 
   it('#385 — a refuted WARNING is still dropped (drop authority below critical is unchanged)', async () => {
@@ -2503,7 +2507,7 @@ describe('verifyFindings', () => {
   it('keeps a critical the model confirms — tags it `verified` (W7 input)', async () => {
     const llm = createMockLLM(['{"valid": true, "confidence": 0.9, "reason": "genuine defect"}']);
     const result = await verifyFindings([critical], fileContents, 'light', llm);
-    expect(result).toEqual([{ ...critical, verification: 'verified' }]);
+    expect(result).toEqual([{ ...critical, verification: 'verified', evidence: { reason: 'genuine defect' } }]);
   });
 
   it('keeps the finding when the file could not be fetched — leaves verification UNSET (W2 didn\'t run)', async () => {
@@ -2544,7 +2548,7 @@ describe('verifyFindings', () => {
       '{"valid": true, "confidence": 0.9, "reason": "confirmed on retry"}',
     ]);
     const result = await verifyFindings([critical], fileContents, 'light', llm);
-    expect(result).toEqual([{ ...critical, verification: 'verified' }]);
+    expect(result).toEqual([{ ...critical, verification: 'verified', evidence: { reason: 'confirmed on retry' } }]);
     expect(llm.calls).toHaveLength(2);
   });
 
@@ -2587,7 +2591,7 @@ describe('verifyFindings', () => {
     const warning = { ...critical, severity: 'warning' as const };
     const llm = createMockLLM(['{"valid": true, "confidence": 0.85, "reason": "genuine smell"}']);
     const result = await verifyFindings([warning], fileContents, 'light', llm);
-    expect(result).toEqual([{ ...warning, verification: 'verified' }]);
+    expect(result).toEqual([{ ...warning, verification: 'verified', evidence: { reason: 'genuine smell' } }]);
   });
 
   it('FP-E — keeps a warning the model can\'t verdict on — tags it `unverified`', async () => {
@@ -2628,7 +2632,7 @@ describe('verifyFindings', () => {
     ]);
     const result = await verifyFindings([c, w, i], fileContents, 'light', llm);
     expect(result).toEqual([
-      { ...c, verification: 'verified' },
+      { ...c, verification: 'verified', evidence: { reason: 'real bug' } },
       // w dropped (invalid)
       i, // pass-through, no tag
     ]);
@@ -2849,7 +2853,7 @@ describe('verifyFindings', () => {
         '{"valid": false, "confidence": 0.92, "reason": "abstraction-safe — Drizzle eq() parameterizes the value"}',
       ]);
       const result = await verifyFindings([finding], fileContents, 'light', llm);
-      expect(result).toEqual([{ ...finding, verification: 'unverified' }]);
+      expect(result).toEqual([{ ...finding, verification: 'unverified', evidence: { reason: 'abstraction-safe — Drizzle eq() parameterizes the value' } }]);
     });
 
     it('still KEEPS the finding when the model returns valid:true (regression: FP-K must not over-suppress)', async () => {
@@ -2861,7 +2865,7 @@ describe('verifyFindings', () => {
         '{"valid": true, "confidence": 0.85, "reason": "raw concat, no parameterization in sight"}',
       ]);
       const result = await verifyFindings([finding], fileContents, 'light', llm);
-      expect(result).toEqual([{ ...finding, verification: 'verified' }]);
+      expect(result).toEqual([{ ...finding, verification: 'verified', evidence: { reason: 'raw concat, no parameterization in sight' } }]);
     });
   });
 });
@@ -3627,7 +3631,7 @@ describe('verifyFindings — intent-claim guard (#372)', () => {
       '{"valid": false, "reason": "The query goes through a parameterized prepared statement two lines up."}',
     ]);
     const result = await verifyFindings([critical], fileContents, 'light', llm);
-    expect(result).toEqual([{ ...critical, verification: 'unverified' }]);
+    expect(result).toEqual([{ ...critical, verification: 'unverified', evidence: { reason: 'The query goes through a parameterized prepared statement two lines up.' } }]);
   });
 });
 
@@ -3766,7 +3770,7 @@ describe('structured outputs (#390)', () => {
       },
     };
     const result = await verifyFindings([{ ...finding, category: 'security' }], fileContents, 'light', llm);
-    expect(result).toEqual([{ ...finding, category: 'security', verification: 'unverified' }]);
+    expect(result).toEqual([{ ...finding, category: 'security', verification: 'unverified', evidence: { reason: 'the code is parameterized' } }]);
   });
 
   it('verifyFindings falls back to the text path when structured is unsupported', async () => {
@@ -3776,6 +3780,92 @@ describe('structured outputs (#390)', () => {
       async invokeStructured(): Promise<never> { throw new StructuredOutputUnsupportedError('none'); },
     };
     const result = await verifyFindings([{ ...finding, category: 'security' }], fileContents, 'light', llm);
-    expect(result).toEqual([{ ...finding, category: 'security', verification: 'verified' }]);
+    expect(result).toEqual([{ ...finding, category: 'security', verification: 'verified', evidence: { reason: 'real' } }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Evidence plumbing (#469)
+// ---------------------------------------------------------------------------
+
+describe('withEvidenceCode (#469)', () => {
+  const contents = {
+    'src/db.ts': ['const a = 1;', 'const b = 2;', 'query(`${id}`);', 'const d = 4;'].join('\n'),
+  };
+  // Typed, not inferred: an untyped literal narrows `evidence` out of T and
+  // every assertion below loses the field.
+  const base: OrchestratedFinding = {
+    file: 'src/db.ts', line: 3, severity: 'critical',
+    category: 'security', title: 't', description: 'd', suggestion: 's',
+  };
+
+  it('cites the anchor line plus one either side', () => {
+    const [f] = withEvidenceCode([base], contents);
+    expect(f.evidence?.code).toBe('const b = 2;\nquery(`${id}`);\nconst d = 4;');
+    expect(f.evidence?.codeStartLine).toBe(2);
+  });
+
+  it('caps the citation at 3 lines', () => {
+    const [f] = withEvidenceCode([base], contents);
+    expect(f.evidence!.code!.split('\n')).toHaveLength(3);
+  });
+
+  it('clamps at the start of file without wrapping', () => {
+    const [f] = withEvidenceCode([{ ...base, line: 1 }], contents);
+    expect(f.evidence?.code).toBe('const a = 1;\nconst b = 2;');
+    expect(f.evidence?.codeStartLine).toBe(1);
+  });
+
+  it('clamps at the end of file', () => {
+    const [f] = withEvidenceCode([{ ...base, line: 4 }], contents);
+    expect(f.evidence?.code).toBe('query(`${id}`);\nconst d = 4;');
+  });
+
+  it('skips info findings — the verifier never runs on them', () => {
+    const [f] = withEvidenceCode([{ ...base, severity: 'info' as const }], contents);
+    expect(f.evidence).toBeUndefined();
+  });
+
+  it('is a no-op when the file was not fetched', () => {
+    const [f] = withEvidenceCode([base], {});
+    expect(f.evidence).toBeUndefined();
+  });
+
+  it('is a no-op when the anchor is out of range', () => {
+    const [f] = withEvidenceCode([{ ...base, line: 999 }], contents);
+    expect(f.evidence).toBeUndefined();
+  });
+
+  it('preserves evidence already attached upstream', () => {
+    // Explicit generic: the inline `evidence` literal re-narrows T and would
+    // otherwise hide `code` from the assertion below.
+    const [f] = withEvidenceCode<OrchestratedFinding>(
+      [{ ...base, evidence: { agents: ['security', 'bugs'] } }],
+      contents,
+    );
+    expect(f.evidence?.agents).toEqual(['security', 'bugs']);
+    expect(f.evidence?.code).toContain('query(');
+  });
+});
+
+describe('normalizeEvidenceReason (#469)', () => {
+  it('caps at EVIDENCE_REASON_MAX with an ellipsis', () => {
+    const out = normalizeEvidenceReason('x'.repeat(500))!;
+    expect(out.length).toBe(EVIDENCE_REASON_MAX);
+    expect(out.endsWith('…')).toBe(true);
+  });
+
+  it('flattens newlines so the reason stays one rendered line', () => {
+    expect(normalizeEvidenceReason('line one\nline two\ttab')).toBe('line one line two tab');
+  });
+
+  it('returns undefined for empty or whitespace-only input', () => {
+    expect(normalizeEvidenceReason(undefined)).toBeUndefined();
+    expect(normalizeEvidenceReason('')).toBeUndefined();
+    expect(normalizeEvidenceReason('   \n  ')).toBeUndefined();
+  });
+
+  it('leaves a short reason untouched', () => {
+    expect(normalizeEvidenceReason('Line 15 interpolates id.')).toBe('Line 15 interpolates id.');
   });
 });

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -46,6 +46,7 @@ import { computeReviewDelta, fingerprintFromCode } from '../review-delta.js';
 import { partitionDisputed } from '../triage.js';
 import { detectNoTestHarness, suppressTestCoverageFindings } from '../scope-awareness.js';
 import { clusterFindings, dedupeCrossAgentByLine, extractSignificantTokens } from '../finding-clustering.js';
+import type { FindingEvidence } from '../types/db.js';
 import { FILE_REQUEST_INSTRUCTION, invokeWithFileFetching } from '../context/agentic-fetcher.js';
 import type { FileFetchOptions } from '../context/agentic-fetcher.js';
 import { fetchFileContents } from '../context/file-fetcher.js';
@@ -87,6 +88,13 @@ export interface AgentFinding {
    * warnings is informational + used downstream by delta/UX.
    */
   verification?: 'verified' | 'unverified';
+  /**
+   * #469 — per-finding proof (cited code, the verifier's reason, cross-agent
+   * convergence). Assembled inside the pipeline because its inputs are local
+   * to it: `groundingFileContents` never leaves `runReviewPipeline`, and the
+   * verifier's reason is discarded inside `verifyFindings`.
+   */
+  evidence?: FindingEvidence;
 }
 
 export interface OrchestratedFinding extends AgentFinding {
@@ -1282,6 +1290,22 @@ export type PreviousFinding = {
 /** Maximum characters per serialised string field to limit prompt injection surface. */
 const PREV_FINDING_FIELD_MAX = 200;
 
+/**
+ * #469 — cap on the verifier reason surfaced to the developer. A finding that
+ * needs a paragraph to justify itself has failed to justify itself; the
+ * verifier prompt already specifies "one sentence citing the specific code".
+ * Same bound as PREV_FINDING_FIELD_MAX above, for the same reason.
+ */
+export const EVIDENCE_REASON_MAX = 200;
+
+/** Collapse whitespace and clamp a verifier reason to one renderable sentence. */
+export function normalizeEvidenceReason(reason: string | undefined): string | undefined {
+  if (!reason) return undefined;
+  const flat = reason.replace(/[\r\n\t\x00-\x1f\x7f]+/g, ' ').trim();
+  if (!flat) return undefined;
+  return flat.length <= EVIDENCE_REASON_MAX ? flat : `${flat.slice(0, EVIDENCE_REASON_MAX - 1)}…`;
+}
+
 /** Strip newlines/control chars and cap length to bound malicious input. */
 function sanitizePreviousFindingString(value: unknown): string {
   if (typeof value !== 'string') return '';
@@ -2121,7 +2145,9 @@ export async function verifyFindings(
     priorContextBlock,
   );
 
-  type Verdict = { keep: boolean; verification?: 'verified' | 'unverified' };
+  // #469 — `reason` rides along so the verifier's one-sentence justification
+  // reaches the developer instead of only CloudWatch.
+  type Verdict = { keep: boolean; verification?: 'verified' | 'unverified'; reason?: string };
   const verdicts = await withConcurrency<Verdict>(
     findings.map((f) => async () => {
       // FP-E: verify both criticals and warnings; skip only info-level.
@@ -2213,7 +2239,7 @@ ${content}`;
               f.line,
               (parsed.reason ?? '').slice(0, 200),
             );
-            return { keep: true, verification: 'unverified' };
+            return { keep: true, verification: 'unverified', reason: parsed.reason };
           }
           // #385 — a refuted CRITICAL demotes to advisory, never deletes.
           // The verifier runs on the light model and can refute a true
@@ -2232,7 +2258,7 @@ ${content}`;
               f.line,
               (parsed.reason ?? '').slice(0, 200),
             );
-            return { keep: true, verification: 'unverified' };
+            return { keep: true, verification: 'unverified', reason: parsed.reason };
           }
           console.warn(
             '[finding-verify] dropped false-positive %s "%s" (%s:%d): %s',
@@ -2245,7 +2271,7 @@ ${content}`;
           return { keep: false };
         }
         if (parsed.valid === true) {
-          return { keep: true, verification: 'verified' };
+          return { keep: true, verification: 'verified', reason: parsed.reason };
         }
         // Ambiguous twice: parsed but no usable verdict even after the retry.
         console.warn(
@@ -2283,7 +2309,20 @@ ${content}`;
   for (let i = 0; i < findings.length; i++) {
     const v = verdicts[i];
     if (!v.keep) continue;
-    result.push(v.verification ? { ...findings[i], verification: v.verification } : findings[i]);
+    const f = findings[i];
+    if (!v.verification) {
+      result.push(f);
+      continue;
+    }
+    // #469 — merge rather than overwrite: cross-agent convergence was already
+    // attached upstream by dedupeCrossAgentByLine and must survive this pass.
+    const reason = normalizeEvidenceReason(v.reason);
+    const evidence = reason ? { ...(f.evidence ?? {}), reason } : f.evidence;
+    result.push({
+      ...f,
+      verification: v.verification,
+      ...(evidence ? { evidence } : {}),
+    });
   }
   return result;
 }
@@ -2297,6 +2336,41 @@ ${content}`;
  * Best-effort: when the file wasn't fetched or the anchor is out of range,
  * the finding keeps no fingerprint and delta falls back to the title key.
  */
+/**
+ * #469 — attach the cited code to each finding's evidence: the anchor line
+ * ±1, at most 3 lines, from the contents already fetched for grounding.
+ *
+ * Critical and warning only, matching where evidence renders. Info findings
+ * are skipped deliberately — `verifyFindings` never runs on them, so they
+ * have no reason to pair the code with, and storing code that will never be
+ * shown just inflates every persisted review.
+ *
+ * Best-effort, like withCodeFingerprints below: no contents or an
+ * out-of-range anchor means no code, not a broken finding.
+ */
+export function withEvidenceCode<T extends OrchestratedFinding>(
+  findings: T[],
+  fileContents: Record<string, string>,
+): T[] {
+  return findings.map((f) => {
+    if (f.severity !== 'critical' && f.severity !== 'warning') return f;
+    const content = fileContents[f.file];
+    if (!content) return f;
+    const lines = content.split('\n');
+    const idx = f.line - 1;
+    if (idx < 0 || idx >= lines.length) return f;
+    const start = Math.max(0, idx - 1);
+    const end = Math.min(lines.length, idx + 2);
+    const code = lines.slice(start, end).join('\n');
+    // An anchor on a blank line yields nothing worth rendering.
+    if (!code.trim()) return f;
+    return {
+      ...f,
+      evidence: { ...(f.evidence ?? {}), code, codeStartLine: start + 1 },
+    };
+  });
+}
+
 function withCodeFingerprints<T extends OrchestratedFinding>(
   findings: T[],
   fileContents: Record<string, string>,
@@ -3028,10 +3102,16 @@ export async function runReviewPipeline(
       customFindings.length === 1 ? '' : 's',
     );
   }
-  const preTriageFindings = [
-    ...onChangedLines,
-    ...withCodeFingerprints(customFindings, groundingFileContents),
-  ];
+  // #469 — attach cited code once, after builtin and custom findings are
+  // combined, so a single call covers both paths rather than two that can
+  // drift apart.
+  const preTriageFindings = withEvidenceCode(
+    [
+      ...onChangedLines,
+      ...withCodeFingerprints(customFindings, groundingFileContents),
+    ],
+    groundingFileContents,
+  );
 
   // W3 convergence guard: drop findings the author already rebutted/deferred
   // in a prior `## mergewatch triage` reply (keyed via the W9 stable

--- a/packages/core/src/comment-formatter.test.ts
+++ b/packages/core/src/comment-formatter.test.ts
@@ -796,3 +796,147 @@ describe('comment size budget (#468)', () => {
     expect(noticeAt).toBeLessThan(firstCriticalAt);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Per-finding evidence (#469)
+// ---------------------------------------------------------------------------
+
+describe('per-finding evidence (#469)', () => {
+  const EVIDENCE = {
+    code: 'const q = `SELECT * FROM users WHERE id = ${id}`;',
+    codeStartLine: 14,
+    reason: 'Line 15 interpolates `id` straight into the SQL string.',
+  };
+
+  it('renders all three elements inline on a critical', () => {
+    const result = formatReviewComment(baseOptions({
+      findings: [makeFinding({
+        severity: 'critical',
+        evidence: { ...EVIDENCE, agents: ['security', 'bugs'] },
+      })],
+      mergeScore: 1,
+    }));
+    expect(result).toContain('Cited code');
+    expect(result).toContain('SELECT * FROM users');
+    expect(result).toContain('Line 15 interpolates');
+    expect(result).toContain('security + bugs agreed independently');
+  });
+
+  it('does not collapse critical evidence behind a <details>', () => {
+    const result = formatReviewComment(baseOptions({
+      findings: [makeFinding({ severity: 'critical', evidence: EVIDENCE })],
+      mergeScore: 1,
+    }));
+    // The critical section itself is uncollapsed; hiding proof behind a click
+    // on the highest-stakes finding would be backwards.
+    const criticalAt = result.indexOf('### 🔴');
+    const evidenceAt = result.indexOf('Cited code');
+    const detailsAt = result.indexOf('<details>', criticalAt);
+    expect(evidenceAt).toBeGreaterThan(criticalAt);
+    expect(detailsAt === -1 || evidenceAt < detailsAt).toBe(true);
+  });
+
+  it('gives a warning the reason only — no code block', () => {
+    const result = formatReviewComment(baseOptions({
+      findings: [makeFinding({ severity: 'warning', evidence: EVIDENCE })],
+      mergeScore: 3,
+    }));
+    expect(result).toContain('Line 15 interpolates');
+    expect(result).not.toContain('Cited code');
+    expect(result).not.toContain('SELECT * FROM users');
+  });
+
+  it('renders NOTHING for info — an empty shell would imply a check that never ran', () => {
+    const result = formatReviewComment(baseOptions({
+      findings: [makeFinding({ severity: 'info', evidence: EVIDENCE })],
+      mergeScore: 5,
+    }));
+    expect(result).not.toContain('Cited code');
+    expect(result).not.toContain('Line 15 interpolates');
+    expect(result).not.toContain('↳');
+  });
+
+  it('omits agent attribution when only one agent raised it', () => {
+    const result = formatReviewComment(baseOptions({
+      findings: [makeFinding({ severity: 'critical', evidence: { ...EVIDENCE, agents: ['security'] } })],
+      mergeScore: 1,
+    }));
+    expect(result).not.toContain('agreed independently');
+    expect(result).not.toContain('security +');
+  });
+
+  it('gives each unverified concern its own reason, not just the blanket sentence', () => {
+    const result = formatReviewComment(baseOptions({
+      findings: [
+        makeFinding({
+          severity: 'critical', verification: 'unverified', title: 'A',
+          evidence: { reason: 'Could not confirm: the sink is behind an interface.' },
+        }),
+        makeFinding({
+          severity: 'critical', verification: 'unverified', title: 'B', line: 40,
+          evidence: { reason: 'The cited line is a comment, not executable code.' },
+        }),
+      ],
+      mergeScore: 3,
+    }));
+    expect(result).toContain('Unverified concerns');
+    expect(result).toContain('the sink is behind an interface');
+    expect(result).toContain('The cited line is a comment');
+  });
+
+  it('ux.showEvidence: false suppresses evidence entirely', () => {
+    const result = formatReviewComment(baseOptions({
+      findings: [makeFinding({ severity: 'critical', evidence: { ...EVIDENCE, agents: ['security', 'bugs'] } })],
+      mergeScore: 1,
+      ux: { showEvidence: false },
+    }));
+    expect(result).not.toContain('Cited code');
+    expect(result).not.toContain('Line 15 interpolates');
+    expect(result).not.toContain('agreed independently');
+    // The finding itself still renders.
+    expect(result).toContain('SQL injection risk');
+  });
+
+  it('leaves the "Requires your attention" table unchanged', () => {
+    const result = formatReviewComment(baseOptions({
+      findings: [makeFinding({ severity: 'critical', evidence: EVIDENCE })],
+      mergeScore: 1,
+    }));
+    const table = result.slice(result.indexOf('| | Location | Finding |'), result.indexOf('### 🔴'));
+    expect(table).not.toContain('Cited code');
+    expect(table).not.toContain('↳');
+  });
+
+  it('back-compat: a finding with no evidence renders exactly as before', () => {
+    const withEvidence = formatReviewComment(baseOptions({
+      findings: [makeFinding({ severity: 'critical' })], mergeScore: 1,
+    }));
+    const suppressed = formatReviewComment(baseOptions({
+      findings: [makeFinding({ severity: 'critical' })], mergeScore: 1, ux: { showEvidence: false },
+    }));
+    expect(withEvidence).toBe(suppressed);
+  });
+
+  it('stays within the ~350-char budget for a fully populated critical', () => {
+    const bare = formatReviewComment(baseOptions({
+      findings: [makeFinding({ severity: 'critical' })], mergeScore: 1,
+    }));
+    const full = formatReviewComment(baseOptions({
+      findings: [makeFinding({
+        severity: 'critical',
+        evidence: { ...EVIDENCE, agents: ['security', 'bugs'] },
+      })],
+      mergeScore: 1,
+    }));
+    expect(full.length - bare.length).toBeLessThanOrEqual(350);
+  });
+
+  it('omits the code block when the anchor line is blank', () => {
+    const result = formatReviewComment(baseOptions({
+      findings: [makeFinding({ severity: 'critical', evidence: { reason: 'r', code: '   \n  ' } })],
+      mergeScore: 1,
+    }));
+    expect(result).not.toContain('Cited code');
+    expect(result).toContain('↳ r');
+  });
+});

--- a/packages/core/src/comment-formatter.ts
+++ b/packages/core/src/comment-formatter.ts
@@ -7,6 +7,7 @@
 
 import type { UXConfig } from './config/defaults.js';
 import type { ReviewDelta } from './review-delta.js';
+import type { FindingEvidence } from './types/db.js';
 import { isValidMermaidDiagram } from './agents/reviewer.js';
 
 // ─── Types ─────────────────────────────────────────────────────────────────
@@ -29,6 +30,12 @@ export interface Finding {
    * Absent → treated as a pre-W2 record and rendered as a normal critical.
    */
   verification?: 'verified' | 'unverified';
+  /**
+   * #469 — per-finding proof. Rendering is severity-asymmetric because the
+   * data is: the verifier never runs on info findings, so they have no reason
+   * to show and get no evidence affordance at all.
+   */
+  evidence?: FindingEvidence;
 }
 
 export interface WorkDoneSection {
@@ -257,7 +264,45 @@ function shortenPath(path: string): string {
 }
 
 /** Render a single finding as a detailed markdown list item. */
-function renderFinding(f: Finding, showConfidence: boolean): string {
+/**
+ * #469 — render a finding's proof, inline and short.
+ *
+ * Severity decides how much, because availability does. Criticals get all
+ * three elements uncollapsed: they already render open, and hiding proof
+ * behind a click on the highest-stakes finding is backwards. Warnings get the
+ * reason alone — a code block per warning is more chrome than signal at that
+ * volume. Info gets nothing, because `verifyFindings` skips info entirely and
+ * an empty evidence shell would imply a check that never ran.
+ */
+function renderEvidence(f: Finding): string {
+  const e = f.evidence;
+  if (!e) return '';
+  if (f.severity === 'info') return '';
+
+  const reason = e.reason?.trim();
+  if (f.severity === 'warning') {
+    return reason ? `\n  ↳ ${reason}` : '';
+  }
+
+  // Critical: cited code, then the reason, then convergence.
+  let out = '';
+  if (e.code?.trim()) {
+    const startLine = e.codeStartLine;
+    const gutter = startLine != null ? ` \`${f.file}:${startLine}\`` : '';
+    out += `\n\n  <sub>Cited code${gutter}</sub>\n\n\`\`\`\n${e.code}\n\`\`\``;
+  }
+  if (reason) {
+    out += `\n  ↳ ${reason}`;
+  }
+  // Only ever rendered on convergence — a single agent's name restates the
+  // category and tells the reader nothing they cannot already see.
+  if (e.agents && e.agents.length > 1) {
+    out += `\n  ↳ <sub>${e.agents.join(' + ')} agreed independently</sub>`;
+  }
+  return out;
+}
+
+function renderFinding(f: Finding, showConfidence: boolean, showEvidence = true): string {
   const confidenceBadge = showConfidence && f.confidence != null
     ? ` \`${f.confidence}%\``
     : '';
@@ -267,6 +312,9 @@ function renderFinding(f: Finding, showConfidence: boolean): string {
   }
   if (f.suggestion) {
     line += `\n  > **Suggestion:** ${f.suggestion}`;
+  }
+  if (showEvidence) {
+    line += renderEvidence(f);
   }
   return line;
 }
@@ -577,6 +625,9 @@ export function formatReviewComment(options: FormatOptions): string {
   // FP-L — unverified criticals are excluded from the action-items table. They
   // render below under "Unverified concerns" instead, so the top-of-comment
   // "Requires your attention" surface stays aligned with the W7-clamped score.
+  // #469 — evidence is a trust surface: on unless a repo opts out.
+  const showEvidence = ux?.showEvidence !== false;
+
   const grouped = groupBySeverity(findings);
   const actionFindings = findings.filter((f) => {
     if (f.severity === 'warning') return true;
@@ -621,7 +672,7 @@ export function formatReviewComment(options: FormatOptions): string {
       const crit = section('critical', KEEP);
       crit.push(`### ${SEVERITY_META.critical.emoji} Critical (${criticalFindings.length})`);
       for (const f of criticalFindings) {
-        crit.push(renderFinding(f, showConfidence));
+        crit.push(renderFinding(f, showConfidence, showEvidence));
       }
       crit.push('');
     }
@@ -637,7 +688,7 @@ export function formatReviewComment(options: FormatOptions): string {
       );
       unver.push('');
       for (const f of unverifiedCriticals) {
-        unver.push(renderFinding(f, showConfidence));
+        unver.push(renderFinding(f, showConfidence, showEvidence));
       }
       unver.push('');
     }
@@ -648,7 +699,7 @@ export function formatReviewComment(options: FormatOptions): string {
       warn.push(`<details><summary>${SEVERITY_META.warning.emoji} Warnings (${warningFindings.length})</summary>`);
       warn.push('');
       for (const f of warningFindings) {
-        warn.push(renderFinding(f, showConfidence));
+        warn.push(renderFinding(f, showConfidence, showEvidence));
       }
       warn.push('');
       warn.push('</details>');
@@ -661,7 +712,7 @@ export function formatReviewComment(options: FormatOptions): string {
       info.push(`<details><summary>${SEVERITY_META.info.emoji} Info (${infoFindings.length})</summary>`);
       info.push('');
       for (const f of infoFindings) {
-        info.push(renderFinding(f, showConfidence));
+        info.push(renderFinding(f, showConfidence, showEvidence));
       }
       info.push('');
       info.push('</details>');

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -29,6 +29,12 @@ export interface UXConfig {
   allClearMessage: boolean;
   /** Custom header text for the review comment (replaces default logo) */
   commentHeader: string;
+  /**
+   * #469 — whether to render per-finding evidence (cited code, the verifier's
+   * reason, cross-agent convergence). Default true: this is a trust surface,
+   * and a reader who cannot check a claim has to take it on faith.
+   */
+  showEvidence: boolean;
 }
 
 export const DEFAULT_UX_CONFIG: UXConfig = {
@@ -38,6 +44,7 @@ export const DEFAULT_UX_CONFIG: UXConfig = {
   reviewerChecklist: true,
   allClearMessage: true,
   commentHeader: '',
+  showEvidence: true,
 };
 
 export interface RulesConfig {

--- a/packages/core/src/finding-clustering.test.ts
+++ b/packages/core/src/finding-clustering.test.ts
@@ -305,3 +305,58 @@ describe('dedupeCrossAgentByLine', () => {
     expect(bug.findings![0].description).toMatch(/\(error-handling\)/);
   });
 });
+
+describe('cross-agent convergence evidence (#469)', () => {
+  function cf(partial: Partial<ClusterableFinding> & { line: number; title: string }): ClusterableFinding {
+    return { file: 'src/x.ts', severity: 'warning', description: '', ...partial };
+  }
+
+  it('records which agents converged when a merge happens', () => {
+    const r = dedupeCrossAgentByLine([
+      { category: 'security', findings: [cf({ line: 10, severity: 'critical', title: 'Command injection via user input' })] },
+      { category: 'bug',      findings: [cf({ line: 10, severity: 'warning',  title: 'Command argument not escaped' })] },
+    ]);
+    const merged = r.taggedFindings.find((t) => t.category === 'security')!.findings![0];
+    expect(merged.evidence?.agents).toEqual(['security', 'bug']);
+  });
+
+  it('records no agents when a finding stands alone', () => {
+    const r = dedupeCrossAgentByLine([
+      { category: 'security', findings: [cf({ line: 1, title: 'Alone' })] },
+      { category: 'bug',      findings: [cf({ line: 2, title: 'Elsewhere entirely' })] },
+    ]);
+    for (const t of r.taggedFindings) {
+      for (const f of t.findings ?? []) {
+        expect(f.evidence?.agents).toBeUndefined();
+      }
+    }
+  });
+
+  it('does not attribute convergence to same-line findings that were NOT merged', () => {
+    // Same line, no shared significant token — these are different concerns
+    // that happen to collide, so claiming the agents "agreed" would be false.
+    const r = dedupeCrossAgentByLine([
+      { category: 'security', findings: [cf({ line: 10, title: 'Hardcoded credential exposure' })] },
+      { category: 'style',    findings: [cf({ line: 10, title: 'Prefer const over let' })] },
+    ]);
+    expect(r.dedupedCount).toBe(0);
+    for (const t of r.taggedFindings) {
+      for (const f of t.findings ?? []) {
+        expect(f.evidence?.agents).toBeUndefined();
+      }
+    }
+  });
+
+  it('preserves evidence already on the primary finding', () => {
+    const r = dedupeCrossAgentByLine([
+      { category: 'security', findings: [cf({
+        line: 10, severity: 'critical', title: 'Command injection via user input',
+        evidence: { reason: 'confirmed against the file' },
+      })] },
+      { category: 'bug', findings: [cf({ line: 10, title: 'Command argument not escaped' })] },
+    ]);
+    const merged = r.taggedFindings.find((t) => t.category === 'security')!.findings![0];
+    expect(merged.evidence?.reason).toBe('confirmed against the file');
+    expect(merged.evidence?.agents).toEqual(['security', 'bug']);
+  });
+});

--- a/packages/core/src/finding-clustering.ts
+++ b/packages/core/src/finding-clustering.ts
@@ -26,6 +26,8 @@
  */
 
 /** Minimal shape of a finding this module consumes. */
+import type { FindingEvidence } from './types/db.js';
+
 export interface ClusterableFinding {
   file: string;
   line: number;
@@ -38,6 +40,13 @@ export interface ClusterableFinding {
    * which the FP-A floor already treats as 100.
    */
   confidence?: number;
+  /**
+   * #469 — carried through so cross-agent convergence recorded here survives
+   * the rest of the pipeline. This is the only point where "which agents
+   * independently raised this" is known: the merge below collapses them and
+   * the categories are gone afterwards.
+   */
+  evidence?: FindingEvidence;
 }
 
 const SEVERITY_RANK: Record<ClusterableFinding['severity'], number> = {
@@ -327,10 +336,18 @@ export function dedupeCrossAgentByLine<T extends ClusterableFinding>(
     const relatedList = others
       .map((o) => `- (${o.category}) ${o.finding.title}`)
       .join('\n');
+    // #469 — record WHICH agents converged before the merge discards them.
+    // Two agents reaching the same line independently is real signal; a single
+    // agent's name just restates the category, so this is only ever populated
+    // with two or more and the renderer drops anything shorter.
+    const agents = Array.from(new Set([primary.category, ...others.map((o) => o.category)]));
     const mergedFinding: T = {
       ...primary.finding,
       title: `${primary.finding.title} — and ${others.length} related cross-agent concern${others.length === 1 ? '' : 's'}`,
       description: `${primary.finding.description}\n\n**Related cross-agent concerns merged into this finding (FP-C):**\n${relatedList}`,
+      ...(agents.length > 1
+        ? { evidence: { ...(primary.finding.evidence ?? {}), agents } }
+        : {}),
     };
     surviving.push({ category: primary.category, finding: mergedFinding, order: primary.order });
     dedupedCount += others.length;

--- a/packages/core/src/github/client.test.ts
+++ b/packages/core/src/github/client.test.ts
@@ -1153,3 +1153,20 @@ describe('inline cap holds at the fingerprint boundary (#474 review)', () => {
     }
   });
 });
+
+describe('ux.showEvidence parsing (#469)', () => {
+  it('parses an explicit opt-out', () => {
+    const c = parseRepoConfigYaml('ux:\n  showEvidence: false\n');
+    expect(c?.ux?.showEvidence).toBe(false);
+  });
+
+  it('parses an explicit opt-in', () => {
+    const c = parseRepoConfigYaml('ux:\n  showEvidence: true\n');
+    expect(c?.ux?.showEvidence).toBe(true);
+  });
+
+  it('ignores a non-boolean so the default (on) survives a typo', () => {
+    const c = parseRepoConfigYaml('ux:\n  showEvidence: "nope"\n');
+    expect(c?.ux?.showEvidence).toBeUndefined();
+  });
+});

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -1219,6 +1219,7 @@ export function parseRepoConfigYaml(content: string): Partial<MergeWatchConfig> 
       if (typeof u.reviewerChecklist === 'boolean') ux.reviewerChecklist = u.reviewerChecklist;
       if (typeof u.allClearMessage === 'boolean') ux.allClearMessage = u.allClearMessage;
       if (typeof u.commentHeader === 'string') ux.commentHeader = u.commentHeader;
+      if (typeof u.showEvidence === 'boolean') ux.showEvidence = u.showEvidence;
       config.ux = ux as UXConfig;
     }
 

--- a/packages/core/src/types/db.ts
+++ b/packages/core/src/types/db.ts
@@ -430,6 +430,40 @@ export interface ReviewItem {
   inlineResolvedKeys?: string[];
 }
 
+/**
+ * #469 — per-finding proof, so a reader can check a claim instead of taking
+ * the model's word for it. Every element is already produced somewhere in the
+ * pipeline and was being discarded; none of it is new inference.
+ *
+ * Severity-asymmetric by construction, because the data is: `verifyFindings`
+ * skips info entirely, so info findings have no `reason` to show and render no
+ * evidence affordance at all. An empty shell would be exactly the coverage
+ * illusion this work exists to remove.
+ */
+export interface FindingEvidence {
+  /**
+   * The cited code — anchor line ±1, at most 3 lines, from the file contents
+   * already fetched for grounding. The highest-value element by a wide margin:
+   * it makes the claim checkable at a glance.
+   */
+  code?: string;
+  /** 1-based line number of the first line of `code`, for the rendered gutter. */
+  codeStartLine?: number;
+  /**
+   * The W2/FP-E verifier's one-sentence justification, capped at
+   * EVIDENCE_REASON_MAX. Previously formatted into a console.warn and thrown
+   * away. Present on confirmation, on a refuted-and-demoted critical, and on a
+   * refused intent-claim dismissal — each of which is a reason the reader wants.
+   */
+  reason?: string;
+  /**
+   * Agent categories that independently raised this finding at the same line.
+   * Only ever populated with two or more: naming a single agent restates the
+   * category and is noise, while "security + bugs agreed" is real signal.
+   */
+  agents?: string[];
+}
+
 /** A single finding stored on a ReviewItem (matches comment-formatter Finding). */
 export interface ReviewFinding {
   file: string;
@@ -454,6 +488,12 @@ export interface ReviewFinding {
    * Optional / back-compat with pre-W7 stored reviews.
    */
   verification?: 'verified' | 'unverified';
+  /**
+   * #469 — per-finding proof rendered in the PR comment. Persisted so a
+   * re-review can show the same evidence without re-deriving it. Optional and
+   * back-compat: findings stored before #469 simply have none.
+   */
+  evidence?: FindingEvidence;
 }
 
 // =============================================================================


### PR DESCRIPTION
Closes #469. Stage 1 of #467, landing after its dependency #468.

A developer reading a finding had no reason to believe it — a title, a description, a suggestion, a confidence percentage, all model prose. Nothing showed the code the finding was about or that anything had checked it.

**This is plumbing, not new inference.** The W2/FP-E verifier already produces exactly that confirmation, one sentence citing specific code, and formats it into a `console.warn` before discarding it. We already fetch the full file at head for every finding's path and keep none of the cited lines.

## Three elements, nothing else

| element | source | why |
|---|---|---|
| **Cited code** | `groundingFileContents`, anchor ±1, ≤ 3 lines | makes the claim checkable at a glance |
| **Verifier reason** | `verifyFindings`, capped at 200 chars | the one sentence that was being logged and dropped |
| **Convergence** | `dedupeCrossAgentByLine` | "security + bugs agreed" is signal; one agent is noise |

A finding that needs a paragraph to justify itself has failed to justify itself, hence the 200-char cap — the same bound as the `PREV_FINDING_FIELD_MAX` precedent.

**Convergence is captured at the merge because that is the only place it exists.** `dedupeCrossAgentByLine` collapses same-line findings across agents and then discards which agents agreed; reconstructing it later is impossible. Notably it is recorded *only* when a merge actually happened — two findings colliding on one line with no shared token are different concerns, and claiming the agents "agreed" there would be false. There is a test for exactly that.

## Rendering is severity-asymmetric because the data is

`verifyFindings` skips info entirely (`if (f.severity !== 'critical' && f.severity !== 'warning') return { keep: true }`), so info findings have **no verifier reason to show**:

- **critical** — all three, **inline and uncollapsed**. Criticals already render open; hiding proof behind a click on the highest-stakes finding is backwards.
- **warning** — the reason alone, one `↳` line. A code block per warning is chrome at that volume.
- **info** — nothing. An empty evidence shell would be the exact coverage illusion this work exists to remove.

This also repairs **Unverified concerns**, which explained every item with a single blanket sentence. Each demoted critical now carries its own reason.

## Deliberately excluded

The grounding result ("anchor confirmed" is internal jargon nobody can act on) and confidence-vs-floor (the percentage already renders via `showConfidence`). The **"Requires your attention" table is untouched** — it is a scannable index and markdown tables cannot hold multi-line code blocks.

## No migration

`findings` is `jsonb`, and both runtimes pass `result.findings` straight through (`review-agent.ts:923`, `:1091`) with no field-picking — so evidence reaches storage and the formatter without rewiring.

## Verification

```
build      12/12
typecheck  20/20
test       21/21   (1,094 tests — 30 new)
```

Ten existing `verifyFindings` assertions changed, and each was updated to assert the **exact reason its own mock returns** rather than loosened to `objectContaining` — the new field is the feature, so the assertions should pin it. Back-compat is covered directly: a finding with no evidence renders byte-identically to the same finding with evidence suppressed.

Also tested: the ~350-char budget, the 3-line cap, start/end-of-file clamping, a blank anchor line, and `ux.showEvidence: false`.