### PR TITLE
feat(core): filter outcome ledger — record why every finding was dropped

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -3469,6 +3469,7 @@ Two production reviews reported `1430` and `3869 findings removed by dedup & qua
 - [ ] Where an agent does malfunction, the details drawer shows **⚠️ Malformed agent output — N agent response(s) returned unusable findings**, not an inflated Suppressed line
 - [ ] `[findings] DEGENERATE agent response: N of M entries unusable` appears in the logs when it happens
 - [ ] A normal review is unchanged — no new warning, suppressed counts still reflect real dedup work
+- [ ] **(#470)** The Suppressed number is now *derived* from the filter ledger rather than `raw − final`. On a repo with **custom agents** the number may legitimately drop: the old subtraction was measured upstream of where #385's custom-agent findings re-enter, so it counted them as suppressed. A change there is the fix, not a regression — but on a repo with no custom agents the two must agree exactly.
 - [ ] `⚠️ Unparsed agent output` (#382) still appears independently for genuinely unparseable responses
 
 **Failure modes.**

--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -3869,3 +3869,147 @@ describe('normalizeEvidenceReason (#469)', () => {
     expect(normalizeEvidenceReason('Line 15 interpolates id.')).toBe('Line 15 interpolates id.');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Filter outcome ledger (#470)
+// ---------------------------------------------------------------------------
+
+describe('filter outcome ledger (#470)', () => {
+  const allAgents = {
+    security: true, bugs: true, style: true, summary: true, diagram: true,
+    errorHandling: true, testCoverage: true, commentAccuracy: true,
+  };
+  const empty = JSON.stringify({ findings: [] });
+  const summaryResponse = JSON.stringify({ summary: 'Refactor.' });
+  const diagramResponse = '%% overview\nflowchart TD\n  A-->B';
+
+  // Two findings on changed lines, deliberately sharing no significant token
+  // so neither FP-C (same line) nor W10 (shared wording) merges them — this
+  // isolates the stage under test.
+  const twoFindings = JSON.stringify({
+    findings: [
+      { file: 'foo.ts', line: 2, severity: 'warning', category: 'bug', title: 'Unbounded retry loop', description: 'd', suggestion: 's' },
+      { file: 'foo.ts', line: 3, severity: 'warning', category: 'bug', title: 'Missing null check on payload', description: 'd', suggestion: 's' },
+    ],
+  });
+
+  async function run(responses: string[], extra: Record<string, unknown> = {}) {
+    const llm = createMockLLM(responses);
+    return runReviewPipeline(
+      {
+        diff: sampleDiff, context: sampleContext,
+        modelId: 'heavy-model', lightModelId: 'light-model',
+        maxFindings: 25, enabledAgents: allAgents, ...extra,
+      },
+      { llm },
+    );
+  }
+
+  it('derives suppressedCount equal to the old raw-minus-final subtraction', async () => {
+    // No custom agents run here, which is the condition under which the old
+    // subtraction was correct — it double-counted #385 re-entrants otherwise.
+    const orchestrator = JSON.stringify({
+      findings: [{ file: 'foo.ts', line: 3, severity: 'warning', category: 'bug', title: 'Missing null check on payload', description: 'd', suggestion: 's' }],
+      mergeScore: 3, mergeScoreReason: 'One warning.',
+    });
+    const result = await run([
+      twoFindings, empty, empty, empty, empty, empty,
+      summaryResponse, diagramResponse, orchestrator,
+    ]);
+
+    const totalRaw = 2;                       // what the old counter measured
+    const oldSubtraction = totalRaw - result.findings.length;
+    expect(result.suppressedCount).toBe(oldSubtraction);
+    expect(result.suppressedCount).toBe(1);
+  });
+
+  it('gives every finding that entered exactly one terminal outcome', async () => {
+    const orchestrator = JSON.stringify({
+      findings: [{ file: 'foo.ts', line: 3, severity: 'warning', category: 'bug', title: 'Missing null check on payload', description: 'd', suggestion: 's' }],
+      mergeScore: 3, mergeScoreReason: 'One warning.',
+    });
+    const result = await run([
+      twoFindings, empty, empty, empty, empty, empty,
+      summaryResponse, diagramResponse, orchestrator,
+    ]);
+
+    const keys = result.filterOutcomes.map((o) => o.key);
+    expect(new Set(keys).size).toBe(keys.length);          // no finding recorded twice
+    expect(result.filterOutcomes).toHaveLength(2);          // no finding lost
+    for (const o of result.filterOutcomes) {
+      expect(['surfaced', 'merged', 'dropped', 'demoted']).toContain(o.outcome);
+    }
+    expect(result.filterOutcomes.filter((o) => o.outcome === 'surfaced')).toHaveLength(1);
+  });
+
+  it('attributes an orchestrator drop to its stage, with no reason', async () => {
+    // #473 would let the orchestrator explain itself; until then its drops are
+    // attributable but not explained, and the ledger should not invent a reason.
+    const orchestrator = JSON.stringify({ findings: [], mergeScore: 5, mergeScoreReason: 'Clean.' });
+    const result = await run([
+      twoFindings, empty, empty, empty, empty, empty,
+      summaryResponse, diagramResponse, orchestrator,
+    ]);
+
+    const dropped = result.filterOutcomes.filter((o) => o.outcome === 'dropped');
+    expect(dropped).toHaveLength(2);
+    for (const o of dropped) {
+      expect(o.stage).toBe('orchestrator');
+      expect(o.reason).toBeUndefined();
+    }
+  });
+
+  it('records the agent that raised each finding', async () => {
+    const orchestrator = JSON.stringify({ findings: [], mergeScore: 5, mergeScoreReason: 'Clean.' });
+    const result = await run([
+      twoFindings, empty, empty, empty, empty, empty,
+      summaryResponse, diagramResponse, orchestrator,
+    ]);
+    for (const o of result.filterOutcomes) {
+      expect(o.agents).toEqual(['security']);
+    }
+  });
+
+  it('does NOT turn an unparseable agent response into a ledger entry', async () => {
+    // A response that did not parse yields no finding object at all. It stays a
+    // parseFailureCount reliability warning, which already says the right thing.
+    const orchestrator = JSON.stringify({ findings: [], mergeScore: 5, mergeScoreReason: 'Clean.' });
+    const result = await run([
+      'not json at all', empty, empty, empty, empty, empty,
+      summaryResponse, diagramResponse, orchestrator,
+    ]);
+    expect(result.parseFailureCount).toBeGreaterThan(0);
+    expect(result.filterOutcomes).toHaveLength(0);
+  });
+
+  it('does NOT turn a degenerate (title-less) finding into a ledger entry', async () => {
+    // #401's shape: parses cleanly, but the entries are unusable. Counting
+    // those as "filtered" is what made a malfunction look like productive work.
+    const degenerate = JSON.stringify({
+      findings: [
+        { file: 'foo.ts', line: 2, severity: 'warning', category: 'bug', title: '', description: '', suggestion: '' },
+        { file: 'foo.ts', line: 3, severity: 'warning', category: 'bug', title: '', description: '', suggestion: '' },
+      ],
+    });
+    const orchestrator = JSON.stringify({ findings: [], mergeScore: 5, mergeScoreReason: 'Clean.' });
+    const result = await run([
+      degenerate, empty, empty, empty, empty, empty,
+      summaryResponse, diagramResponse, orchestrator,
+    ]);
+    expect(result.filterOutcomes).toHaveLength(0);
+  });
+
+  it('records a surfaced finding as surfaced, not merely as absent', async () => {
+    const orchestrator = JSON.stringify({
+      findings: [{ file: 'foo.ts', line: 3, severity: 'warning', category: 'bug', title: 'Missing null check on payload', description: 'd', suggestion: 's' }],
+      mergeScore: 3, mergeScoreReason: 'One warning.',
+    });
+    const result = await run([
+      twoFindings, empty, empty, empty, empty, empty,
+      summaryResponse, diagramResponse, orchestrator,
+    ]);
+    const surfaced = result.filterOutcomes.find((o) => o.outcome === 'surfaced')!;
+    expect(surfaced.title).toBe('Missing null check on payload');
+    expect(surfaced.stage).toBeUndefined();
+  });
+});

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -47,6 +47,7 @@ import { partitionDisputed } from '../triage.js';
 import { detectNoTestHarness, suppressTestCoverageFindings } from '../scope-awareness.js';
 import { clusterFindings, dedupeCrossAgentByLine, extractSignificantTokens } from '../finding-clustering.js';
 import type { FindingEvidence } from '../types/db.js';
+import { TraceRecorder, outcomeKey, type FindingOutcome } from '../filter-trace.js';
 import { FILE_REQUEST_INSTRUCTION, invokeWithFileFetching } from '../context/agentic-fetcher.js';
 import type { FileFetchOptions } from '../context/agentic-fetcher.js';
 import { fetchFileContents } from '../context/file-fetcher.js';
@@ -1549,6 +1550,13 @@ export interface ReviewPipelineResult {
   /** Number of findings suppressed by the orchestrator (deduplication + filtering) */
   suppressedCount: number;
   /**
+   * #470 — why every finding was dropped, merged, or demoted. `suppressedCount`
+   * above is derived from this rather than subtracted, so a stage that forgets
+   * to record shows up as a mismatch instead of quietly balancing the books.
+   * In-memory only in this stage; #471 persists it, #472 renders it.
+   */
+  filterOutcomes: FindingOutcome[];
+  /**
    * #382 — findings-bearing agent responses that could not be parsed. These
    * agents contributed zero raw findings, so the loss is invisible to
    * `suppressedCount`; a non-zero value means findings may be missing.
@@ -2110,6 +2118,12 @@ export async function verifyFindings(
    * here — same set the orchestrator sees.
    */
   previousFindings?: PreviousFinding[],
+  /**
+   * #470 — optional ledger. This function owns two of the twelve stages
+   * (FP-I's already-applied short-circuit and the verifier's own verdict), and
+   * both were previously visible only in CloudWatch.
+   */
+  trace?: TraceRecorder,
 ): Promise<OrchestratedFinding[]> {
   // Each task returns the disposition for one finding:
   //   - { keep: true }                            — pass-through (info-only).
@@ -2173,6 +2187,9 @@ export async function verifyFindings(
           '[finding-verify] dropped %s "%s" (%s:%d) — FP-I L2: suggestion already implemented at cited location',
           f.severity, f.title, f.file, f.line,
         );
+        trace?.record(f, 'dropped', 'fp-i-already-applied', {
+          reason: 'the suggestion is already implemented at the cited location',
+        });
         return { keep: false };
       }
 
@@ -2239,6 +2256,10 @@ ${content}`;
               f.line,
               (parsed.reason ?? '').slice(0, 200),
             );
+            trace?.record(f, 'demoted', 'finding-verify', {
+              reason: normalizeEvidenceReason(parsed.reason)
+                ?? 'dismissal rested on an in-code intent claim, which is unverified input',
+            });
             return { keep: true, verification: 'unverified', reason: parsed.reason };
           }
           // #385 — a refuted CRITICAL demotes to advisory, never deletes.
@@ -2258,6 +2279,9 @@ ${content}`;
               f.line,
               (parsed.reason ?? '').slice(0, 200),
             );
+            trace?.record(f, 'demoted', 'finding-verify', {
+              reason: normalizeEvidenceReason(parsed.reason),
+            });
             return { keep: true, verification: 'unverified', reason: parsed.reason };
           }
           console.warn(
@@ -2268,6 +2292,9 @@ ${content}`;
             f.line,
             (parsed.reason ?? '').slice(0, 200),
           );
+          trace?.record(f, 'dropped', 'finding-verify', {
+            reason: normalizeEvidenceReason(parsed.reason),
+          });
           return { keep: false };
         }
         if (parsed.valid === true) {
@@ -2853,19 +2880,6 @@ export async function runReviewPipeline(
     ...customTagged,
   ];
 
-  // Count total raw findings before orchestration. Captured before FP-C
-  // merges cross-agent doubles so the downstream `suppressedCount` math
-  // (totalRawFindings − filteredFindings.length) accurately reflects the
-  // dedup work, alongside W10's same-region clustering + W11's coverage
-  // suppression.
-  // #401 — count only well-formed entries. parseAgentFindings already filters
-  // the built-in agents, but custom/org-agent results arrive by another path,
-  // and `.length` on any non-array would otherwise contribute silently.
-  const totalRawFindings = taggedFindings.reduce(
-    (sum, t) => sum + (Array.isArray(t.findings) ? t.findings.filter(isUsableFinding).length : 0),
-    0,
-  );
-
   // #385 — custom/org-agent findings are user-legislated policy, so they are
   // routed AROUND every model-taste layer: the orchestrator (whose
   // anti-pedantry rule classified a blocking org agent's "new TODO" findings
@@ -2874,6 +2888,20 @@ export async function runReviewPipeline(
   // grounding/line-proximity geometry. They re-enter deterministically just
   // before W3 triage below — the one legitimate filter, because triage is
   // user action, not model opinion.
+  // #470 — register every finding that enters, attributed to the agent that
+  // raised it. This is the only point where per-agent attribution exists:
+  // FP-C's merge below collapses same-line findings and the categories are
+  // gone afterwards. `isUsableFinding` gates entry for the same reason it
+  // gates the count — a parse failure yields no finding object and a
+  // degenerate entry has no title, and neither is a filtering decision.
+  const trace = new TraceRecorder();
+  for (const t of taggedFindings) {
+    if (!Array.isArray(t.findings)) continue;
+    for (const f of t.findings) {
+      if (isUsableFinding(f)) trace.enter(f, t.category);
+    }
+  }
+
   const customCategorySet = new Set(enabledCustomAgents.map((a) => a.name));
   const builtinTagged = taggedFindings.filter((t) => !customCategorySet.has(t.category));
 
@@ -2884,7 +2912,36 @@ export async function runReviewPipeline(
   // POST-orchestrator on the final finding set. Custom-agent findings are
   // excluded (#385): an fp-c merge into a builtin finding would re-expose
   // them to the orchestrator's drop authority.
+  // #470 — several stages report only how many they removed, never which.
+  // Diffing before against after by identity recovers the "which" without
+  // rewriting each filter to thread findings through.
+  const recordDrops = (
+    before: OrchestratedFinding[],
+    after: OrchestratedFinding[],
+    stage: Parameters<TraceRecorder['record']>[2],
+    reasonFor?: (f: OrchestratedFinding) => string | undefined,
+  ) => {
+    const kept = new Set(after.map(outcomeKey));
+    for (const f of before) {
+      if (!kept.has(outcomeKey(f))) {
+        trace.record(f, 'dropped', stage, { reason: reasonFor?.(f) });
+      }
+    }
+  };
+
   const fpCResult = dedupeCrossAgentByLine(builtinTagged);
+  // FP-C merged siblings into a survivor whose title it rewrote; alias the
+  // survivor so later stages still resolve to the row that entered.
+  for (const m of fpCResult.merges) {
+    const into = outcomeKey(m.primaryAfter);
+    trace.alias(outcomeKey(m.primaryBefore), into);
+    for (const a of m.absorbed) {
+      trace.record(a, 'merged', 'fp-c-line-dedup', {
+        mergedInto: into,
+        reason: 'same file and line as a stronger finding, with overlapping wording',
+      });
+    }
+  }
   if (fpCResult.dedupedCount > 0) {
     console.warn(
       '[fp-c] merged %d cross-agent finding%s at the same (file, line)',
@@ -2902,6 +2959,18 @@ export async function runReviewPipeline(
     previousFindings,
     conventions,
     agentAuthored,
+  );
+
+  // #470 — the orchestrator is an LLM: it returns a new set, so what it
+  // dropped is only knowable by difference. It cannot explain itself without a
+  // schema change and extra output tokens (#473), so these record with a stage
+  // and no reason — attributable, but not explained. A finding whose title the
+  // orchestrator reworded reads here as a drop plus a new entry; that is what
+  // is actually observable, and inventing a link would be a guess.
+  recordDrops(
+    dedupedTaggedFindings.flatMap((t) => (t.findings ?? []) as OrchestratedFinding[]),
+    orchestratorResult.findings,
+    'orchestrator',
   );
 
   // #385 — W10 runs BEFORE the deleting filters below.
@@ -2926,9 +2995,19 @@ export async function runReviewPipeline(
   // and a cluster-size cap keep over-clustering risk low. The absorbed
   // count rolls into the downstream suppressedCount math.
   {
-    const { findings: clustered, clusteredCount } = clusterFindings(
+    const { findings: clustered, clusteredCount, merges } = clusterFindings(
       orchestratorResult.findings,
     );
+    for (const m of merges) {
+      const into = outcomeKey(m.primaryAfter);
+      trace.alias(outcomeKey(m.primaryBefore), into);
+      for (const a of m.absorbed) {
+        trace.record(a, 'merged', 'w10-clustering', {
+          mergedInto: into,
+          reason: 'same code region and shared wording as a stronger finding',
+        });
+      }
+    }
     if (clusteredCount > 0) {
       console.warn(
         '[clustering] merged %d related finding%s into existing clusters',
@@ -2947,9 +3026,16 @@ export async function runReviewPipeline(
   // default to 100 (no surprise suppression of legacy findings). The floor is
   // configurable via yml `minConfidence:` (default CONFIDENCE_FLOOR).
   {
-    const before = orchestratorResult.findings.length;
+    const beforeFindings = orchestratorResult.findings;
+    const before = beforeFindings.length;
     orchestratorResult.findings = orchestratorResult.findings.filter(
       (f) => (f.confidence ?? 100) >= minConfidence,
+    );
+    recordDrops(
+      beforeFindings,
+      orchestratorResult.findings,
+      'confidence-floor',
+      (f) => `confidence ${f.confidence ?? 100} is below the floor of ${minConfidence}`,
     );
     const dropped = before - orchestratorResult.findings.length;
     if (dropped > 0) {
@@ -2971,9 +3057,16 @@ export async function runReviewPipeline(
   if (minSeverity !== 'info') {
     const severityRank: Record<string, number> = { info: 0, warning: 1, critical: 2 };
     const threshold = severityRank[minSeverity];
-    const before = orchestratorResult.findings.length;
+    const beforeFindings = orchestratorResult.findings;
+    const before = beforeFindings.length;
     orchestratorResult.findings = orchestratorResult.findings.filter(
       (f) => (severityRank[f.severity] ?? threshold) >= threshold,
+    );
+    recordDrops(
+      beforeFindings,
+      orchestratorResult.findings,
+      'min-severity',
+      (f) => `severity ${f.severity} is below the configured threshold of ${minSeverity}`,
     );
     const dropped = before - orchestratorResult.findings.length;
     if (dropped > 0) {
@@ -2996,6 +3089,12 @@ export async function runReviewPipeline(
   if (detectNoTestHarness(conventions)) {
     const { findings: collapsed, suppressedCount } = suppressTestCoverageFindings(
       orchestratorResult.findings,
+    );
+    recordDrops(
+      orchestratorResult.findings,
+      collapsed,
+      'w11-scope-awareness',
+      () => "the repo's conventions declare no test harness, so coverage findings are collapsed",
     );
     if (suppressedCount > 0) {
       console.warn(
@@ -3050,6 +3149,24 @@ export async function runReviewPipeline(
       && p.grounded.severity === 'critical'
       && p.grounded.verification === 'unverified'
       && p.original.verification !== 'unverified').length;
+    for (const pair of groundedPairs) {
+      if (pair.grounded === null) {
+        trace.record(pair.original, 'dropped', 'grounding', {
+          reason: 'the cited anchor did not survive structural grounding',
+        });
+      } else if (
+        pair.grounded.severity === 'critical'
+        && pair.grounded.verification === 'unverified'
+        && pair.original.verification !== 'unverified'
+      ) {
+        // #385/#460 — a critical whose anchor could not be confirmed is
+        // demoted, never deleted. `demoted` is its own outcome precisely so
+        // this stops looking like a drop in the ledger.
+        trace.record(pair.grounded, 'demoted', 'grounding', {
+          reason: 'anchor unconfirmed against the file, so the critical was demoted rather than deleted',
+        });
+      }
+    }
     if (dropped > 0) {
       console.warn('[grounding] dropped %d finding%s whose anchor did not survive',
         dropped, dropped === 1 ? '' : 's');
@@ -3069,17 +3186,22 @@ export async function runReviewPipeline(
     // findings that contradict the bot's prior recommendations. No-op
     // on first reviews (previousFindings is undefined / empty).
     previousFindings,
+    trace,
   );
 
   // Filter findings to only those on or near actually changed lines.
   // `changedLines` was already computed up-front (used by FP-D too).
   const CHANGED_LINE_TOLERANCE = 3;
-  const onChangedLines = withCodeFingerprints(
-    groundedFindings.filter(
-      (f) => isLineNearChange(changedLines, f.file, f.line, CHANGED_LINE_TOLERANCE),
-    ),
-    groundingFileContents,
+  const nearChange = groundedFindings.filter(
+    (f) => isLineNearChange(changedLines, f.file, f.line, CHANGED_LINE_TOLERANCE),
   );
+  recordDrops(
+    groundedFindings,
+    nearChange,
+    'line-proximity',
+    (f) => `line ${f.line} is more than ${CHANGED_LINE_TOLERANCE} lines from any change in this PR`,
+  );
+  const onChangedLines = withCodeFingerprints(nearChange, groundingFileContents);
 
   // #385 — re-enter the custom/org-agent findings (partitioned out before
   // fp-c above). Deterministic dedup only: one entry per (agent, file, line),
@@ -3091,9 +3213,20 @@ export async function runReviewPipeline(
     .flatMap((t) => (t.findings ?? []).map((f) => ({ ...f, category: t.category } as OrchestratedFinding)))
     .filter((f) => {
       const key = `${f.category}|${f.file}|${f.line}`;
-      if (seenCustomKeys.has(key)) return false;
+      if (seenCustomKeys.has(key)) {
+        trace.record(f, 'dropped', 'custom-agent-dedup', {
+          reason: 'the same custom agent already reported this file and line',
+        });
+        return false;
+      }
       seenCustomKeys.add(key);
-      return !onChangedLines.some((k) => k.file === f.file && k.line === f.line);
+      const alreadySurfaced = onChangedLines.some((k) => k.file === f.file && k.line === f.line);
+      if (alreadySurfaced) {
+        trace.record(f, 'dropped', 'custom-agent-dedup', {
+          reason: 'a built-in finding already surfaced this location',
+        });
+      }
+      return !alreadySurfaced;
     });
   if (customFindings.length > 0) {
     console.log(
@@ -3123,6 +3256,9 @@ export async function runReviewPipeline(
     disputedKeys,
   );
   for (const f of triageSuppressed) {
+    trace.record(f, 'dropped', 'triage-suppressed', {
+      reason: 'the author rebutted or deferred this in a prior triage reply',
+    });
     console.warn(
       '[triage-suppressed] "%s" (%s:%d) — author rebutted/deferred this in a prior triage; not re-raising',
       f.title,
@@ -3133,6 +3269,10 @@ export async function runReviewPipeline(
 
   // Delta caption — only on re-reviews where something actually changed
   // commit-to-commit. Uses lightModel to match the other prose agents.
+  // #470 — everything still un-adjudicated survived to the reader.
+  trace.finalize(filteredFindings);
+  const filterOutcomes = trace.outcomes();
+
   const delta = computeReviewDelta(filteredFindings, previousFindings);
   const deltaCaption = delta
     ? await runDeltaCaptionAgent(delta, lightModelId, llm)
@@ -3194,7 +3334,12 @@ export async function runReviewPipeline(
     mergeScore,
     mergeScoreReason,
     ...(disputeDisclosure ? { disputeDisclosure } : {}),
-    suppressedCount: Math.max(0, totalRawFindings - filteredFindings.length),
+    // #470 — derived from the ledger, not subtracted. The old subtraction was
+    // measured upstream of where #385's custom-agent findings re-enter, so it
+    // counted them as suppressed; and a count cannot distinguish good
+    // filtering from a malfunction (#401), which is what the ledger is for.
+    suppressedCount: trace.suppressedCount(),
+    filterOutcomes,
     parseFailureCount: diag.parseFailures,
     degenerateResponseCount: diag.degenerateResponses,
     enabledAgentCount,

--- a/packages/core/src/filter-trace.test.ts
+++ b/packages/core/src/filter-trace.test.ts
@@ -132,3 +132,54 @@ describe('TraceRecorder', () => {
     expect(o.stage).toBeUndefined();
   });
 });
+
+describe('TraceRecorder — dangling alias (#478 review)', () => {
+  // An orchestrator rewrite that a merge stage then renames produces an alias
+  // whose TARGET never entered the ledger. The fallback in record() must key
+  // off the finding itself, not the resolved key: the resolved key has no row,
+  // so reading it back would hand `undefined` to a non-null assertion and
+  // throw on exactly the path the fallback exists to handle.
+  it('handles an alias pointing at a row that never entered', () => {
+    const t = new TraceRecorder();
+    const reworded = f({ title: 'Reworded by the orchestrator' });
+    const merged = f({ title: 'Reworded by the orchestrator — and 1 related concern' });
+
+    t.alias(outcomeKey(reworded), outcomeKey(merged));   // target never entered
+    expect(() => t.record(merged, 'surfaced')).not.toThrow();
+
+    const rows = t.outcomes();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].outcome).toBe('surfaced');
+  });
+
+  it('does not create a duplicate row when the same finding is recorded twice through a dangling alias', () => {
+    const t = new TraceRecorder();
+    const reworded = f({ title: 'Reworded' });
+    const merged = f({ title: 'Reworded — and 1 related concern' });
+
+    t.alias(outcomeKey(reworded), outcomeKey(merged));
+    t.record(merged, 'dropped', 'confidence-floor', { reason: 'first' });
+    t.record(merged, 'surfaced');
+
+    const rows = t.outcomes();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].outcome).toBe('dropped');   // first verdict still wins
+    expect(rows[0].reason).toBe('first');
+  });
+
+  it('still resolves through an alias whose target DID enter', () => {
+    // The ordinary case must keep working — this is the one the fallback is
+    // not involved in at all.
+    const t = new TraceRecorder();
+    const before = f({ title: 'Original' });
+    const after = f({ title: 'Original — and 1 related concern' });
+    t.enter(before, 'security');
+    t.alias(outcomeKey(before), outcomeKey(after));
+    t.record(after, 'surfaced');
+
+    const rows = t.outcomes();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].title).toBe('Original');
+    expect(rows[0].agents).toEqual(['security']);
+  });
+});

--- a/packages/core/src/filter-trace.test.ts
+++ b/packages/core/src/filter-trace.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { TraceRecorder, outcomeKey, type TraceableFinding } from './filter-trace.js';
+
+function f(over: Partial<TraceableFinding> = {}): TraceableFinding {
+  return {
+    file: 'src/db.ts', line: 10, severity: 'critical',
+    confidence: 90, title: 'SQL injection', ...over,
+  };
+}
+
+describe('outcomeKey', () => {
+  it('prefers the fingerprint form when one exists', () => {
+    expect(outcomeKey(f({ fingerprint: 'abc' }))).toBe('src/db.ts::F::abc');
+  });
+
+  it('falls back to the title form', () => {
+    expect(outcomeKey(f())).toBe('src/db.ts::T::SQL injection');
+  });
+});
+
+describe('TraceRecorder', () => {
+  it('records one row per finding, with its agent', () => {
+    const t = new TraceRecorder();
+    t.enter(f(), 'security');
+    t.finalize([f()]);
+    const [o] = t.outcomes();
+    expect(o.outcome).toBe('surfaced');
+    expect(o.agents).toEqual(['security']);
+  });
+
+  it('collapses the same finding from two agents into one row with both', () => {
+    // Pre-FP-C convergence: this is the only point where it is knowable, since
+    // the merge downstream destroys the per-agent attribution.
+    const t = new TraceRecorder();
+    t.enter(f(), 'security');
+    t.enter(f(), 'bugs');
+    expect(t.outcomes()).toHaveLength(1);
+    expect(t.outcomes()[0].agents).toEqual(['security', 'bugs']);
+  });
+
+  it('distinguishes demoted from dropped', () => {
+    const t = new TraceRecorder();
+    t.enter(f({ title: 'A' }), 'security');
+    t.enter(f({ title: 'B' }), 'security');
+    t.record(f({ title: 'A' }), 'dropped', 'confidence-floor', { reason: 'low' });
+    t.record(f({ title: 'B' }), 'demoted', 'grounding', { reason: 'anchor unconfirmed' });
+    const by = Object.fromEntries(t.outcomes().map((o) => [o.title, o]));
+    expect(by.A.outcome).toBe('dropped');
+    expect(by.B.outcome).toBe('demoted');
+    expect(by.B.stage).toBe('grounding');
+  });
+
+  it('follows a survivor across a merge rename via alias()', () => {
+    // FP-C and W10 both rewrite the primary's title. Without the alias the
+    // survivor would look like a different finding and the ledger would split
+    // into an orphan row and a ghost row.
+    const t = new TraceRecorder();
+    const before = f({ title: 'Original' });
+    const after = f({ title: 'Original — and 2 related concerns' });
+    t.enter(before, 'security');
+    t.alias(outcomeKey(before), outcomeKey(after));
+    t.finalize([after]);
+    const rows = t.outcomes();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].title).toBe('Original');
+    expect(rows[0].outcome).toBe('surfaced');
+  });
+
+  it('survives a second rename (FP-C then W10)', () => {
+    const t = new TraceRecorder();
+    const a = f({ title: 'One' });
+    const b = f({ title: 'One — and 1 related cross-agent concern' });
+    const c = f({ title: 'One — and 1 related cross-agent concern — and 2 related concerns' });
+    t.enter(a, 'security');
+    t.alias(outcomeKey(a), outcomeKey(b));
+    t.alias(outcomeKey(b), outcomeKey(c));
+    t.finalize([c]);
+    expect(t.outcomes()).toHaveLength(1);
+    expect(t.outcomes()[0].outcome).toBe('surfaced');
+  });
+
+  it('records the key a merged finding folded into', () => {
+    const t = new TraceRecorder();
+    const primary = f({ title: 'Primary' });
+    const sibling = f({ title: 'Sibling', line: 11 });
+    t.enter(primary, 'security');
+    t.enter(sibling, 'bugs');
+    t.record(sibling, 'merged', 'w10-clustering', { mergedInto: outcomeKey(primary) });
+    const row = t.outcomes().find((o) => o.title === 'Sibling')!;
+    expect(row.outcome).toBe('merged');
+    expect(row.mergedInto).toBe('src/db.ts::T::Primary');
+  });
+
+  it('first verdict wins — a later stage cannot rewrite history', () => {
+    const t = new TraceRecorder();
+    t.enter(f(), 'security');
+    t.record(f(), 'dropped', 'confidence-floor', { reason: 'first' });
+    t.record(f(), 'surfaced');
+    const [o] = t.outcomes();
+    expect(o.outcome).toBe('dropped');
+    expect(o.reason).toBe('first');
+  });
+
+  it('registers an unknown key rather than dropping the row silently', () => {
+    // The orchestrator can return a finding whose title it reworded. A ledger
+    // that ignored those rows would be lying by omission.
+    const t = new TraceRecorder();
+    t.record(f({ title: 'Reworded by the orchestrator' }), 'surfaced');
+    expect(t.outcomes()).toHaveLength(1);
+    expect(t.outcomes()[0].agents).toEqual(['orchestrator']);
+  });
+
+  it('derives suppressedCount as everything that did not surface', () => {
+    const t = new TraceRecorder();
+    for (const title of ['a', 'b', 'c', 'd']) t.enter(f({ title }), 'security');
+    t.record(f({ title: 'a' }), 'dropped', 'confidence-floor');
+    t.record(f({ title: 'b' }), 'merged', 'w10-clustering');
+    t.record(f({ title: 'c' }), 'demoted', 'grounding');
+    t.finalize([f({ title: 'd' })]);
+    // Demoted counts as suppressed-from-the-rendered-set only in the sense
+    // that it did not surface unchanged; the ledger keeps the distinction.
+    expect(t.suppressedCount()).toBe(3);
+  });
+
+  it('leaves an unadjudicated entry visible as dropped with no stage', () => {
+    // A stage that forgets to record must surface as a wiring bug, not be
+    // quietly balanced away.
+    const t = new TraceRecorder();
+    t.enter(f(), 'security');
+    const [o] = t.outcomes();
+    expect(o.outcome).toBe('dropped');
+    expect(o.stage).toBeUndefined();
+  });
+});

--- a/packages/core/src/filter-trace.test.ts
+++ b/packages/core/src/filter-trace.test.ts
@@ -183,3 +183,32 @@ describe('TraceRecorder — dangling alias (#478 review)', () => {
     expect(rows[0].agents).toEqual(['security']);
   });
 });
+
+describe('TraceRecorder — alias chain termination (#478 review)', () => {
+  it('terminates on a cyclic alias chain instead of walking a fixed bound', () => {
+    const t = new TraceRecorder();
+    const a = f({ title: 'A' });
+    const b = f({ title: 'B' });
+    t.enter(a, 'security');
+    // Force a cycle directly — the pipeline only ever renames forward, but the
+    // recorder should not depend on its one caller behaving.
+    t.alias(outcomeKey(a), outcomeKey(b));
+    t.alias(outcomeKey(b), outcomeKey(a));
+    expect(() => t.record(b, 'surfaced')).not.toThrow();
+    expect(t.outcomes().length).toBeGreaterThan(0);
+  });
+
+  it('resolves a three-link chain to the original row', () => {
+    const t = new TraceRecorder();
+    const one = f({ title: 'One' });
+    const two = f({ title: 'Two' });
+    const three = f({ title: 'Three' });
+    t.enter(one, 'security');
+    t.alias(outcomeKey(one), outcomeKey(two));
+    t.alias(outcomeKey(two), outcomeKey(three));
+    t.record(three, 'surfaced');
+    const rows = t.outcomes();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].title).toBe('One');
+  });
+});

--- a/packages/core/src/filter-trace.ts
+++ b/packages/core/src/filter-trace.ts
@@ -1,0 +1,220 @@
+/**
+ * #470 — the filter outcome ledger.
+ *
+ * Twelve stages in `runReviewPipeline` can delete, merge, or demote a finding.
+ * Every one announced its decision to `console.warn` and nowhere else, and
+ * what survived to the reader was a single scalar:
+ *
+ *     suppressedCount: Math.max(0, totalRawFindings - filteredFindings.length)
+ *
+ * rendered as "13 findings removed by dedup & quality filters". No way to
+ * learn which thirteen, why, or whether the one thing you were worried about
+ * was among them.
+ *
+ * A bare count is not merely uninformative — #401 shipped because two
+ * production reviews reported "1430" and "3869 findings removed by dedup &
+ * quality filters" on 4-line diffs. That was a malfunctioning agent's junk,
+ * faithfully described as productive filtering. The fix there was to stop
+ * counting junk; the deeper problem is that a count cannot distinguish good
+ * filtering from a malfunction at all. This records the decisions themselves.
+ *
+ * In-memory and core-only. #471 persists it; #472 renders it.
+ */
+
+/** The stages that can remove, merge, or demote a finding. */
+export type FilterStage =
+  | 'fp-c-line-dedup'       // cross-agent same (file,line) merge
+  | 'orchestrator'          // LLM dedup / rank / maxFindings cap
+  | 'w10-clustering'        // same-region consolidation
+  | 'confidence-floor'      // FP-A
+  | 'min-severity'          // #310
+  | 'w11-scope-awareness'   // no-test-harness collapse
+  | 'grounding'             // anchor / identifier / no-op-suggestion
+  | 'fp-i-already-applied'  // suggestion byte-equals existing code
+  | 'finding-verify'        // W2 / FP-E verifier verdict
+  | 'line-proximity'        // ±3 changed-line filter
+  | 'custom-agent-dedup'    // #385 re-entry
+  | 'triage-suppressed';    // W3
+
+/**
+ * What happened to one finding in one review.
+ *
+ * `demoted` is a distinct outcome, not a flavour of `dropped`: grounding and
+ * the verifier both demote criticals to `unverified` rather than deleting them
+ * (#385), and that decision was previously invisible.
+ */
+export interface FindingOutcome {
+  /** W9 identity — `file::F::<fingerprint>` when available, else `file::T::<title>`. */
+  key: string;
+  file: string;
+  line: number;
+  severity: 'critical' | 'warning' | 'info';
+  confidence?: number;
+  title: string;
+  /** Every agent that independently emitted this, pre-FP-C merge. */
+  agents: string[];
+  outcome: 'surfaced' | 'merged' | 'dropped' | 'demoted';
+  stage?: FilterStage;
+  reason?: string;
+  /** For `merged`: the key it folded into. */
+  mergedInto?: string;
+}
+
+/** The minimum shape the recorder needs off a finding. */
+export interface TraceableFinding {
+  file: string;
+  line: number;
+  severity: 'critical' | 'warning' | 'info';
+  confidence?: number;
+  title: string;
+  fingerprint?: string;
+}
+
+/**
+ * W9 identity for a finding, preferring the fingerprint form. Mirrors
+ * `findingMatchKeys` in review-delta.ts, but returns the single strongest key
+ * rather than the union: the ledger needs one identity per row, not a match set.
+ */
+export function outcomeKey(f: TraceableFinding): string {
+  return f.fingerprint ? `${f.file}::F::${f.fingerprint}` : `${f.file}::T::${f.title}`;
+}
+
+interface Entry {
+  key: string;
+  file: string;
+  line: number;
+  severity: 'critical' | 'warning' | 'info';
+  confidence?: number;
+  title: string;
+  agents: Set<string>;
+  outcome?: FindingOutcome['outcome'];
+  stage?: FilterStage;
+  reason?: string;
+  mergedInto?: string;
+}
+
+/**
+ * Accumulates one terminal outcome per finding that enters the pipeline.
+ *
+ * Identity is the problem this class exists to solve. Two stages rewrite a
+ * surviving finding's title — FP-C's cross-agent merge and W10's clustering
+ * both append "and N related concerns" — so a title-derived key changes
+ * mid-flight. `alias()` records the rename so a later decision on the new key
+ * resolves back to the row that entered, and the one-terminal-outcome
+ * invariant holds across a merge instead of splitting into an orphan and a
+ * ghost.
+ *
+ * Recording is idempotent-by-first-write: the first terminal outcome for a
+ * finding wins. A stage cannot overwrite an earlier stage's verdict, so a
+ * double-record is a no-op rather than a silent rewrite of history.
+ */
+export class TraceRecorder {
+  private entries = new Map<string, Entry>();
+  /** current key → entry key, for findings a merge stage renamed. */
+  private aliases = new Map<string, string>();
+
+  /** Register a finding as it enters the pipeline, attributed to its agent. */
+  enter(f: TraceableFinding, agent: string): void {
+    const key = outcomeKey(f);
+    const existing = this.entries.get(key);
+    if (existing) {
+      // Same (file, title) from a second agent — one row, both agents. This is
+      // the pre-FP-C convergence signal, and it must be captured here because
+      // the merge downstream is what destroys it.
+      existing.agents.add(agent);
+      return;
+    }
+    this.entries.set(key, {
+      key,
+      file: f.file,
+      line: f.line,
+      severity: f.severity,
+      confidence: f.confidence,
+      title: f.title,
+      agents: new Set([agent]),
+    });
+  }
+
+  /** Resolve a possibly-renamed key back to the row that entered. */
+  private resolve(key: string): string {
+    let k = key;
+    // Bounded walk: a finding can be renamed by FP-C and again by W10.
+    for (let i = 0; i < 8 && this.aliases.has(k); i++) {
+      k = this.aliases.get(k)!;
+    }
+    return k;
+  }
+
+  /**
+   * Record that a surviving finding was renamed by a merge stage, so later
+   * decisions about it still land on the row that entered.
+   */
+  alias(fromKey: string, toKey: string): void {
+    if (fromKey === toKey) return;
+    this.aliases.set(toKey, this.resolve(fromKey));
+  }
+
+  /**
+   * Record a terminal outcome. Unknown keys register themselves first — the
+   * orchestrator can return a finding whose title it reworded, and a ledger
+   * that silently dropped those rows would be lying by omission.
+   */
+  record(
+    f: TraceableFinding,
+    outcome: FindingOutcome['outcome'],
+    stage?: FilterStage,
+    extra?: { reason?: string; mergedInto?: string },
+  ): void {
+    const key = this.resolve(outcomeKey(f));
+    let e = this.entries.get(key);
+    if (!e) {
+      this.enter(f, 'orchestrator');
+      e = this.entries.get(outcomeKey(f))!;
+    }
+    // First verdict wins: a later stage never rewrites an earlier one's record.
+    if (e.outcome) return;
+    e.outcome = outcome;
+    e.stage = stage;
+    e.reason = extra?.reason;
+    e.mergedInto = extra?.mergedInto;
+  }
+
+  /** Mark everything still un-adjudicated as surfaced. Call once, at the end. */
+  finalize(surfaced: TraceableFinding[]): void {
+    for (const f of surfaced) {
+      this.record(f, 'surfaced');
+    }
+  }
+
+  /** The ledger. */
+  outcomes(): FindingOutcome[] {
+    return [...this.entries.values()].map((e) => ({
+      key: e.key,
+      file: e.file,
+      line: e.line,
+      severity: e.severity,
+      confidence: e.confidence,
+      title: e.title,
+      agents: [...e.agents],
+      // An entry with no recorded verdict never reached a terminal stage. That
+      // is a bug in the wiring, not a state to invent a value for — call it
+      // dropped with no stage so the self-consistency test can see it.
+      outcome: e.outcome ?? 'dropped',
+      stage: e.stage,
+      reason: e.reason,
+      mergedInto: e.mergedInto,
+    }));
+  }
+
+  /**
+   * Findings removed from the rendered set, derived rather than subtracted.
+   *
+   * The old `totalRawFindings - filteredFindings.length` was measured upstream
+   * of where #385's custom-agent findings re-enter, so it double-counted them.
+   * Deriving it also means a stage that forgets to record shows up as a
+   * mismatch instead of quietly balancing the books.
+   */
+  suppressedCount(): number {
+    return this.outcomes().filter((o) => o.outcome !== 'surfaced').length;
+  }
+}

--- a/packages/core/src/filter-trace.ts
+++ b/packages/core/src/filter-trace.ts
@@ -169,6 +169,12 @@ export class TraceRecorder {
     let e = this.entries.get(key);
     if (!e) {
       this.enter(f, 'orchestrator');
+      // Read back the key `enter()` actually used, NOT the resolved one.
+      // These differ when an alias points at a row that never entered — an
+      // orchestrator rewrite that a merge stage then renamed. In that case the
+      // resolved key is dangling and has no row, so looking it up here would
+      // hand back `undefined` and the assertion below would throw on the very
+      // path this fallback exists to handle.
       e = this.entries.get(outcomeKey(f))!;
     }
     // First verdict wins: a later stage never rewrites an earlier one's record.

--- a/packages/core/src/filter-trace.ts
+++ b/packages/core/src/filter-trace.ts
@@ -138,9 +138,17 @@ export class TraceRecorder {
   /** Resolve a possibly-renamed key back to the row that entered. */
   private resolve(key: string): string {
     let k = key;
-    // Bounded walk: a finding can be renamed by FP-C and again by W10.
-    for (let i = 0; i < 8 && this.aliases.has(k); i++) {
-      k = this.aliases.get(k)!;
+    // A finding can be renamed twice (FP-C, then W10), so this walks a chain.
+    // Termination is by cycle detection rather than an iteration count: a
+    // counter stops the hang but returns whichever key the loop happened to
+    // land on, which is a different wrong answer per bound. Breaking on the
+    // first repeat is deterministic and independent of chain length.
+    const seen = new Set<string>([k]);
+    while (this.aliases.has(k)) {
+      const next = this.aliases.get(k)!;
+      if (seen.has(next)) break;
+      seen.add(next);
+      k = next;
     }
     return k;
   }

--- a/packages/core/src/finding-clustering.test.ts
+++ b/packages/core/src/finding-clustering.test.ts
@@ -44,8 +44,8 @@ describe('extractSignificantTokens', () => {
 describe('clusterFindings', () => {
   it('returns inputs unchanged when there are < 2 findings', () => {
     const single = [f({ line: 1, title: 'Single finding about validation' })];
-    expect(clusterFindings(single)).toEqual({ findings: single, clusteredCount: 0 });
-    expect(clusterFindings([])).toEqual({ findings: [], clusteredCount: 0 });
+    expect(clusterFindings(single)).toEqual({ findings: single, clusteredCount: 0, merges: [] });
+    expect(clusterFindings([])).toEqual({ findings: [], clusteredCount: 0, merges: [] });
   });
 
   it('merges two findings when same file + close lines + shared significant token', () => {

--- a/packages/core/src/finding-clustering.ts
+++ b/packages/core/src/finding-clustering.ts
@@ -28,6 +28,18 @@
 /** Minimal shape of a finding this module consumes. */
 import type { FindingEvidence } from './types/db.js';
 
+/**
+ * #470 — what a merge stage actually did, so the filter ledger can attribute
+ * each absorbed finding and follow the survivor across its rename. Both merge
+ * stages rewrite the primary's title, so recording only the absorbed set would
+ * leave the survivor looking like a different finding downstream.
+ */
+export interface MergeReport<T> {
+  primaryBefore: T;
+  primaryAfter: T;
+  absorbed: T[];
+}
+
 export interface ClusterableFinding {
   file: string;
   line: number;
@@ -146,14 +158,14 @@ function clusterPair(
 export function clusterFindings<T extends ClusterableFinding>(
   findings: T[],
   options: ClusterOptions = {},
-): { findings: T[]; clusteredCount: number } {
+): { findings: T[]; clusteredCount: number; merges: MergeReport<T>[] } {
   const opts: Required<ClusterOptions> = {
     maxLineSpan: options.maxLineSpan ?? 50,
     minTokenOverlap: options.minTokenOverlap ?? 1,
     maxClusterSize: options.maxClusterSize ?? 5,
   };
 
-  if (findings.length < 2) return { findings, clusteredCount: 0 };
+  if (findings.length < 2) return { findings, clusteredCount: 0, merges: [] };
 
   // Pre-extract token sets — repeated tokenization is by far the hot path.
   const tokenSets = findings.map((f) =>
@@ -194,6 +206,7 @@ export function clusterFindings<T extends ClusterableFinding>(
 
   const result: T[] = [];
   let clusteredCount = 0;
+  const merges: MergeReport<T>[] = [];
 
   for (const indices of buckets.values()) {
     if (indices.length === 1) {
@@ -241,10 +254,11 @@ export function clusterFindings<T extends ClusterableFinding>(
       description: `${primary.description}\n\n**Related concerns clustered into this finding (W10):**\n${relatedList}`,
     };
     result.push(merged);
+    merges.push({ primaryBefore: primary, primaryAfter: merged, absorbed: others });
     clusteredCount += others.length;
   }
 
-  return { findings: result, clusteredCount };
+  return { findings: result, clusteredCount, merges };
 }
 
 /**
@@ -278,7 +292,7 @@ export interface TaggedClusterableFindings<T extends ClusterableFinding> {
 
 export function dedupeCrossAgentByLine<T extends ClusterableFinding>(
   taggedFindings: ReadonlyArray<TaggedClusterableFindings<T>>,
-): { taggedFindings: TaggedClusterableFindings<T>[]; dedupedCount: number } {
+): { taggedFindings: TaggedClusterableFindings<T>[]; dedupedCount: number; merges: MergeReport<T>[] } {
   // Flatten with category + original-order attribution.
   interface Entry { category: string; finding: T; order: number }
   const all: Entry[] = [];
@@ -289,7 +303,7 @@ export function dedupeCrossAgentByLine<T extends ClusterableFinding>(
     }
   }
   if (all.length < 2) {
-    return { taggedFindings: taggedFindings.map((t) => ({ ...t, findings: [...(t.findings ?? [])] })), dedupedCount: 0 };
+    return { taggedFindings: taggedFindings.map((t) => ({ ...t, findings: [...(t.findings ?? [])] })), dedupedCount: 0, merges: [] };
   }
 
   // Group by exact `file::line`.
@@ -302,6 +316,7 @@ export function dedupeCrossAgentByLine<T extends ClusterableFinding>(
   }
 
   const surviving: Entry[] = [];
+  const merges: MergeReport<T>[] = [];
   let dedupedCount = 0;
 
   for (const g of groups.values()) {
@@ -350,6 +365,11 @@ export function dedupeCrossAgentByLine<T extends ClusterableFinding>(
         : {}),
     };
     surviving.push({ category: primary.category, finding: mergedFinding, order: primary.order });
+    merges.push({
+      primaryBefore: primary.finding,
+      primaryAfter: mergedFinding,
+      absorbed: others.map((o) => o.finding),
+    });
     dedupedCount += others.length;
   }
 
@@ -377,5 +397,6 @@ export function dedupeCrossAgentByLine<T extends ClusterableFinding>(
       findings: byCategory.get(t.category) ?? [],
     })),
     dedupedCount,
+    merges,
   };
 }


### PR DESCRIPTION
Closes #470. Stage 2 of #467, landed after #469 as the issue requires — both edit `agents/reviewer.ts` heavily.

Twelve stages can delete, merge, or demote a finding. Every one announced its decision to `console.warn` and nowhere else; what reached the reader was one scalar — *"13 findings removed by dedup & quality filters"*. No way to learn which thirteen, why, or whether the thing you were worried about was among them.

That a bare count is actively misleading is not hypothetical: **#401 shipped because two production reviews reported `1430` and `3869` findings removed on 4-line diffs** — a malfunctioning agent's junk, faithfully described as productive filtering. The fix then was to stop counting junk. The deeper problem is that a count cannot distinguish good filtering from a malfunction at all.

## The design problem the ticket did not name

**Identity is not stable across the pipeline.** FP-C's cross-agent merge and W10's clustering both rewrite a *surviving* finding's title (`— and N related concerns`), so a title-derived key changes mid-flight. Recording only the absorbed siblings would leave the survivor looking like a different finding downstream, and "exactly one terminal outcome per entrant" would split into an **orphan row and a ghost row**.

Both merge stages now report `{ primaryBefore, primaryAfter, absorbed }`, and `TraceRecorder.alias()` resolves later decisions back to the row that entered. There is a test that renames twice — FP-C, then W10 — because that is the case a single-alias implementation would silently get wrong.

## Decisions worth stating

- **`demoted` is its own outcome**, not a flavour of dropped. Grounding and the verifier demote criticals to `unverified` rather than deleting (#385); that was invisible before.
- **First verdict wins.** A later stage cannot rewrite an earlier one's record, so a double-record is a no-op rather than a silent revision of history.
- **An unadjudicated entry surfaces as `dropped` with no stage** — a wiring gap shows up instead of quietly balancing the books.
- **The orchestrator is attributable, not explained.** It is an LLM returning a new set, so its drops are knowable only by difference, and it cannot explain itself without a schema change and extra output tokens (#473). A title it reworded reads as a drop plus a new entry — that is what is *observable*, and inventing a link would be a guess.
- **Parse failures and degenerate entries never enter.** A response that did not parse yields no finding object; `isUsableFinding` rejects title-less entries. Both stay reliability warnings, which already say the right thing. Two tests pin this.

## One genuinely user-visible consequence

`suppressedCount` is now **derived**, and the dead `totalRawFindings` subtraction is deleted. The old subtraction was measured *upstream* of where #385's custom-agent findings re-enter, so it counted them as suppressed.

**On a repo with custom agents the rendered number may legitimately drop.** That is the fix, not a regression — and on a repo without custom agents the two must agree exactly, which is asserted directly. RUNBOOK E2E-99 now records this so a future reader does not file it as a bug.

## Naming

Deliberately **not** an extension of `FindingDispositionRecord` (`types/db.ts:654`), which is a *cross-review lifetime counter* backing the FB-E insights rollup. Extending it would corrupt that rollup. This record is per-review, per-finding.

## Verification

```
build      12/12
typecheck  20/20
test       21/21   (1,113 tests — 19 new)
```

Core-only, as the issue's parity section requires: no new code in `packages/lambda` or `packages/server`. Both handlers already read `result.suppressedCount`, so the switch reaches both runtimes unchanged.