### PR TITLE
fix(core): carry convergence past the orchestrator; make the cited-code fence safe

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -3539,6 +3539,8 @@ This also repairs the **Unverified concerns** section, which explained every ite
 - [ ] The cited code is at most 3 lines and is the anchor line ±1
 - [ ] The verifier's sentence appears under the finding, capped at 200 chars
 - [ ] Two agents on one line render `security + bugs agreed independently`; a lone agent renders **no** attribution
+- [ ] **(#477)** Convergence survives the **orchestrator**, which rebuilds every finding from its own JSON and whose schema has no `evidence` property. This shipped broken in #476 and three unit suites missed it, each testing one side of the seam — the pipeline-level test in `reviewer.test.ts` is the one that catches it, and it asserts on the *rendered comment*
+- [ ] **(#477)** Cited code containing a triple backtick does not break the comment, and the code block renders **inside** its finding's bullet with the `↳` reason still attached
 - [ ] A warning shows the reason with **no** code block
 - [ ] An info finding shows **no** evidence affordance at all
 - [ ] Each item under "Unverified concerns" carries its own reason
@@ -3550,6 +3552,7 @@ This also repairs the **Unverified concerns** section, which explained every ite
 **Failure modes.**
 - ❌ Evidence on an info finding — an empty shell implying a check that never ran, which is the coverage illusion this exists to remove
 - ❌ A single agent named as if it were convergence — restates the category and dilutes the real signal
+- ❌ Convergence attributed to a finding that did NOT converge — a false "two agents agreed" is worse than none, since the signal's value is that it is rarer and stronger than one agent's opinion
 - ❌ Evidence collapsed behind a click on a critical — hiding proof on the highest-stakes finding is backwards
 - ❌ The reason runs to a paragraph — a finding needing a paragraph to justify itself has failed to justify itself
 - ❌ Comment growth is noticeably larger than ~350 chars per critical

--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -35,6 +35,7 @@ import {
   EVIDENCE_REASON_MAX,
   type OrchestratedFinding,
 } from './reviewer.js';
+import { formatReviewComment } from '../comment-formatter.js';
 import { AGENT_MODE_SUFFIX, AGENT_MODE_PLACEHOLDER, FINDING_VERIFICATION_PROMPT } from './prompts.js';
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -4011,5 +4012,110 @@ describe('filter outcome ledger (#470)', () => {
     const surfaced = result.filterOutcomes.find((o) => o.outcome === 'surfaced')!;
     expect(surfaced.title).toBe('Missing null check on payload');
     expect(surfaced.stage).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Convergence survives the orchestrator (#477)
+// ---------------------------------------------------------------------------
+
+describe('cross-agent convergence across the orchestrator boundary (#477)', () => {
+  const allAgents = {
+    security: true, bugs: true, style: true, summary: true, diagram: true,
+    errorHandling: true, testCoverage: true, commentAccuracy: true,
+  };
+  const empty = JSON.stringify({ findings: [] });
+  const summaryResponse = JSON.stringify({ summary: 'Refactor.' });
+  const diagramResponse = '%% overview\nflowchart TD\n  A-->B';
+
+  // Two agents independently flag foo.ts:3, sharing the token "command" so
+  // FP-C genuinely merges them. Critical, because that is the severity the
+  // renderer shows convergence for.
+  const securityFinding = JSON.stringify({
+    findings: [{
+      file: 'foo.ts', line: 3, severity: 'critical', category: 'security',
+      title: 'Command injection via user input',
+      description: 'exec receives unsanitized command input',
+      suggestion: 'escape it',
+    }],
+  });
+  const bugFinding = JSON.stringify({
+    findings: [{
+      file: 'foo.ts', line: 3, severity: 'critical', category: 'bug',
+      title: 'Command argument not escaped',
+      description: 'the command argument is passed through unescaped',
+      suggestion: 'escape it',
+    }],
+  });
+
+  // The orchestrator rebuilds findings from its own JSON and the schema has no
+  // `evidence` property — so this deliberately carries NO evidence. If the
+  // re-attach regresses, convergence is simply gone and the assertion fails.
+  function orchestratorEchoing(title: string, line = 3, description = 'exec receives unsanitized command input') {
+    return JSON.stringify({
+      findings: [{
+        file: 'foo.ts', line, severity: 'critical', category: 'security',
+        title, description, suggestion: 'escape it',
+      }],
+      mergeScore: 2, mergeScoreReason: 'Critical present.',
+    });
+  }
+
+  async function run(orchestrator: string) {
+    const llm = createMockLLM([
+      securityFinding, bugFinding, empty, empty, empty, empty,
+      summaryResponse, diagramResponse, orchestrator,
+    ]);
+    return runReviewPipeline(
+      {
+        diff: sampleDiff, context: sampleContext,
+        modelId: 'heavy-model', lightModelId: 'light-model',
+        maxFindings: 25, enabledAgents: allAgents,
+      },
+      { llm },
+    );
+  }
+
+  const MERGED_TITLE = 'Command injection via user input — and 1 related cross-agent concern';
+
+  it('convergence reaches the RENDERED comment, not just the finding object', async () => {
+    // The seam the three #469 test suites each stopped short of: FP-C sets the
+    // field, the renderer displays a hand-built one, and withEvidenceCode
+    // merges a hand-injected one — but nothing crossed the orchestrator.
+    const result = await run(orchestratorEchoing(MERGED_TITLE));
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].evidence?.agents).toEqual(['security', 'bug']);
+
+    const comment = formatReviewComment({
+      summary: 'Refactor.',
+      findings: result.findings,
+      mergeScore: result.mergeScore,
+    });
+    expect(comment).toContain('security + bug agreed independently');
+  });
+
+  it('does NOT attribute convergence to an unrelated finding at the same line', async () => {
+    // A false "two agents agreed" is worse than none: the signal's whole value
+    // is that it is rarer and stronger than one agent's opinion.
+    const result = await run(orchestratorEchoing(
+      'Missing copyright header',
+      3,
+      'the file header lacks a license notice',
+    ));
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].evidence?.agents).toBeUndefined();
+
+    const comment = formatReviewComment({
+      summary: 'Refactor.', findings: result.findings, mergeScore: result.mergeScore,
+    });
+    expect(comment).not.toContain('agreed independently');
+  });
+
+  it('degrades to no convergence when the orchestrator rewrites the line', async () => {
+    // Best-effort, matching the withCodeFingerprints contract: a missed
+    // re-attach means no convergence line, never a wrong one.
+    const result = await run(orchestratorEchoing(MERGED_TITLE, 2));
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].evidence?.agents).toBeUndefined();
   });
 });

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -2378,24 +2378,77 @@ ${content}`;
 export function withEvidenceCode<T extends OrchestratedFinding>(
   findings: T[],
   fileContents: Record<string, string>,
+  /**
+   * #477 — cross-agent convergence, carried around the orchestrator.
+   *
+   * FP-C sets `evidence.agents` pre-orchestrator, but `runOrchestratorAgent`
+   * rebuilds every finding from the model's JSON and ORCHESTRATOR_SCHEMA has
+   * no `evidence` property, so the field is destroyed in transit. Worse than
+   * absent: the schema is deliberately permissive, so the model *may* echo it
+   * back, making the behaviour intermittent rather than reliably missing.
+   *
+   * Re-attached here because this already runs post-orchestrator over the
+   * combined builtin + custom list and already merges into existing evidence.
+   */
+  convergence?: Map<string, ConvergenceRecord>,
 ): T[] {
   return findings.map((f) => {
     if (f.severity !== 'critical' && f.severity !== 'warning') return f;
+
+    const agents = resolveConvergence(f, convergence);
+    const withAgents = agents
+      ? { ...f, evidence: { ...(f.evidence ?? {}), agents } }
+      : f;
+
     const content = fileContents[f.file];
-    if (!content) return f;
+    if (!content) return withAgents;
     const lines = content.split('\n');
     const idx = f.line - 1;
-    if (idx < 0 || idx >= lines.length) return f;
+    if (idx < 0 || idx >= lines.length) return withAgents;
     const start = Math.max(0, idx - 1);
     const end = Math.min(lines.length, idx + 2);
     const code = lines.slice(start, end).join('\n');
     // An anchor on a blank line yields nothing worth rendering.
-    if (!code.trim()) return f;
+    if (!code.trim()) return withAgents;
     return {
-      ...f,
-      evidence: { ...(f.evidence ?? {}), code, codeStartLine: start + 1 },
+      ...withAgents,
+      evidence: { ...(withAgents.evidence ?? {}), code, codeStartLine: start + 1 },
     };
   });
+}
+
+/** #477 — what FP-C knew about a converged location, carried past the orchestrator. */
+export interface ConvergenceRecord {
+  agents: string[];
+  /** Significant tokens of the merged finding, used to reject a false match. */
+  tokens: Set<string>;
+}
+
+/**
+ * Decide whether a post-orchestrator finding is the one FP-C merged.
+ *
+ * Location alone is not enough. The orchestrator can return a *different*
+ * concern at the same line, and badging that one "security + bugs agreed"
+ * would be a fabricated claim on a trust surface. Convergence is valuable
+ * precisely because it is rarer and stronger than one agent's opinion, so a
+ * false positive costs more than a miss. Requiring a shared significant token
+ * tolerates the orchestrator rewording a title while rejecting an unrelated
+ * finding that merely landed on the same line.
+ *
+ * Best-effort by design, matching withCodeFingerprints: if the orchestrator
+ * rewrote the line number, this finds nothing and no convergence renders.
+ */
+function resolveConvergence(
+  f: OrchestratedFinding,
+  convergence?: Map<string, ConvergenceRecord>,
+): string[] | undefined {
+  if (!convergence) return undefined;
+  const rec = convergence.get(`${f.file}:${f.line}`);
+  if (!rec || rec.agents.length < 2) return undefined;
+  for (const t of extractSignificantTokens(`${f.title} ${f.description}`)) {
+    if (rec.tokens.has(t)) return rec.agents;
+  }
+  return undefined;
 }
 
 function withCodeFingerprints<T extends OrchestratedFinding>(
@@ -2932,7 +2985,18 @@ export async function runReviewPipeline(
   const fpCResult = dedupeCrossAgentByLine(builtinTagged);
   // FP-C merged siblings into a survivor whose title it rewrote; alias the
   // survivor so later stages still resolve to the row that entered.
+  // #477 — capture convergence before the orchestrator destroys it. The merged
+  // finding already carries evidence.agents (set by dedupeCrossAgentByLine), so
+  // no new return value is needed — just a note of where it was and what it said.
+  const convergence = new Map<string, ConvergenceRecord>();
   for (const m of fpCResult.merges) {
+    const agents = m.primaryAfter.evidence?.agents;
+    if (agents && agents.length > 1) {
+      convergence.set(`${m.primaryAfter.file}:${m.primaryAfter.line}`, {
+        agents,
+        tokens: extractSignificantTokens(`${m.primaryAfter.title} ${m.primaryAfter.description}`),
+      });
+    }
     const into = outcomeKey(m.primaryAfter);
     trace.alias(outcomeKey(m.primaryBefore), into);
     for (const a of m.absorbed) {
@@ -3244,6 +3308,7 @@ export async function runReviewPipeline(
       ...withCodeFingerprints(customFindings, groundingFileContents),
     ],
     groundingFileContents,
+    convergence,
   );
 
   // W3 convergence guard: drop findings the author already rebutted/deferred

--- a/packages/core/src/comment-formatter.test.ts
+++ b/packages/core/src/comment-formatter.test.ts
@@ -940,3 +940,63 @@ describe('per-finding evidence (#469)', () => {
     expect(result).toContain('↳ r');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Cited-code fence safety (#477)
+// ---------------------------------------------------------------------------
+
+describe('cited-code fence safety (#477)', () => {
+  function render(code: string) {
+    return formatReviewComment(baseOptions({
+      findings: [makeFinding({
+        severity: 'critical',
+        evidence: { code, codeStartLine: 14, reason: 'the reason sentence' },
+      })],
+      mergeScore: 1,
+    }));
+  }
+
+  it('opens a longer fence when the cited code contains a triple backtick', () => {
+    // Reachable, not theoretical: #469 cites .md files like any other, and a
+    // docs page quoting a code block closes the fence early — the rest of the
+    // review then renders as broken markdown.
+    const result = render('Here is a fence:\n```\nconst x = 1;\n```');
+    expect(result).toContain('````');
+    // The inner ``` must not be the closer.
+    const opener = result.slice(result.indexOf('Cited code')).match(/`{3,}/)![0];
+    expect(opener.length).toBeGreaterThan(3);
+  });
+
+  it('scales the fence past the longest backtick run, not just to four', () => {
+    const result = render('a ````` b');
+    expect(result).toContain('``````');
+  });
+
+  it('uses a plain 3-backtick fence when the code has none', () => {
+    const result = render('const x = 1;');
+    const opener = result.slice(result.indexOf('Cited code')).match(/`{3,}/)![0];
+    expect(opener).toBe('```');
+  });
+
+  it('indents the fence into the list item so the block stays in its bullet', () => {
+    // In GFM a blank line followed by unindented content ends the list, so an
+    // unindented fence escapes the bullet and detaches what follows.
+    const result = render('const x = 1;');
+    expect(result).toContain('\n  ```\n');
+    expect(result).toContain('\n  const x = 1;\n');
+  });
+
+  it('keeps the ↳ reason line attached after the code block', () => {
+    const result = render('const x = 1;');
+    const codeAt = result.indexOf('Cited code');
+    const reasonAt = result.indexOf('↳ the reason sentence');
+    expect(reasonAt).toBeGreaterThan(codeAt);
+    // Still at the list content column, i.e. still inside the bullet.
+    expect(result).toContain('\n  ↳ the reason sentence');
+  });
+
+  it('indents every line of a multi-line citation', () => {
+    const result = render('const a = 1;\nconst b = 2;\nconst c = 3;');
+    expect(result).toContain('\n  const a = 1;\n  const b = 2;\n  const c = 3;\n');
+  });
+});

--- a/packages/core/src/comment-formatter.ts
+++ b/packages/core/src/comment-formatter.ts
@@ -289,7 +289,25 @@ function renderEvidence(f: Finding): string {
   if (e.code?.trim()) {
     const startLine = e.codeStartLine;
     const gutter = startLine != null ? ` \`${f.file}:${startLine}\`` : '';
-    out += `\n\n  <sub>Cited code${gutter}</sub>\n\n\`\`\`\n${e.code}\n\`\`\``;
+    // #477 — two rendering hazards, both reachable because the cited code is
+    // raw source from the file at head:
+    //
+    //  1. A triple backtick in the code closes the fence early and the rest of
+    //     the review renders as broken markdown. #469 deliberately cites .md
+    //     files like any other, so this is not theoretical. CommonMark allows
+    //     any fence length >= 3 and requires the closer to be at least as long,
+    //     so open with one longer than the longest run in the code itself.
+    //  2. The finding is a `-` bullet, and in GFM a blank line followed by
+    //     unindented content ends the list — an unindented fence escapes the
+    //     bullet and detaches the `↳ reason` line below from its finding.
+    //     Indent the fence and its content to the list content column.
+    const longestRun = Math.max(
+      0,
+      ...(e.code.match(/`+/g) ?? []).map((run) => run.length),
+    );
+    const fence = '`'.repeat(Math.max(3, longestRun + 1));
+    const indented = e.code.split('\n').map((l) => `  ${l}`).join('\n');
+    out += `\n\n  <sub>Cited code${gutter}</sub>\n\n  ${fence}\n${indented}\n  ${fence}`;
   }
   if (reason) {
     out += `\n  ↳ ${reason}`;


### PR DESCRIPTION
Closes #477. Two defects in the #469 evidence surface — both mine, found auditing the merged PR.

## 1. Convergence never reached production

`evidence.agents` is set by FP-C, which runs **before** `runOrchestratorAgent` — and the orchestrator returns findings rebuilt entirely from the model's JSON (`reviewer.ts:1419`), with no `evidence` property in `ORCHESTRATOR_SCHEMA`. I verified the only evidence writes after that point are `reason` (`:2347`) and `code` (`:2396`). So `security + bugs agreed independently` was effectively unreachable.

Worse than a clean absence, as the issue notes: the schema has no `additionalProperties: false`, so the model *can* echo the field back — intermittent, which is the harder failure to diagnose.

**The fix needed no new plumbing.** The merged finding already carries `evidence.agents`, and FP-C already reports its merges (from #470), so the pipeline just notes where convergence happened and what it said, then re-attaches in `withEvidenceCode` — which already runs post-orchestrator over the combined builtin + custom list and already merges rather than overwrites.

**Location alone is not enough to re-attach.** The orchestrator can return a *different* concern at the same line, and badging that one "two agents agreed" would be a fabricated claim on a trust surface. A shared-significant-token guard tolerates a reworded title while rejecting an unrelated finding that merely landed on the same line. Line drift finds nothing and renders nothing — a miss, never a wrong attribution.

### Why #469's tests missed it

Three suites each covered one side of the seam and none crossed the orchestrator:

| suite | what it actually proved |
|---|---|
| `finding-clustering` | FP-C sets the field, in isolation |
| `comment-formatter` | the renderer displays a **hand-built** `evidence.agents` |
| `reviewer` | `withEvidenceCode` merges a **hand-injected** value |

The new test runs the full pipeline with FP-C genuinely merging two agents' findings and asserts on the **rendered comment**. It is verified load-bearing — reverting the fix fails it:

```
× convergence reaches the RENDERED comment, not just the finding object
✓ does NOT attribute convergence to an unrelated finding at the same line
✓ degrades to no convergence when the orchestrator rewrites the line
```

## 2. The cited-code fence could break the comment

`e.code` is raw source from the file at head, emitted inside a fixed three-backtick fence at column 0.

- **A cited line containing a triple backtick closed the fence early**, and the rest of the review rendered as broken markdown. Reachable because #469 cites `.md` files like any other. The fence now opens longer than the longest backtick run in the code — CommonMark allows any length >= 3 with the closer at least as long.
- **In GFM a blank line followed by unindented content ends the list**, so the unindented fence escaped the finding's bullet and detached the reason line below it. Fence and content are now indented to the list content column.

## Verification

```
build      12/12
typecheck  20/20
test       21/21   (1,127 tests — 9 new)
```

RUNBOOK E2E-101 gains the seam and fence checks, plus a failure mode for false attribution — the convergence checkbox was unit-gated, which is exactly how this shipped broken.
