### PR TITLE
feat(storage): persist the filter outcome ledger (Dynamo + Postgres)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -117,6 +117,32 @@ Implementations:
 | `storage-dynamo` | `DynamoReviewStore` | DynamoDB. PK=`repoFullName`, SK=`prNumberCommitSha`. 90-day TTL. |
 | `storage-postgres` | `PostgresReviewStore` | Postgres. Composite PK `(repo_full_name, pr_number_commit_sha)`. |
 
+### IReviewTraceStore
+
+Persists the per-review filter outcome ledger (#470/#471) — why each finding was
+dropped, merged, or demoted. Read by the dashboard (#472) and a future audit
+export (#295).
+
+**It has its own table, and that is a correctness requirement rather than a
+preference.** `queryByPR` matches `begins_with(prNumberCommitSha, "42#")`, so a
+trace keyed `42#abc123#TRACE` beside the review would come back as if it were a
+review — and every call site passes a small `Limit`, so trace rows could evict
+real reviews from the previous-review lookup that feeds `previousFindings`, the
+delta and FP-B.
+
+| | SaaS | Self-hosted |
+|---|---|---|
+| store | `mergewatch-review-traces-{stage}` | `review_traces` |
+| retention | 30-day Dynamo TTL, **enabled** | `expires_at` column; **no** native TTL — operators prune |
+| size guard | 500 outcomes per review, truncation explicitly marked | same |
+
+Retention is deliberately shorter than a review's 90 days: a trace is a
+debugging and trust artifact, not a system of record. Writes are best-effort at
+both runtimes — a trace must never be able to fail a review.
+
+Self-hosted needs **no new environment variable**: the table comes from the
+Drizzle schema, so there is no table-name indirection to forget.
+
 ### IGitHubAuthProvider
 
 ```typescript

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -104,6 +104,11 @@ Globals:
         # DynamoDB table names — injected so Lambda code doesn't hardcode them
         INSTALLATIONS_TABLE: !Ref InstallationsTable
         REVIEWS_TABLE: !Ref ReviewsTable
+        # #471 — the filter outcome ledger. A SEPARATE table, not a suffixed
+        # sort key on ReviewsTable: queryByPR matches begins_with("42#"), so a
+        # trace row there would come back as a review and could evict a real
+        # one from the previous-review lookup under its small Limit.
+        REVIEW_TRACES_TABLE: !Ref ReviewTracesTable
         API_KEYS_TABLE: !Ref ApiKeysTable
         SESSIONS_TABLE: !Ref SessionsTable
         # FB-A / FB-E: shared across ReviewAgent (writes) and InsightsRollup (reads/writes).
@@ -431,6 +436,7 @@ Resources:
           STAGE: !Ref Stage
           INSTALLATIONS_TABLE: !Ref InstallationsTable
           REVIEWS_TABLE: !Ref ReviewsTable
+          REVIEW_TRACES_TABLE: !Ref ReviewTracesTable
           API_KEYS_TABLE: !Ref ApiKeysTable
           SESSIONS_TABLE: !Ref SessionsTable
           DEFAULT_BEDROCK_MODEL_ID: !Ref DefaultBedrockModelId
@@ -635,6 +641,52 @@ Resources:
   #   - Get review for specific PR+commit: PK=repoFullName, SK=prNumber#sha
   #   - List all reviews for a repo:       PK=repoFullName (query)
   #   - List reviews for a PR:             PK=repoFullName, SK begins_with("42#")
+
+  # #471 — filter outcome ledger, one row per review.
+  #
+  # Separate from ReviewsTable by necessity, not preference: queryByPR uses
+  # begins_with(prNumberCommitSha, "42#") and every call site passes a small
+  # Limit, so a `42#abc123#TRACE` row on that table would be returned as a
+  # review and could push a real one out of the previous-review lookup feeding
+  # previousFindings, the delta and FP-B. It also keeps traces clear of the
+  # 400KB item cap.
+  #
+  # TTL is ENABLED here, unlike ReviewsTable where the block is commented out:
+  # a trace is a debugging and trust artifact with a 30-day life, not a system
+  # of record. The application sets `ttl` via buildReviewTrace.
+  ReviewTracesTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub 'mergewatch-review-traces-${Stage}'
+      BillingMode: PAY_PER_REQUEST
+
+      KeySchema:
+        - AttributeName: repoFullName
+          KeyType: HASH
+        - AttributeName: prNumberCommitSha
+          KeyType: RANGE
+
+      AttributeDefinitions:
+        - AttributeName: repoFullName
+          AttributeType: S
+        - AttributeName: prNumberCommitSha
+          AttributeType: S
+
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
+
+      SSESpecification:
+        SSEEnabled: true
+
+      Tags:
+        - Key: Project
+          Value: MergeWatch
+        - Key: Stage
+          Value: !Ref Stage
+
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
 
   ReviewsTable:
     Type: AWS::DynamoDB::Table
@@ -1134,6 +1186,7 @@ Resources:
                   # Table ARNs
                   - !GetAtt InstallationsTable.Arn
                   - !GetAtt ReviewsTable.Arn
+                  - !GetAtt ReviewTracesTable.Arn
                   - !GetAtt ApiKeysTable.Arn
                   - !GetAtt SessionsTable.Arn
                   - !GetAtt FindingDispositionsTable.Arn
@@ -1144,6 +1197,7 @@ Resources:
                   # Index ARNs (for future GSIs)
                   - !Sub '${InstallationsTable.Arn}/index/*'
                   - !Sub '${ReviewsTable.Arn}/index/*'
+                  - !Sub '${ReviewTracesTable.Arn}/index/*'
                   - !Sub '${ApiKeysTable.Arn}/index/*'
                   - !Sub '${SessionsTable.Arn}/index/*'
                   - !Sub '${FindingDispositionsTable.Arn}/index/*'
@@ -1259,6 +1313,10 @@ Outputs:
   InstallationsTableName:
     Description: Name of the DynamoDB installations table
     Value: !Ref InstallationsTable
+
+  ReviewTracesTableName:
+    Description: DynamoDB table storing per-review filter outcome ledgers (#471)
+    Value: !Ref ReviewTracesTable
 
   ReviewsTableName:
     Description: Name of the DynamoDB reviews table

--- a/packages/core/src/filter-trace.test.ts
+++ b/packages/core/src/filter-trace.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { TraceRecorder, outcomeKey, type TraceableFinding } from './filter-trace.js';
+import { TraceRecorder, outcomeKey, type TraceableFinding, buildReviewTrace, MAX_TRACE_OUTCOMES, type FindingOutcome } from './filter-trace.js';
 
 function f(over: Partial<TraceableFinding> = {}): TraceableFinding {
   return {
@@ -210,5 +210,63 @@ describe('TraceRecorder — alias chain termination (#478 review)', () => {
     const rows = t.outcomes();
     expect(rows).toHaveLength(1);
     expect(rows[0].title).toBe('One');
+  });
+});
+
+describe('buildReviewTrace (#471)', () => {
+  const NOW = new Date('2026-08-25T12:00:00.000Z');
+
+  function outcomes(n: number, outcome: 'surfaced' | 'dropped'): FindingOutcome[] {
+    return Array.from({ length: n }, (_, i) => ({
+      key: `src/a.ts::T::${outcome}-${i}`,
+      file: 'src/a.ts', line: i + 1, severity: 'warning' as const,
+      title: `${outcome}-${i}`, agents: ['security'], outcome,
+    }));
+  }
+
+  it('keys the trace exactly as the review — no suffix', () => {
+    // A suffix is what would collide: queryByPR matches begins_with("42#"), so
+    // `42#abc123#TRACE` on the reviews table is returned as a review.
+    const t = buildReviewTrace('o/r', '42#abc123', [], NOW);
+    expect(t.repoFullName).toBe('o/r');
+    expect(t.prNumberCommitSha).toBe('42#abc123');
+  });
+
+  it('sets a 30-day TTL', () => {
+    const t = buildReviewTrace('o/r', '42#abc', [], NOW);
+    expect(t.ttl).toBe(Math.floor(NOW.getTime() / 1000) + 30 * 24 * 60 * 60);
+  });
+
+  it('does not mark an under-cap trace as truncated', () => {
+    const t = buildReviewTrace('o/r', '42#abc', outcomes(10, 'dropped'), NOW);
+    expect(t.truncated).toBeUndefined();
+    expect(t.totalOutcomes).toBeUndefined();
+    expect(t.outcomes).toHaveLength(10);
+  });
+
+  it('caps the retained outcomes and says so', () => {
+    // #401's runaway emitted ~1,430 near-empty findings from one response.
+    const t = buildReviewTrace('o/r', '42#abc', outcomes(1_430, 'dropped'), NOW);
+    expect(t.outcomes).toHaveLength(MAX_TRACE_OUTCOMES);
+    expect(t.truncated).toBe(true);
+    expect(t.totalOutcomes).toBe(1_430);
+  });
+
+  it('keeps the explanatory outcomes when truncating', () => {
+    // Surfaced findings are already visible in the PR comment; the dropped and
+    // merged ones are the only thing the trace adds, so those are what a
+    // truncated trace must retain to still be worth reading.
+    const mixed = [...outcomes(400, 'surfaced'), ...outcomes(400, 'dropped')];
+    const t = buildReviewTrace('o/r', '42#abc', mixed, NOW);
+    expect(t.outcomes).toHaveLength(MAX_TRACE_OUTCOMES);
+    expect(t.outcomes.filter((o) => o.outcome === 'dropped')).toHaveLength(400);
+    expect(t.truncated).toBe(true);
+    expect(t.totalOutcomes).toBe(800);
+  });
+
+  it('handles an empty ledger', () => {
+    const t = buildReviewTrace('o/r', '42#abc', [], NOW);
+    expect(t.outcomes).toEqual([]);
+    expect(t.truncated).toBeUndefined();
   });
 });

--- a/packages/core/src/filter-trace.ts
+++ b/packages/core/src/filter-trace.ts
@@ -21,6 +21,8 @@
  * In-memory and core-only. #471 persists it; #472 renders it.
  */
 
+import type { ReviewTraceItem } from './types/db.js';
+
 /** The stages that can remove, merge, or demote a finding. */
 export type FilterStage =
   | 'fp-c-line-dedup'       // cross-agent same (file,line) merge
@@ -231,4 +233,52 @@ export class TraceRecorder {
   suppressedCount(): number {
     return this.outcomes().filter((o) => o.outcome !== 'surfaced').length;
   }
+}
+
+// ─── Persistence (#471) ────────────────────────────────────────────────────
+
+/**
+ * Cap on the outcomes retained per review.
+ *
+ * A #401-shaped runaway agent emitted ~1,430 near-empty findings from one
+ * response; writing an unbounded trace for that would be both expensive and
+ * useless. The cap exists so a malfunction cannot produce an unbounded record,
+ * and the truncation is always marked so the remainder never reads as the
+ * whole story.
+ */
+export const MAX_TRACE_OUTCOMES = 500;
+
+/** Retention for a persisted trace — a debugging artifact, not a system of record. */
+export const TRACE_TTL_DAYS = 30;
+
+/**
+ * Build the persisted trace for one review.
+ *
+ * When truncating, the non-surfaced outcomes are kept first. Surfaced findings
+ * are already visible in the PR comment, so the dropped, merged and demoted
+ * ones are the only thing the trace adds — keeping those is what makes a
+ * truncated trace still worth reading. Order within each group is preserved.
+ */
+export function buildReviewTrace(
+  repoFullName: string,
+  prNumberCommitSha: string,
+  outcomes: FindingOutcome[],
+  now: Date,
+): ReviewTraceItem {
+  const truncated = outcomes.length > MAX_TRACE_OUTCOMES;
+  const retained = truncated
+    ? [
+        ...outcomes.filter((o) => o.outcome !== 'surfaced'),
+        ...outcomes.filter((o) => o.outcome === 'surfaced'),
+      ].slice(0, MAX_TRACE_OUTCOMES)
+    : outcomes;
+
+  return {
+    repoFullName,
+    prNumberCommitSha,
+    outcomes: retained,
+    ...(truncated ? { truncated: true, totalOutcomes: outcomes.length } : {}),
+    createdAt: now.toISOString(),
+    ttl: Math.floor(now.getTime() / 1000) + TRACE_TTL_DAYS * 24 * 60 * 60,
+  };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,7 @@ export type {
   FindingDispositionAttribution,
   ApiKeyRecord,
   McpSessionRecord,
+  IReviewTraceStore,
 } from './storage/types.js';
 export type { IGitHubAuthProvider } from './github/auth.js';
 export type {
@@ -318,7 +319,18 @@ export type {
   OrgCustomAgent,
   OrgAgentScope,
   OrgAgentEnforcement,
+  ReviewTraceItem,
 } from './types/db.js';
+
+// #470/#471 — the filter outcome ledger and its persisted form.
+export {
+  TraceRecorder,
+  outcomeKey,
+  buildReviewTrace,
+  MAX_TRACE_OUTCOMES,
+  TRACE_TTL_DAYS,
+} from './filter-trace.js';
+export type { FindingOutcome, FilterStage } from './filter-trace.js';
 
 export { resolveReviewModelId } from './config/model-resolution.js';
 export type { ModelResolutionInput, ModelSource, ResolvedModel } from './config/model-resolution.js';

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -8,7 +8,7 @@
 
 import type {
   InstallationItem, InstallationSettings,
-  ReviewItem, ReviewStatus,
+  ReviewItem, ReviewStatus, ReviewTraceItem,
   FindingDispositionRecord,
   InstallationFPInsight,
   PRLifecycleRecord,
@@ -58,6 +58,19 @@ export interface IReviewStore {
     extra?: Partial<ReviewItem>,
   ): Promise<void>;
   queryByPR(repoFullName: string, prPrefix: string, limit?: number): Promise<ReviewItem[]>;
+}
+
+/**
+ * #471 — persistence for the filter outcome ledger.
+ *
+ * Separate from IReviewStore rather than bolted onto it: the backing table is
+ * separate by necessity (see ReviewTraceItem), the lifetime is different (a
+ * debugging artifact, not a system of record), and a runtime that cannot write
+ * traces must still be able to write reviews.
+ */
+export interface IReviewTraceStore {
+  put(trace: ReviewTraceItem): Promise<void>;
+  get(repoFullName: string, prNumberCommitSha: string): Promise<ReviewTraceItem | null>;
 }
 
 export interface ApiKeyRecord {

--- a/packages/core/src/types/db.ts
+++ b/packages/core/src/types/db.ts
@@ -35,6 +35,10 @@
  * maxFileSize: 500
  * ```
  */
+// Type-only, and erased at compile time — filter-trace.ts imports ReviewTraceItem
+// back from here, so a value import would be a runtime cycle. This is not.
+import type { FindingOutcome } from '../filter-trace.js';
+
 export interface RepoConfig {
   /** Whether MergeWatch is enabled for this repo (default: true) */
   enabled?: boolean;
@@ -462,6 +466,41 @@ export interface FindingEvidence {
    * category and is noise, while "security + bugs agreed" is real signal.
    */
   agents?: string[];
+}
+
+/**
+ * #471 — one review's filter ledger, persisted.
+ *
+ * Deliberately its OWN table rather than a sort-key row beside the review.
+ * `queryByPR` matches on `begins_with(prNumberCommitSha, "42#")`, so any
+ * suffixed key like `42#abc123#TRACE` is returned as if it were a review — and
+ * every call site passes `limit: 5`, so trace rows could evict real reviews
+ * from the previous-review lookup that feeds `previousFindings`, the delta and
+ * FP-B. That is a silent correctness regression inside the review pipeline,
+ * not a query annoyance.
+ */
+export interface ReviewTraceItem {
+  /** Same partition key as the review this describes. */
+  repoFullName: string;
+  /** Same sort key as the review: `42#abc123`. */
+  prNumberCommitSha: string;
+  /** The ledger. Capped — see `truncated`. */
+  outcomes: FindingOutcome[];
+  /**
+   * True when `outcomes` holds fewer rows than the review actually produced.
+   * A truncated trace must never read as complete: this is the whole point of
+   * #401, where a bare number described a malfunction as productive filtering.
+   */
+  truncated?: boolean;
+  /** How many outcomes existed before the cap. Present only when truncated. */
+  totalOutcomes?: number;
+  createdAt: string;
+  /**
+   * Dynamo TTL (epoch seconds). Shorter than a review's retention: this is a
+   * debugging and trust artifact, not a system of record (#295 is that).
+   * Postgres has no native TTL — see `review_traces.expires_at`.
+   */
+  ttl?: number;
 }
 
 /** A single finding stored on a ReviewItem (matches comment-formatter Finding). */

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -63,6 +63,7 @@ import {
   languagesFromFiles,
   findingMatchKeys,
   resolveReviewModelId,
+  buildReviewTrace,
 } from '@mergewatch/core';
 import type { RejectCategory, FindingDispositionRecord } from '@mergewatch/core';
 import type {
@@ -77,7 +78,9 @@ import {
   buildWorkDoneSection, computeReviewDelta, resolveAppLogin,
   checkInputBudget, describeOverBudget,
 } from '@mergewatch/core';
-import { DynamoInstallationStore } from '@mergewatch/storage-dynamo';
+import { DynamoInstallationStore,
+  DynamoReviewTraceStore,
+} from '@mergewatch/storage-dynamo';
 import {
 
   DynamoReviewStore,
@@ -121,6 +124,10 @@ const DASHBOARD_BASE_URL = process.env.DASHBOARD_BASE_URL ?? 'https://mergewatch
 
 const installationStore = new DynamoInstallationStore(dynamodb, INSTALLATIONS_TABLE);
 const reviewStore = new DynamoReviewStore(dynamodb, REVIEWS_TABLE);
+// #471 — separate table, separate store. Writes are best-effort (see below):
+// a trace is a debugging artifact and must never be able to fail a review.
+const REVIEW_TRACES_TABLE = process.env.REVIEW_TRACES_TABLE ?? 'mergewatch-review-traces';
+const reviewTraceStore = new DynamoReviewTraceStore(dynamodb, REVIEW_TRACES_TABLE);
 // FB-A — per-finding cross-PR dispositions. Best-effort writes; if the
 // table doesn't exist yet (mid-deploy state) the store layer swallows.
 const dispositionStore = new DynamoFindingDispositionStore(dynamodb, FINDING_DISPOSITIONS_TABLE);
@@ -1071,6 +1078,15 @@ export async function handler(
       : undefined;
 
     const completedAt = new Date().toISOString();
+
+    // #471 — persist the filter ledger. Deliberately AFTER the comment is
+    // posted and wrapped so it cannot fail the review: the developer getting
+    // their review matters, the debugging artifact does not.
+    await reviewTraceStore
+      .put(buildReviewTrace(repoFullName, prNumberCommitSha, result.filterOutcomes, new Date()))
+      .catch((err: unknown) => {
+        console.warn('[filter-trace] failed to persist trace for %s %s:', repoFullName, prNumberCommitSha, err);
+      });
 
     await reviewStore.updateStatus(repoFullName, prNumberCommitSha, 'complete', {
       commentId,

--- a/packages/lambda/src/template.test.ts
+++ b/packages/lambda/src/template.test.ts
@@ -24,6 +24,9 @@ describe('infra/template.yaml — Globals.Function.Environment.Variables', () =>
     'FP_INSIGHTS_TABLE',
     'INSTALLATIONS_TABLE',
     'REVIEWS_TABLE',
+    // #471 — same #181 failure mode: a trace writer resolving to the
+    // unsuffixed default name would ResourceNotFoundException into a void.
+    'REVIEW_TRACES_TABLE',
   ])('exposes %s as a shared Lambda env var', (varName) => {
     expect(globalsBlock).toMatch(new RegExp(`^\\s+${varName}:`, 'm'));
   });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -14,6 +14,7 @@ import {
   PostgresSatisfactionStore,
   PostgresReviewCostStore,
   runMigrations,
+  PostgresReviewTraceStore,
 } from '@mergewatch/storage-postgres';
 import { EnvGitHubAuthProvider } from './github-auth-env.js';
 import { createLLMProvider } from './llm-factory.js';
@@ -71,6 +72,8 @@ async function main() {
   // Initialize providers
   const installationStore = new PostgresInstallationStore(db);
   const reviewStore = new PostgresReviewStore(db);
+  // #471 — filter outcome ledger, its own table (see ReviewTraceItem).
+  const reviewTraceStore = new PostgresReviewTraceStore(db);
   const dispositionStore = new PostgresFindingDispositionStore(db);
   const fpInsightStore = new PostgresFPInsightStore(db);
   const prLifecycleStore = new PostgresPRLifecycleStore(db);
@@ -133,6 +136,7 @@ async function main() {
     webhookSecret,
     installationStore,
     reviewStore,
+    reviewTraceStore,
     dispositionStore,
     fpInsightStore,
     prLifecycleStore,

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -20,6 +20,7 @@ import {
   parseEnvModelPricing,
   selectOrgAgentsForReview, unionCustomAgents, blockingCriticalAgents, languagesFromFiles,
   findingMatchKeys,
+  buildReviewTrace,
 } from '@mergewatch/core';
 import type { WebhookDeps } from './webhook-handler.js';
 // #416 — deployment stage, so review artifacts (comment marker, check-run
@@ -295,7 +296,7 @@ async function handleInlineReplyJob(
 
 export async function processReviewJob(
   job: ReviewJobPayload,
-  deps: Pick<WebhookDeps, 'installationStore' | 'reviewStore' | 'dispositionStore' | 'fpInsightStore' | 'prLifecycleStore' | 'satisfactionStore' | 'costStore' | 'authProvider' | 'llm' | 'dashboardBaseUrl'>,
+  deps: Pick<WebhookDeps, 'installationStore' | 'reviewStore' | 'reviewTraceStore' | 'dispositionStore' | 'fpInsightStore' | 'prLifecycleStore' | 'satisfactionStore' | 'costStore' | 'authProvider' | 'llm' | 'dashboardBaseUrl'>,
 ): Promise<void> {
   const { installationId, owner, repo, prNumber, mode } = job;
   const instId = String(installationId);
@@ -917,6 +918,18 @@ export async function processReviewJob(
           (severityRank[f.severity] ?? 99) < (severityRank[top] ?? 99) ? f.severity : top,
         result.findings[0].severity) as 'info' | 'warning' | 'critical'
       : undefined;
+
+    // #471 — persist the filter ledger. After the comment is posted and
+    // wrapped so it can never fail the review: the developer getting their
+    // review matters, the debugging artifact does not. Optional store, so a
+    // deployment that has not wired it is simply unaffected.
+    if (deps.reviewTraceStore) {
+      await deps.reviewTraceStore
+        .put(buildReviewTrace(repoFullName, prNumberCommitSha, result.filterOutcomes, new Date()))
+        .catch((err: unknown) => {
+          console.warn('[filter-trace] failed to persist trace for %s %s:', repoFullName, prNumberCommitSha, err);
+        });
+    }
 
     await deps.reviewStore.updateStatus(repoFullName, prNumberCommitSha, 'complete', {
       completedAt: new Date().toISOString(),

--- a/packages/server/src/webhook-handler.ts
+++ b/packages/server/src/webhook-handler.ts
@@ -1,6 +1,8 @@
 import { createHmac, timingSafeEqual } from 'crypto';
 import type { Request, Response } from 'express';
-import type { IInstallationStore, IReviewStore, IFindingDispositionStore, IFPInsightStore, IPRLifecycleStore, ISatisfactionStore, IReviewCostStore, IGitHubAuthProvider, ILLMProvider, AgentReviewConfig } from '@mergewatch/core';
+import type { IInstallationStore, IReviewStore, IFindingDispositionStore, IFPInsightStore, IPRLifecycleStore, ISatisfactionStore, IReviewCostStore, IGitHubAuthProvider, ILLMProvider, AgentReviewConfig,
+  IReviewTraceStore,
+} from '@mergewatch/core';
 import type { ReviewJobPayload, ReviewMode, PullRequestEvent, IssueCommentEvent, PullRequestReviewCommentEvent, InstallationEvent, CheckRunEvent, IReviewJobQueue } from '@mergewatch/core';
 import { REVIEW_TRIGGERING_ACTIONS, COMMENT_LOOKUP_ACTIONS, MERGEWATCH_CHECK_RUN_NAME, checkRunName, findExistingBotComment, classifyPrSource, fetchRepoConfig, mergeConfig, isBotActor, sweepInlineReactionsOnClose } from '@mergewatch/core';
 import { processReviewJob } from './review-processor.js';
@@ -40,6 +42,12 @@ export interface WebhookDeps {
    * in-process call.
    */
   reviewQueue?: IReviewJobQueue;
+  /**
+   * #471 — optional filter-trace store. Best-effort by design: when unset,
+   * traces are simply not written and the review is unaffected. A trace is a
+   * debugging artifact, so it must never be able to fail a review.
+   */
+  reviewTraceStore?: IReviewTraceStore;
   /** FB-A — optional disposition store. Best-effort: when unset, writes are
    *  no-ops and the review pipeline runs unchanged. */
   dispositionStore?: IFindingDispositionStore;

--- a/packages/storage-dynamo/src/index.ts
+++ b/packages/storage-dynamo/src/index.ts
@@ -1,5 +1,6 @@
 export { DynamoInstallationStore } from './installation-store.js';
 export { DynamoReviewStore } from './review-store.js';
+export { DynamoReviewTraceStore, DEFAULT_REVIEW_TRACES_TABLE } from './review-trace-store.js';
 export { createDynamoDashboardStore } from './dashboard-store.js';
 export type { DynamoDashboardStoreOptions } from './dashboard-store.js';
 export {

--- a/packages/storage-dynamo/src/review-trace-store.test.ts
+++ b/packages/storage-dynamo/src/review-trace-store.test.ts
@@ -75,3 +75,21 @@ describe('queryByPR isolation (#471 regression)', () => {
     expect(sent[0].input.KeyConditionExpression).toContain('begins_with(prNumberCommitSha');
   });
 });
+
+describe('malformed stored data (#480 review)', () => {
+  it('treats an item with non-array outcomes as absent', async () => {
+    // Consumers (#472, #295) iterate `outcomes`; handing them an object would
+    // crash there instead of failing at the storage boundary.
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { client } = makeClient({ ...TRACE, outcomes: { not: 'an array' } });
+    const got = await new DynamoReviewTraceStore(client, 'traces').get('o/r', '42#abc123');
+    expect(got).toBeNull();
+  });
+
+  it('treats an item missing outcomes entirely as absent', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { client } = makeClient({ repoFullName: 'o/r', prNumberCommitSha: '42#abc123' });
+    const got = await new DynamoReviewTraceStore(client, 'traces').get('o/r', '42#abc123');
+    expect(got).toBeNull();
+  });
+});

--- a/packages/storage-dynamo/src/review-trace-store.test.ts
+++ b/packages/storage-dynamo/src/review-trace-store.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import type { ReviewTraceItem } from '@mergewatch/core';
+import {
+  DynamoReviewTraceStore,
+  DEFAULT_REVIEW_TRACES_TABLE,
+} from './review-trace-store.js';
+import { DynamoReviewStore } from './review-store.js';
+
+function makeClient(item?: unknown) {
+  const sent: any[] = [];
+  const client = {
+    send: vi.fn(async (cmd: any) => {
+      sent.push(cmd);
+      return item !== undefined ? { Item: item } : { Items: [] };
+    }),
+  } as unknown as DynamoDBDocumentClient;
+  return { client, sent };
+}
+
+const TRACE: ReviewTraceItem = {
+  repoFullName: 'o/r',
+  prNumberCommitSha: '42#abc123',
+  outcomes: [],
+  createdAt: '2026-08-25T12:00:00.000Z',
+  ttl: 1_800_000_000,
+};
+
+describe('DynamoReviewTraceStore', () => {
+  it('writes to its own table, never the reviews table', () => {
+    // The whole point of the separate table: queryByPR matches
+    // begins_with(prNumberCommitSha, "42#"), so a trace sharing that key space
+    // would be returned as a review — and with limit 5, could evict a real one
+    // from the previous-review lookup feeding previousFindings, delta and FP-B.
+    expect(DEFAULT_REVIEW_TRACES_TABLE).not.toBe('mergewatch-reviews');
+  });
+
+  it('puts the trace under the review key, unsuffixed', async () => {
+    const { client, sent } = makeClient();
+    await new DynamoReviewTraceStore(client, 'traces').put(TRACE);
+    expect(sent[0].input.TableName).toBe('traces');
+    expect(sent[0].input.Item.prNumberCommitSha).toBe('42#abc123');
+    // A suffix here is exactly what would collide on the reviews table.
+    expect(sent[0].input.Item.prNumberCommitSha).not.toMatch(/#TRACE$/);
+  });
+
+  it('round-trips a stored trace', async () => {
+    const { client } = makeClient(TRACE);
+    const got = await new DynamoReviewTraceStore(client, 'traces').get('o/r', '42#abc123');
+    expect(got).toEqual(TRACE);
+  });
+
+  it('returns null for a missing trace', async () => {
+    const client = { send: vi.fn(async () => ({})) } as unknown as DynamoDBDocumentClient;
+    const got = await new DynamoReviewTraceStore(client, 'traces').get('o/r', 'nope');
+    expect(got).toBeNull();
+  });
+
+  it('carries the TTL attribute so the table self-prunes', async () => {
+    const { client, sent } = makeClient();
+    await new DynamoReviewTraceStore(client, 'traces').put(TRACE);
+    expect(sent[0].input.Item.ttl).toBe(1_800_000_000);
+  });
+});
+
+describe('queryByPR isolation (#471 regression)', () => {
+  it('queries only the reviews table, so a trace can never appear in its results', async () => {
+    const { client, sent } = makeClient();
+    await new DynamoReviewStore(client, 'mergewatch-reviews-test').queryByPR('o/r', '42#');
+    expect(sent).toHaveLength(1);
+    expect(sent[0].input.TableName).toBe('mergewatch-reviews-test');
+    // Traces live in a different table entirely, so the prefix match cannot
+    // reach them regardless of how their sort key is shaped.
+    expect(sent[0].input.TableName).not.toBe(DEFAULT_REVIEW_TRACES_TABLE);
+    expect(sent[0].input.KeyConditionExpression).toContain('begins_with(prNumberCommitSha');
+  });
+});

--- a/packages/storage-dynamo/src/review-trace-store.ts
+++ b/packages/storage-dynamo/src/review-trace-store.ts
@@ -1,0 +1,54 @@
+/**
+ * DynamoDB implementation of `IReviewTraceStore` (#471).
+ *
+ * Table shape (created in infra/template.yaml):
+ *   PK: repoFullName
+ *   SK: prNumberCommitSha   — the SAME key as the review it describes
+ *
+ * A separate table, not a suffixed sort key on the reviews table. `queryByPR`
+ * matches `begins_with(prNumberCommitSha, "42#")`, so a row keyed
+ * `42#abc123#TRACE` comes back as if it were a review — and every call site
+ * passes a small `limit`, so trace rows could evict real reviews from the
+ * previous-review lookup feeding `previousFindings`, the delta and FP-B.
+ * Sharing the key space is a correctness bug, not a style choice. The separate
+ * table also sidesteps Dynamo's 400KB item cap.
+ *
+ * Rows carry a 30-day TTL (set by buildReviewTrace) — shorter than a review,
+ * because this is a debugging and trust artifact rather than a system of
+ * record.
+ */
+
+import {
+  DynamoDBDocumentClient,
+  PutCommand,
+  GetCommand,
+} from '@aws-sdk/lib-dynamodb';
+import type { IReviewTraceStore, ReviewTraceItem } from '@mergewatch/core';
+
+export const DEFAULT_REVIEW_TRACES_TABLE = 'mergewatch-review-traces';
+
+export class DynamoReviewTraceStore implements IReviewTraceStore {
+  constructor(
+    private readonly client: DynamoDBDocumentClient,
+    private readonly tableName: string = DEFAULT_REVIEW_TRACES_TABLE,
+  ) {}
+
+  async put(trace: ReviewTraceItem): Promise<void> {
+    await this.client.send(
+      new PutCommand({ TableName: this.tableName, Item: trace }),
+    );
+  }
+
+  async get(
+    repoFullName: string,
+    prNumberCommitSha: string,
+  ): Promise<ReviewTraceItem | null> {
+    const result = await this.client.send(
+      new GetCommand({
+        TableName: this.tableName,
+        Key: { repoFullName, prNumberCommitSha },
+      }),
+    );
+    return (result.Item as ReviewTraceItem | undefined) ?? null;
+  }
+}

--- a/packages/storage-dynamo/src/review-trace-store.ts
+++ b/packages/storage-dynamo/src/review-trace-store.ts
@@ -49,6 +49,19 @@ export class DynamoReviewTraceStore implements IReviewTraceStore {
         Key: { repoFullName, prNumberCommitSha },
       }),
     );
-    return (result.Item as ReviewTraceItem | undefined) ?? null;
+    const item = result.Item as ReviewTraceItem | undefined;
+    if (!item) return null;
+    // Validate the one field consumers iterate. An item written by an older
+    // shape, or a partial write, would otherwise pass the cast and crash the
+    // dashboard (#472) or the audit export (#295) rather than failing here.
+    if (!Array.isArray(item.outcomes)) {
+      console.warn(
+        '[filter-trace] malformed trace item for %s %s — treating as absent',
+        repoFullName,
+        prNumberCommitSha,
+      );
+      return null;
+    }
+    return item;
   }
 }

--- a/packages/storage-postgres/drizzle/0017_great_viper.sql
+++ b/packages/storage-postgres/drizzle/0017_great_viper.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS "review_traces" (
+	"repo_full_name" text NOT NULL,
+	"pr_number_commit_sha" text NOT NULL,
+	"outcomes" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"truncated" boolean DEFAULT false NOT NULL,
+	"total_outcomes" integer,
+	"created_at" text NOT NULL,
+	"expires_at" timestamp with time zone,
+	CONSTRAINT "review_traces_repo_full_name_pr_number_commit_sha_pk" PRIMARY KEY("repo_full_name","pr_number_commit_sha")
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "review_traces_expires_idx" ON "review_traces" USING btree ("expires_at");

--- a/packages/storage-postgres/drizzle/meta/0017_snapshot.json
+++ b/packages/storage-postgres/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,1330 @@
+{
+  "id": "450d654d-3d39-4e41-96af-7a305a9c508a",
+  "prevId": "a7ac5547-9dee-4602-9119-e16f0b9837be",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_installation_idx": {
+          "name": "api_keys_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finding_dispositions": {
+      "name": "finding_dispositions",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding_match_key": {
+          "name": "finding_match_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_count": {
+          "name": "surface_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dispute_count": {
+          "name": "dispute_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verified_count": {
+          "name": "verified_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unverified_count": {
+          "name": "unverified_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "silent_drop_count": {
+          "name": "silent_drop_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "agreement_count": {
+          "name": "agreement_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resolve_count": {
+          "name": "resolve_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_agent": {
+          "name": "top_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sig_tokens": {
+          "name": "sig_tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reject_reasons": {
+          "name": "reject_reasons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_counts": {
+          "name": "period_counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "finding_dispositions_installation_idx": {
+          "name": "finding_dispositions_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "finding_dispositions_installation_id_repo_full_name_finding_match_key_pk": {
+          "name": "finding_dispositions_installation_id_repo_full_name_finding_match_key_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name",
+            "finding_match_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.helpful_votes": {
+      "name": "helpful_votes",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "up": {
+          "name": "up",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "down": {
+          "name": "down",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_vote_at": {
+          "name": "last_vote_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "helpful_votes_installation_idx": {
+          "name": "helpful_votes_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "helpful_votes_installation_id_repo_full_name_pr_number_pk": {
+          "name": "helpful_votes_installation_id_repo_full_name_pr_number_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name",
+            "pr_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installation_fp_insights": {
+      "name": "installation_fp_insights",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window": {
+          "name": "window",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_end": {
+          "name": "window_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_findings_surfaced": {
+          "name": "total_findings_surfaced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_disputes": {
+          "name": "total_disputes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dispute_rate": {
+          "name": "dispute_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_silent_drops": {
+          "name": "total_silent_drops",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_agreements": {
+          "name": "total_agreements",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "per_category": {
+          "name": "per_category",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "per_severity": {
+          "name": "per_severity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "per_repo": {
+          "name": "per_repo",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "top_clusters": {
+          "name": "top_clusters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "cycle_time": {
+          "name": "cycle_time",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "engagement": {
+          "name": "engagement",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "installation_fp_insights_installation_id_window_pk": {
+          "name": "installation_fp_insights_installation_id_window_pk",
+          "columns": [
+            "installation_id",
+            "window"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installation_settings": {
+      "name": "installation_settings",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "severity_threshold": {
+          "name": "severity_threshold",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Low'"
+        },
+        "comment_types": {
+          "name": "comment_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"syntax\":true,\"logic\":true,\"style\":true}'::jsonb"
+        },
+        "max_comments": {
+          "name": "max_comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 25
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"prSummary\":true,\"confidenceScore\":true,\"issuesTable\":true,\"diagram\":true}'::jsonb"
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "comment_header": {
+          "name": "comment_header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "custom_agents": {
+          "name": "custom_agents",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installations": {
+      "name": "installations",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "installations_installation_id_repo_full_name_pk": {
+          "name": "installations_installation_id_repo_full_name_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_sessions": {
+      "name": "mcp_sessions",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_billed_at": {
+          "name": "first_billed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_billed_cents": {
+          "name": "max_billed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iteration": {
+          "name": "iteration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nps_responses": {
+      "name": "nps_responses",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_user_id": {
+          "name": "github_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nps_responses_installation_idx": {
+          "name": "nps_responses_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "nps_responses_installation_id_github_user_id_pk": {
+          "name": "nps_responses_installation_id_github_user_id_pk",
+          "columns": [
+            "installation_id",
+            "github_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pr_lifecycle": {
+      "name": "pr_lifecycle",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_created_at": {
+          "name": "pr_created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_review_at": {
+          "name": "first_review_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "reviewed": {
+          "name": "reviewed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "total_pushes": {
+          "name": "total_pushes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pushes_after_first_review": {
+          "name": "pushes_after_first_review",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pr_lifecycle_installation_idx": {
+          "name": "pr_lifecycle_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "pr_lifecycle_installation_id_repo_full_name_pr_number_pk": {
+          "name": "pr_lifecycle_installation_id_repo_full_name_pr_number_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name",
+            "pr_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_costs": {
+      "name": "review_costs",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "review_costs_installation_idx": {
+          "name": "review_costs_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "review_costs_installation_id_repo_full_name_pr_number_commit_sha_pk": {
+          "name": "review_costs_installation_id_repo_full_name_pr_number_commit_sha_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name",
+            "pr_number",
+            "commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_jobs": {
+      "name": "review_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_jobs_claim_idx": {
+          "name": "review_jobs_claim_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_traces": {
+      "name": "review_traces",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number_commit_sha": {
+          "name": "pr_number_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcomes": {
+          "name": "outcomes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "truncated": {
+          "name": "truncated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "total_outcomes": {
+          "name": "total_outcomes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "review_traces_expires_idx": {
+          "name": "review_traces_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "review_traces_repo_full_name_pr_number_commit_sha_pk": {
+          "name": "review_traces_repo_full_name_pr_number_commit_sha_pk",
+          "columns": [
+            "repo_full_name",
+            "pr_number_commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number_commit_sha": {
+          "name": "pr_number_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_title": {
+          "name": "pr_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_author": {
+          "name": "pr_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_author_avatar": {
+          "name": "pr_author_avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_branch": {
+          "name": "head_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_severity": {
+          "name": "top_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_text": {
+          "name": "summary_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagram_text": {
+          "name": "diagram_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_score": {
+          "name": "merge_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_score_reason": {
+          "name": "merge_score_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings": {
+          "name": "findings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reactions": {
+          "name": "reactions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_used": {
+          "name": "settings_used",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inline_resolved_keys": {
+          "name": "inline_resolved_keys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "inline_reactions_snapshot": {
+          "name": "inline_reactions_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "reviews_installation_idx": {
+          "name": "reviews_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_pr_idx": {
+          "name": "reviews_pr_idx",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "reviews_repo_full_name_pr_number_commit_sha_pk": {
+          "name": "reviews_repo_full_name_pr_number_commit_sha_pk",
+          "columns": [
+            "repo_full_name",
+            "pr_number_commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/storage-postgres/drizzle/meta/_journal.json
+++ b/packages/storage-postgres/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1786940740187,
       "tag": "0016_sparkling_the_hood",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1787701645324,
+      "tag": "0017_great_viper",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/storage-postgres/src/index.ts
+++ b/packages/storage-postgres/src/index.ts
@@ -1,5 +1,6 @@
 export { PostgresInstallationStore } from './installation-store.js';
 export { PostgresReviewStore } from './review-store.js';
+export { PostgresReviewTraceStore } from './review-trace-store.js';
 export { PostgresFindingDispositionStore } from './finding-disposition-store.js';
 export { PostgresFPInsightStore } from './fp-insight-store.js';
 export { PostgresPRLifecycleStore } from './pr-lifecycle-store.js';

--- a/packages/storage-postgres/src/review-trace-store.test.ts
+++ b/packages/storage-postgres/src/review-trace-store.test.ts
@@ -83,3 +83,35 @@ describe('PostgresReviewTraceStore', () => {
     expect(await new PostgresReviewTraceStore(db).get('o/r', 'nope')).toBeNull();
   });
 });
+
+describe('malformed stored data (#480 review)', () => {
+  function dbReturning(row: Row) {
+    return {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({ where: vi.fn(() => ({ limit: vi.fn(async () => [row]) })) })),
+      })),
+    } as any;
+  }
+
+  it('degrades a non-array jsonb outcomes column to an empty ledger', async () => {
+    // jsonb accepts any shape, so the column type is not a guarantee.
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const db = dbReturning({
+      repoFullName: 'o/r', prNumberCommitSha: '42#abc', outcomes: { not: 'an array' },
+      truncated: false, totalOutcomes: null, createdAt: 'now', expiresAt: null,
+    });
+    const got = await new PostgresReviewTraceStore(db).get('o/r', '42#abc');
+    expect(got?.outcomes).toEqual([]);
+  });
+
+  it('ignores a non-numeric totalOutcomes rather than passing it through', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const db = dbReturning({
+      repoFullName: 'o/r', prNumberCommitSha: '42#abc', outcomes: [],
+      truncated: 'yes', totalOutcomes: 'lots', createdAt: 'now', expiresAt: null,
+    });
+    const got = await new PostgresReviewTraceStore(db).get('o/r', '42#abc');
+    expect(got?.totalOutcomes).toBeUndefined();
+    expect(got?.truncated).toBeUndefined();
+  });
+});

--- a/packages/storage-postgres/src/review-trace-store.test.ts
+++ b/packages/storage-postgres/src/review-trace-store.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { ReviewTraceItem } from '@mergewatch/core';
+import { PostgresReviewTraceStore } from './review-trace-store.js';
+
+type Row = Record<string, any>;
+
+/** Minimal drizzle mock: captures upserts and serves them back through select. */
+function makeMockDb() {
+  const rows: Row[] = [];
+  const onConflictDoUpdate = vi.fn(async (_args: unknown) => undefined);
+  const insertValues = vi.fn((row: Row) => {
+    const i = rows.findIndex(
+      (r) => r.repoFullName === row.repoFullName
+        && r.prNumberCommitSha === row.prNumberCommitSha,
+    );
+    if (i >= 0) rows[i] = row; else rows.push(row);
+    return { onConflictDoUpdate };
+  });
+
+  const db = {
+    insert: vi.fn(() => ({ values: insertValues })),
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({ limit: vi.fn(async () => rows.slice(0, 1)) })),
+      })),
+    })),
+  };
+  return { db: db as any, rows };
+}
+
+const TRACE: ReviewTraceItem = {
+  repoFullName: 'o/r',
+  prNumberCommitSha: '42#abc123',
+  outcomes: [{
+    key: 'src/a.ts::T::x', file: 'src/a.ts', line: 1, severity: 'critical',
+    title: 'x', agents: ['security'], outcome: 'dropped', stage: 'confidence-floor',
+  }],
+  createdAt: '2026-08-25T12:00:00.000Z',
+  ttl: 1_800_000_000,
+};
+
+describe('PostgresReviewTraceStore', () => {
+  it('stores the trace under the review key, unsuffixed', async () => {
+    const { db, rows } = makeMockDb();
+    await new PostgresReviewTraceStore(db).put(TRACE);
+    expect(rows[0].prNumberCommitSha).toBe('42#abc123');
+    expect(rows[0].truncated).toBe(false);
+  });
+
+  it('converts the Dynamo epoch TTL to a prunable timestamp', async () => {
+    // Postgres has no native TTL; expires_at exists so an operator can prune
+    // with a one-liner rather than computing dates over created_at.
+    const { db, rows } = makeMockDb();
+    await new PostgresReviewTraceStore(db).put(TRACE);
+    expect(rows[0].expiresAt).toEqual(new Date(1_800_000_000 * 1000));
+  });
+
+  it('round-trips a trace, preserving outcomes', async () => {
+    const { db } = makeMockDb();
+    const store = new PostgresReviewTraceStore(db);
+    await store.put(TRACE);
+    const got = await store.get('o/r', '42#abc123');
+    expect(got?.outcomes).toHaveLength(1);
+    expect(got?.outcomes[0].stage).toBe('confidence-floor');
+    expect(got?.prNumberCommitSha).toBe('42#abc123');
+  });
+
+  it('carries truncation through the round trip', async () => {
+    const { db } = makeMockDb();
+    const store = new PostgresReviewTraceStore(db);
+    await store.put({ ...TRACE, truncated: true, totalOutcomes: 1430 });
+    const got = await store.get('o/r', '42#abc123');
+    expect(got?.truncated).toBe(true);
+    expect(got?.totalOutcomes).toBe(1430);
+  });
+
+  it('returns null when there is no trace', async () => {
+    const db = {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({ where: vi.fn(() => ({ limit: vi.fn(async () => []) })) })),
+      })),
+    } as any;
+    expect(await new PostgresReviewTraceStore(db).get('o/r', 'nope')).toBeNull();
+  });
+});

--- a/packages/storage-postgres/src/review-trace-store.ts
+++ b/packages/storage-postgres/src/review-trace-store.ts
@@ -1,0 +1,66 @@
+/**
+ * Postgres implementation of `IReviewTraceStore` (#471).
+ *
+ * Mirrors the Dynamo store so a self-hosted deployment can serve the same
+ * dashboard feature (#472). Separate table for the same reason as Dynamo: the
+ * review key space must not be shared, or a trace row is returned as a review.
+ *
+ * Latest-wins on conflict — a re-run of the same commit overwrites its trace
+ * rather than accumulating rows, matching how `reviews` behaves for the same key.
+ */
+
+import { eq, and } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import type { IReviewTraceStore, ReviewTraceItem, FindingOutcome } from '@mergewatch/core';
+import { reviewTraces } from './schema.js';
+
+export class PostgresReviewTraceStore implements IReviewTraceStore {
+  constructor(private readonly db: NodePgDatabase<Record<string, unknown>>) {}
+
+  async put(trace: ReviewTraceItem): Promise<void> {
+    const row = {
+      repoFullName: trace.repoFullName,
+      prNumberCommitSha: trace.prNumberCommitSha,
+      outcomes: trace.outcomes,
+      truncated: trace.truncated ?? false,
+      totalOutcomes: trace.totalOutcomes ?? null,
+      createdAt: trace.createdAt,
+      // The Dynamo TTL is epoch seconds; Postgres has no TTL, so it is stored
+      // as a timestamp an operator can prune on.
+      expiresAt: trace.ttl != null ? new Date(trace.ttl * 1000) : null,
+    };
+    await this.db
+      .insert(reviewTraces)
+      .values(row)
+      .onConflictDoUpdate({
+        target: [reviewTraces.repoFullName, reviewTraces.prNumberCommitSha],
+        set: row,
+      });
+  }
+
+  async get(
+    repoFullName: string,
+    prNumberCommitSha: string,
+  ): Promise<ReviewTraceItem | null> {
+    const rows = await this.db
+      .select()
+      .from(reviewTraces)
+      .where(and(
+        eq(reviewTraces.repoFullName, repoFullName),
+        eq(reviewTraces.prNumberCommitSha, prNumberCommitSha),
+      ))
+      .limit(1);
+
+    const r = rows[0];
+    if (!r) return null;
+    return {
+      repoFullName: r.repoFullName,
+      prNumberCommitSha: r.prNumberCommitSha,
+      outcomes: (r.outcomes ?? []) as FindingOutcome[],
+      ...(r.truncated ? { truncated: true } : {}),
+      ...(r.totalOutcomes != null ? { totalOutcomes: r.totalOutcomes } : {}),
+      createdAt: r.createdAt,
+      ...(r.expiresAt ? { ttl: Math.floor(r.expiresAt.getTime() / 1000) } : {}),
+    };
+  }
+}

--- a/packages/storage-postgres/src/review-trace-store.ts
+++ b/packages/storage-postgres/src/review-trace-store.ts
@@ -53,12 +53,23 @@ export class PostgresReviewTraceStore implements IReviewTraceStore {
 
     const r = rows[0];
     if (!r) return null;
+    // jsonb accepts any shape, so validate at the boundary rather than trusting
+    // the column type. #472 and #295 both iterate `outcomes`; handing them a
+    // non-array would crash the consumer instead of degrading here. Same guard
+    // finding-disposition-store.ts and review-store.ts already use.
+    if (!Array.isArray(r.outcomes)) {
+      console.warn(
+        '[filter-trace] malformed outcomes for %s %s — returning an empty ledger',
+        repoFullName,
+        prNumberCommitSha,
+      );
+    }
     return {
       repoFullName: r.repoFullName,
       prNumberCommitSha: r.prNumberCommitSha,
-      outcomes: (r.outcomes ?? []) as FindingOutcome[],
-      ...(r.truncated ? { truncated: true } : {}),
-      ...(r.totalOutcomes != null ? { totalOutcomes: r.totalOutcomes } : {}),
+      outcomes: Array.isArray(r.outcomes) ? (r.outcomes as FindingOutcome[]) : [],
+      ...(r.truncated === true ? { truncated: true } : {}),
+      ...(typeof r.totalOutcomes === 'number' ? { totalOutcomes: r.totalOutcomes } : {}),
       createdAt: r.createdAt,
       ...(r.expiresAt ? { ttl: Math.floor(r.expiresAt.getTime() / 1000) } : {}),
     };

--- a/packages/storage-postgres/src/schema.ts
+++ b/packages/storage-postgres/src/schema.ts
@@ -67,6 +67,34 @@ export const reviews = pgTable('reviews', {
   prIdx: index('reviews_pr_idx').on(t.repoFullName),
 }));
 
+/**
+ * #471 — one review's filter outcome ledger.
+ *
+ * A separate table, mirroring the Dynamo side and for the same reason: the
+ * review key space must not be shared. `queryByPR` matches on a `42#` prefix,
+ * so a suffixed key would be returned as if it were a review and could evict
+ * real reviews from the previous-review lookup.
+ *
+ * `expiresAt` mirrors the Dynamo TTL, but Postgres has no native TTL — nothing
+ * prunes this automatically. Self-hosted operators can delete on it; the
+ * column exists so that is a one-liner rather than a date computation over
+ * `created_at`.
+ */
+export const reviewTraces = pgTable('review_traces', {
+  repoFullName: text('repo_full_name').notNull(),
+  prNumberCommitSha: text('pr_number_commit_sha').notNull(),
+  outcomes: jsonb('outcomes').notNull().default([]),
+  /** True when `outcomes` holds fewer rows than the review produced. */
+  truncated: boolean('truncated').notNull().default(false),
+  /** Pre-truncation count; null unless truncated. */
+  totalOutcomes: integer('total_outcomes'),
+  createdAt: text('created_at').notNull(),
+  expiresAt: timestamp('expires_at', { withTimezone: true }),
+}, (t) => ({
+  pk: primaryKey({ columns: [t.repoFullName, t.prNumberCommitSha] }),
+  expiresIdx: index('review_traces_expires_idx').on(t.expiresAt),
+}));
+
 export const apiKeys = pgTable('api_keys', {
   keyHash: text('key_hash').primaryKey(),
   installationId: text('installation_id').notNull(),


### PR DESCRIPTION
Closes #471. Stage 3 of #467, landing after #470 built the ledger.

#470 builds the `FindingOutcome` ledger in memory, where it dies with the invocation. The dashboard (#472) and the audit export (#295) both need it durable.

## A separate table, and the reason is correctness

I verified the issue's argument before designing around it. `queryByPR` uses `begins_with(prNumberCommitSha, :pr)` and every call site passes `${prNumber}#`:

| call site | limit |
|---|---|
| `disposition-writer.ts:398` | 10 |
| `review-processor.ts:88 / :165 / :557` | 5 |
| Lambda `review-agent.ts` | 5 |

A `42#abc123#TRACE` row matches that prefix **by construction**, so it would be returned as if it were a review — and under those small limits it could evict a real review from the lookup feeding `previousFindings`, the delta and FP-B. That is a silent correctness regression inside the review pipeline, not a query annoyance. The separate table also keeps traces clear of the 400KB item cap.

## Retention and size

| | SaaS | Self-hosted |
|---|---|---|
| store | `mergewatch-review-traces-{stage}` | `review_traces` |
| retention | 30-day TTL, **enabled** | `expires_at`; no native TTL — operators prune |
| cap | 500 outcomes, truncation marked | same |

30 days is deliberately shorter than a review's: a trace is a debugging and trust artifact, not a system of record (#295 is that).

Worth flagging: **the reviews table's `TimeToLiveSpecification` is commented out**, so its documented 90-day TTL is not actually active. I enabled TTL properly on the new table rather than copying that.

**When truncating, non-surfaced outcomes are kept first.** Surfaced findings are already visible in the PR comment, so the dropped, merged and demoted ones are the only thing the trace adds — keeping those is what makes a truncated trace still worth reading. A #401-shaped runaway (~1,430 near-empty findings from one response) must not write an unbounded record, and the remainder must never read as complete.

## Two findings that shrank the ticket

- **Self-hosted needs no new env var.** Postgres gets `review_traces` from the Drizzle schema, so there is no table-name indirection to forget. `docker-compose.yml` and `.env.example` need nothing, and the issue's deployment checklist collapses to `template.yaml` alone.
- **The Amplify SSR grant already covers it.** That inline policy is on `table/mergewatch-*` (recorded at `template.yaml:1270`), so the new table is in scope with no IAM change. `next.config.js` is untouched because nothing in the dashboard reads traces yet — that belongs with #472, which will need it.

`REVIEW_TRACES_TABLE` is added to the **#181 Globals regression guard** in `template.test.ts`: a trace writer resolving to the unsuffixed default would `ResourceNotFoundException` into a void, which is exactly the failure #181 was about.

## Safety

Writes are best-effort at both runtimes — after the comment is posted, wrapped in a catch. The developer getting their review matters; the debugging artifact does not. On self-hosted the store is optional, so a deployment that has not wired it is simply unaffected.

## Verification

```
build             12/12
typecheck         20/20
test              21/21   (1,153 tests — 16 new)
migrations:check  Everything's fine
```

The migration was hand-edited to `IF NOT EXISTS` per CLAUDE.md, matching the `0016` precedent. Includes a regression test asserting `queryByPR` queries only the reviews table and so cannot reach traces regardless of how their sort key is shaped.
