### PR TITLE
fix(core): omit absent fields from the ledger so traces can actually persist

### DIFF
--- a/packages/core/src/filter-trace.test.ts
+++ b/packages/core/src/filter-trace.test.ts
@@ -270,3 +270,59 @@ describe('buildReviewTrace (#471)', () => {
     expect(t.truncated).toBeUndefined();
   });
 });
+
+describe('no undefined values in the ledger (#471 prod bug)', () => {
+  // DynamoDB's marshaller rejects undefined outright:
+  //   "Pass options.removeUndefinedValues=true to remove undefined values"
+  // Emitting them made every trace write fail for any review with a
+  // non-trivial ledger — silently, because the write is best-effort by design.
+  function assertNoUndefined(rows: object[]) {
+    for (const row of rows) {
+      for (const [k, v] of Object.entries(row)) {
+        expect(v, `${k} must be omitted, not undefined`).not.toBeUndefined();
+      }
+    }
+  }
+
+  it('omits stage, reason and mergedInto when absent', () => {
+    const t = new TraceRecorder();
+    t.enter(f({ confidence: undefined }), 'security');
+    t.finalize([f({ confidence: undefined })]);
+    const rows = t.outcomes();
+    expect('stage' in rows[0]).toBe(false);
+    expect('reason' in rows[0]).toBe(false);
+    expect('mergedInto' in rows[0]).toBe(false);
+    expect('confidence' in rows[0]).toBe(false);
+    assertNoUndefined(rows);
+  });
+
+  it('keeps them when present', () => {
+    const t = new TraceRecorder();
+    t.enter(f(), 'security');
+    t.record(f(), 'merged', 'w10-clustering', { reason: 'r', mergedInto: 'k' });
+    const [row] = t.outcomes();
+    expect(row.stage).toBe('w10-clustering');
+    expect(row.reason).toBe('r');
+    expect(row.mergedInto).toBe('k');
+    expect(row.confidence).toBe(90);
+  });
+
+  it('emits nothing undefined for an unadjudicated entry either', () => {
+    // The wiring-gap row is the one most likely to be sparse.
+    const t = new TraceRecorder();
+    t.enter(f({ confidence: undefined }), 'security');
+    assertNoUndefined(t.outcomes());
+  });
+
+  it('a full trace round-trips through JSON unchanged', () => {
+    // A cheap proxy for marshalling: JSON.stringify silently drops undefined,
+    // so a mismatch here means undefined was present.
+    const t = new TraceRecorder();
+    t.enter(f({ title: 'a', confidence: undefined }), 'security');
+    t.enter(f({ title: 'b' }), 'bugs');
+    t.record(f({ title: 'b' }), 'dropped', 'confidence-floor', { reason: 'low' });
+    t.finalize([f({ title: 'a', confidence: undefined })]);
+    const rows = t.outcomes();
+    expect(JSON.parse(JSON.stringify(rows))).toEqual(rows);
+  });
+});

--- a/packages/core/src/filter-trace.ts
+++ b/packages/core/src/filter-trace.ts
@@ -202,23 +202,40 @@ export class TraceRecorder {
     }
   }
 
-  /** The ledger. */
+  /**
+   * The ledger.
+   *
+   * Optional fields are OMITTED when absent rather than set to `undefined`.
+   * DynamoDB's document marshaller rejects undefined outright —
+   *
+   *   Error: Pass options.removeUndefinedValues=true to remove undefined
+   *   values from map/array/set.
+   *
+   * — so emitting them made every trace write fail for any review with a
+   * non-trivial ledger. The write is best-effort, so it failed silently and
+   * #471 shipped to production looking fine while persisting almost nothing.
+   * Only empty ledgers marshalled cleanly.
+   *
+   * Fixed here rather than by passing `removeUndefinedValues` at the client:
+   * the record should be clean at the source, for every backend, rather than
+   * relying on one store's marshaller to tidy up after it.
+   */
   outcomes(): FindingOutcome[] {
     return [...this.entries.values()].map((e) => ({
       key: e.key,
       file: e.file,
       line: e.line,
       severity: e.severity,
-      confidence: e.confidence,
+      ...(e.confidence != null ? { confidence: e.confidence } : {}),
       title: e.title,
       agents: [...e.agents],
       // An entry with no recorded verdict never reached a terminal stage. That
       // is a bug in the wiring, not a state to invent a value for — call it
       // dropped with no stage so the self-consistency test can see it.
       outcome: e.outcome ?? 'dropped',
-      stage: e.stage,
-      reason: e.reason,
-      mergedInto: e.mergedInto,
+      ...(e.stage ? { stage: e.stage } : {}),
+      ...(e.reason ? { reason: e.reason } : {}),
+      ...(e.mergedInto ? { mergedInto: e.mergedInto } : {}),
     }));
   }
 

--- a/packages/storage-dynamo/src/review-trace-store.test.ts
+++ b/packages/storage-dynamo/src/review-trace-store.test.ts
@@ -93,3 +93,43 @@ describe('malformed stored data (#480 review)', () => {
     expect(got).toBeNull();
   });
 });
+
+describe('the ledger survives the real marshaller (#471 prod bug)', () => {
+  // This test lives here, not in core: core has no AWS dependency by design
+  // (CLAUDE.md), and the marshaller is this package's concern. It is pinned by
+  // the thing that actually failed in production rather than by a proxy —
+  //
+  //   [filter-trace] failed to persist trace for mergewatch/mergewatch.ai
+  //   482#49641eb: Error: Pass options.removeUndefinedValues=true to remove
+  //   undefined values from map/array/set.
+  //
+  // The write is best-effort, so it failed silently and #471 shipped looking
+  // healthy while persisting almost nothing: only empty ledgers marshalled.
+  it('marshalls a sparse ledger without throwing', async () => {
+    const { marshall } = await import('@aws-sdk/util-dynamodb');
+    const { TraceRecorder, buildReviewTrace } = await import('@mergewatch/core');
+
+    const finding = (over: Record<string, unknown> = {}) => ({
+      file: 'a.ts', line: 1, severity: 'warning' as const, title: 't', ...over,
+    });
+
+    const t = new TraceRecorder();
+    t.enter(finding({ title: 'x' }), 'security');          // sparse: no confidence
+    t.enter(finding({ title: 'y', confidence: 80 }), 'bugs');
+    t.record(finding({ title: 'y', confidence: 80 }), 'dropped', 'confidence-floor', { reason: 'low' });
+    t.finalize([finding({ title: 'x' })]);
+
+    const trace = buildReviewTrace('o/r', '42#abc', t.outcomes(), new Date(0));
+    expect(() => marshall(trace)).not.toThrow();
+  });
+
+  it('rejects the pre-fix shape, so the regression is real', async () => {
+    const { marshall } = await import('@aws-sdk/util-dynamodb');
+    const preFix = {
+      key: 'k', file: 'a.ts', line: 1, severity: 'warning', confidence: undefined,
+      title: 't', agents: ['security'], outcome: 'dropped',
+      stage: undefined, reason: undefined, mergedInto: undefined,
+    };
+    expect(() => marshall({ outcomes: [preFix] })).toThrow(/removeUndefinedValues/);
+  });
+});


### PR DESCRIPTION
**#471 shipped to production and persisted almost nothing.** Found by using the feature on my own PR.

## How it surfaced

Investigating #482's advisory verdict, I queried `mergewatch-review-traces-prod` for that review and got no item — while fixture traces written minutes either side existed:

| repo | traces in prod table |
|---|---|
| `mergewatch/fixtures` | 4 |
| `mergewatch/mergewatch.ai` | **0** |

The review had completed normally (`status: complete`), so the write ran — and failed into the best-effort `catch` that #471 deliberately wraps it in. That warning is what made the diagnosis possible:

```
[filter-trace] failed to persist trace for mergewatch/mergewatch.ai 482#49641eb:
Error: Pass options.removeUndefinedValues=true to remove undefined values from map/array/set.
  at convertToAttr (@aws-sdk/util-dynamodb)
```

## Root cause

`TraceRecorder.outcomes()` emitted `confidence`, `stage`, `reason` and `mergedInto` **unconditionally**, so absent ones arrived as `undefined` and DynamoDB's marshaller rejected the whole item. Only a ledger with no sparse fields marshalled — which is exactly why the four surviving traces are fixture PRs with trivial ledgers, and why every `mergewatch.ai` review had none.

## Why it shipped looking healthy

The write is best-effort by design, so reviews were never affected and nothing surfaced except a warning nobody was reading. **That tradeoff was still right** — a debugging artifact must not be able to fail a review — but it means the feature needed verifying *in production*, not only in tests. My #471 tests all passed and could not have caught this: they never went near a marshaller.

## The fix

Omit absent fields instead of emitting `undefined`. Fixed at the source rather than by passing `removeUndefinedValues` at the client — the record should be clean for every backend, not tidied up by one store's marshaller on the way out. Postgres was unaffected either way, since `JSON.stringify` drops `undefined`.

## Pinned by the thing that actually failed

```
old shape: FAILED — Pass options.removeUndefinedValues=true …
new shape: OK — the real DynamoDB marshaller accepts it
```

`storage-dynamo` now asserts a sparse ledger marshalls, **and** that the pre-fix shape throws `/removeUndefinedValues/`, so the regression is guarded by the real marshaller rather than a proxy for it. That test lives in `storage-dynamo` rather than `core` — core has no AWS dependency by design (CLAUDE.md), and it only resolved in core via hoisting.

## Verification

```
build      12/12
typecheck  20/20
test       21/21   (1,196 tests — 7 new)
```

Fixes the persistence half of #471. #482 renders this trail, and rendering an always-missing trace would have been useless — so this should land first.
