### PR TITLE
fix(core): alias the ledger key when a fingerprint is assigned

### DIFF
--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -4119,3 +4119,94 @@ describe('cross-agent convergence across the orchestrator boundary (#477)', () =
     expect(result.findings[0].evidence?.agents).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Ledger identity across fingerprinting (#484)
+// ---------------------------------------------------------------------------
+
+describe('ledger survives fingerprinting (#484)', () => {
+  const allAgents = {
+    security: true, bugs: true, style: true, summary: true, diagram: true,
+    errorHandling: true, testCoverage: true, commentAccuracy: true,
+  };
+  const empty = JSON.stringify({ findings: [] });
+  const summaryResponse = JSON.stringify({ summary: 'Refactor.' });
+  const diagramResponse = '%% overview\nflowchart TD\n  A-->B';
+
+  // The whole point: #470's self-consistency test ran WITHOUT file contents, so
+  // withCodeFingerprints was a no-op and no key ever changed. The invariant
+  // held in the test for exactly the reason it failed in production.
+  function octokitWithFile(contents: string) {
+    return {
+      repos: {
+        getContent: vi.fn(async () => ({
+          data: { type: 'file', content: Buffer.from(contents, 'utf-8').toString('base64') },
+        })),
+      },
+    } as any;
+  }
+
+  const FILE = ['const a = 1;', 'const b = 2;', 'query(`${id}`);', 'const d = 4;'].join('\n');
+
+  async function run() {
+    const finding = {
+      file: 'foo.ts', line: 3, severity: 'warning' as const, category: 'bug',
+      title: 'Unescaped interpolation in query', description: 'd', suggestion: 's',
+    };
+    const llm = createMockLLM([
+      JSON.stringify({ findings: [finding] }), empty, empty, empty, empty, empty,
+      summaryResponse, diagramResponse,
+      JSON.stringify({ findings: [finding], mergeScore: 3, mergeScoreReason: 'One warning.' }),
+    ]);
+    return runReviewPipeline(
+      {
+        diff: sampleDiff, context: sampleContext,
+        modelId: 'heavy-model', lightModelId: 'light-model',
+        maxFindings: 25, enabledAgents: allAgents,
+        groundingFetch: { octokit: octokitWithFile(FILE), owner: 'o', repo: 'r', ref: 'sha' },
+      },
+      { llm },
+    );
+  }
+
+  it('assigns a fingerprint — otherwise this test proves nothing', async () => {
+    const result = await run();
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].fingerprint).toBeTruthy();
+  });
+
+  it('records ONE terminal outcome for a finding that gains a fingerprint', async () => {
+    const result = await run();
+    expect(result.filterOutcomes).toHaveLength(1);
+    expect(result.filterOutcomes[0].outcome).toBe('surfaced');
+  });
+
+  it('leaves no stageless ghost beside the surfaced finding', async () => {
+    // The production symptom: dropped[T] + surfaced[F] for one finding.
+    const result = await run();
+    const ghosts = result.filterOutcomes.filter(
+      (o) => o.outcome !== 'surfaced' && !o.stage,
+    );
+    expect(ghosts).toEqual([]);
+  });
+
+  it('does not inflate suppressedCount with the ghost', async () => {
+    // suppressedCount is derived as "everything that did not surface", so a
+    // ghost row silently overstates what was filtered — #401's failure mode
+    // returning through a different door.
+    const result = await run();
+    expect(result.suppressedCount).toBe(0);
+  });
+
+  it('keeps the raising agent, rather than re-attributing to the orchestrator', async () => {
+    // The auto-registered replacement row was credited to 'orchestrator',
+    // losing the only record of which agent actually raised the finding.
+    const result = await run();
+    // Assert the SURFACED row specifically. Indexing [0] passed even without
+    // the fix, because the abandoned original happens to sort first — a test
+    // that passes for the wrong reason is worse than no test.
+    const surfaced = result.filterOutcomes.filter((o) => o.outcome === 'surfaced');
+    expect(surfaced).toHaveLength(1);
+    expect(surfaced[0].agents).toEqual(['security']);
+  });
+});

--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -4163,7 +4163,10 @@ describe('ledger survives fingerprinting (#484)', () => {
         diff: sampleDiff, context: sampleContext,
         modelId: 'heavy-model', lightModelId: 'light-model',
         maxFindings: 25, enabledAgents: allAgents,
-        groundingFetch: { octokit: octokitWithFile(FILE), owner: 'o', repo: 'r', ref: 'sha' },
+        groundingFetch: {
+          octokit: octokitWithFile(FILE), owner: 'o', repo: 'r', ref: 'sha',
+          maxContextKB: 256, maxRounds: 1,
+        },
       },
       { llm },
     );

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -3191,6 +3191,24 @@ export async function runReviewPipeline(
     orchestratorResult.findings,
     groundingContext,
   );
+
+  // #484 — adding a fingerprint CHANGES a finding's outcomeKey, from the title
+  // form to the fingerprint form. The ledger keys on that, so without an alias
+  // the entry is lost mid-pipeline: finalize registers a fresh row and the
+  // original is left unadjudicated, which double-counts the finding and
+  // inflates the suppressedCount derived from it.
+  //
+  // Same rename problem FP-C and W10 already alias for, arriving by a
+  // different route — this one renames a SURVIVOR without touching its title.
+  const withTracedFingerprints = <T extends OrchestratedFinding>(findings: T[]): T[] => {
+    const out = withCodeFingerprints(findings, groundingFileContents);
+    for (let i = 0; i < findings.length; i++) {
+      const before = outcomeKey(findings[i]);
+      const after = outcomeKey(out[i]);
+      if (before !== after) trace.alias(before, after);
+    }
+    return out;
+  };
   // Keep each grounded result paired with the finding it came from. Counting
   // from the FILTERED array against the original by index is wrong the moment
   // anything is dropped — the indices shift — and it is wrong precisely in the
@@ -3265,7 +3283,7 @@ export async function runReviewPipeline(
     'line-proximity',
     (f) => `line ${f.line} is more than ${CHANGED_LINE_TOLERANCE} lines from any change in this PR`,
   );
-  const onChangedLines = withCodeFingerprints(nearChange, groundingFileContents);
+  const onChangedLines = withTracedFingerprints(nearChange);
 
   // #385 — re-enter the custom/org-agent findings (partitioned out before
   // fp-c above). Deterministic dedup only: one entry per (agent, file, line),
@@ -3305,7 +3323,7 @@ export async function runReviewPipeline(
   const preTriageFindings = withEvidenceCode(
     [
       ...onChangedLines,
-      ...withCodeFingerprints(customFindings, groundingFileContents),
+      ...withTracedFingerprints(customFindings),
     ],
     groundingFileContents,
     convergence,


### PR DESCRIPTION
Closes #484. Found in live trace data while gathering gate evidence for #473 — not by a test.

## The symptom

Some reviews recorded a finding **twice** — once `surfaced`, once `dropped` with no stage:

```
dropped   stage=(none)  key[T] Comment claims validation that code does not perform
surfaced  stage=(none)  key[F] Comment claims validation that code does not perform
```

Reproduced identically on dev and prod.

## The cause

`outcomeKey` prefers the fingerprint form, but findings **enter the ledger with no fingerprint** — `withCodeFingerprints` assigns it later, from fetched file contents, *after* the last `recordDrops`. So a finding entered as `file::T::<title>` and `finalize` looked it up as `file::F::<fp>`, failed to resolve, registered a fresh row, and abandoned the original.

The data showed it exactly: **every surfaced row was `[F]`-keyed and every stageless ghost was `[T]`-keyed.**

## Impact beyond the stray rows

- The ledger **double-counted**, violating #470's "exactly one terminal outcome per entrant" in production.
- **`suppressedCount` was inflated.** It is derived as *everything that did not surface*, so each ghost overstated what was filtered — #401's failure mode arriving through a different door.
- **Agent attribution was lost**: the replacement row was credited to `orchestrator` rather than the agent that raised the finding.

## The fix

The recorder already has `alias()`, built for exactly this when FP-C and W10 rename a surviving finding's title. Assigning a fingerprint renames a survivor *without* touching its title, and needs the same alias.

## Why the existing tests missed it

**#470's self-consistency test runs the pipeline without file contents**, so `withCodeFingerprints` is a no-op and no key ever changes. The invariant held in the test for precisely the reason it failed in production.

The new test supplies file contents through a mocked `getContent`, and **asserts a fingerprint was actually assigned first** — a test that cannot observe the condition proves nothing about it.

## Verified load-bearing

With the alias removed, **4 of the 5 new tests fail**. The fifth is the setup guard, which should pass either way.

One of the five initially passed *without* the fix for the wrong reason — it asserted `filterOutcomes[0]`, and the abandoned original happens to sort first. It now asserts the surfaced row specifically. A test that passes for the wrong reason is worse than no test.

## Verification

```
build      12/12
typecheck  20/20
test       21/21
```

Second commit fixes a type error I pushed in the first: the `groundingFetch` literal omitted two required `FileFetchOptions` fields. I had run the per-package typecheck *before* adding the test and then only vitest, which does not typecheck strictly.
