### PR TITLE
feat(dashboard): drawer carries the full review; one URL shape for both runtimes

### DIFF
--- a/packages/core/src/comment-formatter.test.ts
+++ b/packages/core/src/comment-formatter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatReviewComment, buildWorkDoneSection, countBlockingCriticals, buildCheckTitle, escapeUserContent, COMMENT_BODY_BUDGET, mergeScoreMeta, type Finding } from './comment-formatter.js';
+import { formatReviewComment, buildWorkDoneSection, countBlockingCriticals, buildCheckTitle, escapeUserContent, COMMENT_BODY_BUDGET, mergeScoreMeta, buildReviewDetailUrl, type Finding } from './comment-formatter.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -1022,5 +1022,49 @@ describe('mergeScoreMeta — fractional scores (#481 review)', () => {
   it('still clamps out of range', () => {
     expect(mergeScoreMeta(0).score).toBe(1);
     expect(mergeScoreMeta(99).score).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Review detail URL — one shape for both runtimes (#486)
+// ---------------------------------------------------------------------------
+
+describe('buildReviewDetailUrl (#486)', () => {
+  it('encodes the whole key into ONE path segment', () => {
+    // The dashboard route is a single [id] segment parsed on the last colon.
+    // Self-hosted used to emit `.../{repo}/{pr#sha}` — two segments — which
+    // 404'd, and left `#` unencoded so the SHA became a browser fragment.
+    const url = buildReviewDetailUrl('https://mw.example', 'owner/repo', '42#abc123')!;
+    const path = url.slice('https://mw.example'.length);
+    expect(path).toBe('/dashboard/reviews/owner%2Frepo%3A42%23abc123');
+    expect(path.split('/dashboard/reviews/')[1]).not.toContain('/');
+  });
+
+  it('encodes the # so the commit SHA reaches the server', () => {
+    const url = buildReviewDetailUrl('https://mw.example', 'owner/repo', '42#abc123')!;
+    expect(url).not.toContain('#');
+    expect(url).toContain('%23');
+  });
+
+  it('round-trips through the route parser', () => {
+    // Mirror of parseReviewId in app/api/reviews/[id]/route.ts.
+    const url = buildReviewDetailUrl('https://mw.example', 'owner/repo', '42#abc123')!;
+    const id = url.split('/dashboard/reviews/')[1];
+    const decoded = decodeURIComponent(id);
+    const idx = decoded.lastIndexOf(':');
+    expect(decoded.slice(0, idx)).toBe('owner/repo');
+    expect(decoded.slice(idx + 1)).toBe('42#abc123');
+  });
+
+  it('returns undefined when there is no dashboard — the normal self-hosted case', () => {
+    // The comment then omits the link rather than rendering a dead one.
+    expect(buildReviewDetailUrl(undefined, 'owner/repo', '42#abc')).toBeUndefined();
+    expect(buildReviewDetailUrl('', 'owner/repo', '42#abc')).toBeUndefined();
+  });
+
+  it('tolerates a trailing slash on the base URL', () => {
+    // DASHBOARD_BASE_URL is operator-set; a trailing slash is a coin flip.
+    expect(buildReviewDetailUrl('https://mw.example/', 'o/r', '1#a'))
+      .toBe(buildReviewDetailUrl('https://mw.example', 'o/r', '1#a'));
   });
 });

--- a/packages/core/src/comment-formatter.ts
+++ b/packages/core/src/comment-formatter.ts
@@ -223,6 +223,29 @@ const MERGE_SCORE_META: Record<number, { emoji: string; label: string }> = {
 };
 
 /**
+ * #486 — the dashboard URL for one review, built the SAME way by both runtimes.
+ *
+ * They had drifted into two different shapes. SaaS produced a single encoded
+ * segment; self-hosted produced `.../{encodedRepo}/{prNumberCommitSha}` — two
+ * segments against a one-segment `[id]` route, so it 404'd. Worse, the `#` in
+ * `42#abc` went unencoded, which a browser treats as a fragment: the commit SHA
+ * never reached the server at all.
+ *
+ * Returns undefined when there is no dashboard, which is the normal
+ * self-hosted case — the comment then omits the link rather than rendering a
+ * dead one.
+ */
+export function buildReviewDetailUrl(
+  dashboardBaseUrl: string | undefined,
+  repoFullName: string,
+  prNumberCommitSha: string,
+): string | undefined {
+  if (!dashboardBaseUrl) return undefined;
+  const base = dashboardBaseUrl.replace(/\/+$/, '');
+  return `${base}/dashboard/reviews/${encodeURIComponent(`${repoFullName}:${prNumberCommitSha}`)}`;
+}
+
+/**
  * The verdict wording for a merge score, clamped to 1–5.
  *
  * Exported so the dashboard (#472) shows the SAME verdict as the PR comment.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -140,7 +140,7 @@ export type { ReviewThreadComment } from './github/client.js';
 
 // ─── Comment formatter ──────────────────────────────────────────────────────
 export { formatReviewComment,
-  mergeScoreMeta, buildWorkDoneSection, countBlockingCriticals, buildCheckTitle, escapeUserContent } from './comment-formatter.js';
+  mergeScoreMeta, buildReviewDetailUrl, buildWorkDoneSection, countBlockingCriticals, buildCheckTitle, escapeUserContent } from './comment-formatter.js';
 export type { Finding, WorkDoneSection } from './comment-formatter.js';
 
 // ─── Review delta ────────────────────────────────────────────────────────────

--- a/packages/dashboard/components/FindingEvidence.tsx
+++ b/packages/dashboard/components/FindingEvidence.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+/**
+ * #486 — the review's findings and their evidence, as ONE implementation.
+ *
+ * These were local functions inside ReviewDetail.tsx, which is the only reason
+ * the drawer — the surface people actually click — could not show evidence.
+ * That was an accident of how #472 was built, not a design constraint: nothing
+ * about them is page-specific.
+ *
+ * Both ReviewDrawer and ReviewDetail mount these. Sharing also collapses a
+ * fork that already existed: ReviewDetail's severity styling was copied from
+ * the drawer during #472.
+ */
+
+import {
+  sortFindingsBySeverity,
+  findingsSummaryLine,
+  confidenceVsFloor,
+  groundingSummary,
+  type DetailFinding,
+} from "../lib/review-findings";
+
+export type { DetailFinding };
+
+// The single severity palette. It was duplicated between ReviewDrawer and
+// ReviewDetail; both now import this one.
+const severityStyles: Record<string, { dot: string; label: string }> = {
+  critical: { dot: "bg-red-500", label: "Critical" },
+  warning: { dot: "bg-yellow-500", label: "Warning" },
+  info: { dot: "bg-blue-500", label: "Info" },
+};
+
+export function SeverityDot({ severity }: { severity?: string }) {
+  const s = severityStyles[severity ?? ""] ?? severityStyles.info;
+  return <span className={`mt-1.5 inline-block h-2 w-2 shrink-0 rounded-full ${s.dot}`} title={s.label} />;
+}
+
+/**
+ * #472 Part B — everything #469 puts in the PR comment, uncollapsed, plus the
+ * two elements deliberately cut from that surface as too jargon-heavy:
+ * confidence against the active floor, and the grounding result.
+ *
+ * Uncollapsed on purpose. The reader opened a review detail page to find out
+ * why a finding exists; making them click again to see the proof is the same
+ * mistake as hiding it in the comment.
+ */
+export function EvidencePanel({
+  finding,
+  minConfidence,
+}: {
+  finding: DetailFinding;
+  minConfidence?: number;
+}) {
+  const e = finding.evidence;
+  const confidence = confidenceVsFloor(finding.confidence, minConfidence);
+  const grounding = groundingSummary(finding);
+  const agents = e?.agents ?? [];
+  if (!e?.code && !e?.reason && agents.length < 2 && !confidence) return null;
+
+  return (
+    <div className="mt-2 rounded border border-border-subtle bg-surface-subtle/40 px-3 py-2">
+      {e?.code && (
+        <pre className="overflow-x-auto rounded bg-surface-card px-2 py-1.5 text-[11px] leading-relaxed text-fg-secondary">
+          <code>{e.code}</code>
+        </pre>
+      )}
+      {e?.reason && <p className="mt-1.5 text-xs text-fg-secondary">{e.reason}</p>}
+      <dl className="mt-1.5 flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-fg-tertiary">
+        {confidence && (
+          <div className="flex gap-1">
+            <dt className="text-fg-faint">Confidence</dt>
+            <dd>{confidence}</dd>
+          </div>
+        )}
+        <div className="flex gap-1">
+          <dt className="text-fg-faint">Grounding</dt>
+          <dd>{grounding}</dd>
+        </div>
+        {/* Only on convergence — one agent's name restates the category. */}
+        {agents.length > 1 && (
+          <div className="flex gap-1">
+            <dt className="text-fg-faint">Agents</dt>
+            <dd>{agents.join(" + ")} agreed independently</dd>
+          </div>
+        )}
+      </dl>
+    </div>
+  );
+}
+
+export function FindingsSection({ findings, minConfidence }: { findings: DetailFinding[]; minConfidence?: number }) {
+  const sorted = sortFindingsBySeverity(findings);
+  return (
+    <div className="rounded-lg border border-border-default overflow-hidden">
+      <div className="bg-surface-card-hover px-4 py-2.5 border-b border-border-default flex items-center justify-between">
+        <h3 className="text-xs font-semibold uppercase tracking-widest text-fg-muted">
+          Findings ({findings.length})
+        </h3>
+        <span className="text-xs text-fg-tertiary">{findingsSummaryLine(findings)}</span>
+      </div>
+      <div className="divide-y divide-border-subtle">
+        {sorted.map((f, i) => (
+          <div key={`${f.file}:${f.line}:${i}`} className="flex items-start gap-2.5 px-4 py-3">
+            <SeverityDot severity={f.severity} />
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-sm font-medium text-fg-primary">{f.title}</span>
+                {f.category && (
+                  <span className="rounded bg-surface-subtle px-1.5 py-0.5 text-[10px] uppercase text-fg-secondary">
+                    {f.category}
+                  </span>
+                )}
+                {f.confidence != null && (
+                  <span className="rounded bg-surface-subtle px-1.5 py-0.5 text-[10px] text-fg-secondary">
+                    {f.confidence}%
+                  </span>
+                )}
+                {/* FP-L — an unverified critical is advisory, and saying so here
+                    keeps the dashboard aligned with the PR comment's split. */}
+                {f.verification === "unverified" && (
+                  <span className="rounded bg-surface-subtle px-1.5 py-0.5 text-[10px] text-fg-tertiary">
+                    unverified
+                  </span>
+                )}
+              </div>
+              <p className="mt-1 text-xs">
+                <code className="text-fg-tertiary">{f.file}:{f.line}</code>
+              </p>
+              {f.description && (
+                <p className="mt-1.5 text-xs leading-relaxed text-fg-secondary">{f.description}</p>
+              )}
+              {f.suggestion && (
+                <p className="mt-1.5 text-xs leading-relaxed text-fg-tertiary">
+                  <span className="font-medium">Suggestion: </span>{f.suggestion}
+                </p>
+              )}
+              <EvidencePanel finding={f} minConfidence={minConfidence} />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/components/ReviewDetail.tsx
+++ b/packages/dashboard/components/ReviewDetail.tsx
@@ -2,14 +2,8 @@
 
 import Link from "next/link";
 import RelativeTime from "./RelativeTime";
-import {
-  sortFindingsBySeverity,
-  findingsSummaryLine,
-  mergeScoreMeta,
-  confidenceVsFloor,
-  groundingSummary,
-  type DetailFinding,
-} from "../lib/review-findings";
+import { mergeScoreMeta, type DetailFinding } from "../lib/review-findings";
+import { FindingsSection } from "./FindingEvidence";
 import FilterTrail from "./FilterTrail";
 import {
   ArrowLeft,
@@ -60,126 +54,6 @@ export interface ReviewData {
   minConfidence?: number;
 }
 
-// Borrowed from ReviewDrawer so the two surfaces describe the same review the
-// same way. A second palette here would drift.
-const severityStyles: Record<string, { dot: string; label: string }> = {
-  critical: { dot: "bg-red-500", label: "Critical" },
-  warning: { dot: "bg-yellow-500", label: "Warning" },
-  info: { dot: "bg-blue-500", label: "Info" },
-};
-
-function SeverityDot({ severity }: { severity?: string }) {
-  const s = severityStyles[severity ?? ""] ?? severityStyles.info;
-  return <span className={`mt-1.5 inline-block h-2 w-2 shrink-0 rounded-full ${s.dot}`} title={s.label} />;
-}
-
-/**
- * #472 Part B — everything #469 puts in the PR comment, uncollapsed, plus the
- * two elements deliberately cut from that surface as too jargon-heavy:
- * confidence against the active floor, and the grounding result.
- *
- * Uncollapsed on purpose. The reader opened a review detail page to find out
- * why a finding exists; making them click again to see the proof is the same
- * mistake as hiding it in the comment.
- */
-function EvidencePanel({
-  finding,
-  minConfidence,
-}: {
-  finding: DetailFinding;
-  minConfidence?: number;
-}) {
-  const e = finding.evidence;
-  const confidence = confidenceVsFloor(finding.confidence, minConfidence);
-  const grounding = groundingSummary(finding);
-  const agents = e?.agents ?? [];
-  if (!e?.code && !e?.reason && agents.length < 2 && !confidence) return null;
-
-  return (
-    <div className="mt-2 rounded border border-border-subtle bg-surface-subtle/40 px-3 py-2">
-      {e?.code && (
-        <pre className="overflow-x-auto rounded bg-surface-card px-2 py-1.5 text-[11px] leading-relaxed text-fg-secondary">
-          <code>{e.code}</code>
-        </pre>
-      )}
-      {e?.reason && <p className="mt-1.5 text-xs text-fg-secondary">{e.reason}</p>}
-      <dl className="mt-1.5 flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-fg-tertiary">
-        {confidence && (
-          <div className="flex gap-1">
-            <dt className="text-fg-faint">Confidence</dt>
-            <dd>{confidence}</dd>
-          </div>
-        )}
-        <div className="flex gap-1">
-          <dt className="text-fg-faint">Grounding</dt>
-          <dd>{grounding}</dd>
-        </div>
-        {/* Only on convergence — one agent's name restates the category. */}
-        {agents.length > 1 && (
-          <div className="flex gap-1">
-            <dt className="text-fg-faint">Agents</dt>
-            <dd>{agents.join(" + ")} agreed independently</dd>
-          </div>
-        )}
-      </dl>
-    </div>
-  );
-}
-
-function FindingsSection({ findings, minConfidence }: { findings: DetailFinding[]; minConfidence?: number }) {
-  const sorted = sortFindingsBySeverity(findings);
-  return (
-    <div className="rounded-lg border border-border-default overflow-hidden">
-      <div className="bg-surface-card-hover px-4 py-2.5 border-b border-border-default flex items-center justify-between">
-        <h3 className="text-xs font-semibold uppercase tracking-widest text-fg-muted">
-          Findings ({findings.length})
-        </h3>
-        <span className="text-xs text-fg-tertiary">{findingsSummaryLine(findings)}</span>
-      </div>
-      <div className="divide-y divide-border-subtle">
-        {sorted.map((f, i) => (
-          <div key={`${f.file}:${f.line}:${i}`} className="flex items-start gap-2.5 px-4 py-3">
-            <SeverityDot severity={f.severity} />
-            <div className="min-w-0 flex-1">
-              <div className="flex flex-wrap items-center gap-2">
-                <span className="text-sm font-medium text-fg-primary">{f.title}</span>
-                {f.category && (
-                  <span className="rounded bg-surface-subtle px-1.5 py-0.5 text-[10px] uppercase text-fg-secondary">
-                    {f.category}
-                  </span>
-                )}
-                {f.confidence != null && (
-                  <span className="rounded bg-surface-subtle px-1.5 py-0.5 text-[10px] text-fg-secondary">
-                    {f.confidence}%
-                  </span>
-                )}
-                {/* FP-L — an unverified critical is advisory, and saying so here
-                    keeps the dashboard aligned with the PR comment's split. */}
-                {f.verification === "unverified" && (
-                  <span className="rounded bg-surface-subtle px-1.5 py-0.5 text-[10px] text-fg-tertiary">
-                    unverified
-                  </span>
-                )}
-              </div>
-              <p className="mt-1 text-xs">
-                <code className="text-fg-tertiary">{f.file}:{f.line}</code>
-              </p>
-              {f.description && (
-                <p className="mt-1.5 text-xs leading-relaxed text-fg-secondary">{f.description}</p>
-              )}
-              {f.suggestion && (
-                <p className="mt-1.5 text-xs leading-relaxed text-fg-tertiary">
-                  <span className="font-medium">Suggestion: </span>{f.suggestion}
-                </p>
-              )}
-              <EvidencePanel finding={f} minConfidence={minConfidence} />
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
 
 const statusConfig: Record<
   ReviewData["status"],

--- a/packages/dashboard/components/ReviewDetail.tsx
+++ b/packages/dashboard/components/ReviewDetail.tsx
@@ -370,7 +370,7 @@ export default function ReviewDetail({ review }: { review: ReviewData }) {
       )}
 
       {/* #472 Part C — why every other finding is not above. */}
-      {review.status === "completed" && (
+      {review.status === "completed" && review.repoFullName && review.prNumberCommitSha && (
         <div className="mt-4">
           <FilterTrail reviewId={`${review.repoFullName}:${review.prNumberCommitSha}`} />
         </div>

--- a/packages/dashboard/components/ReviewDrawer.tsx
+++ b/packages/dashboard/components/ReviewDrawer.tsx
@@ -16,6 +16,9 @@ import {
   ThumbsUp,
   ThumbsDown,
 } from "lucide-react";
+import { FindingsSection } from "./FindingEvidence";
+import FilterTrail from "./FilterTrail";
+import type { DetailFinding } from "../lib/review-findings";
 
 // -- Types ------------------------------------------------------------------
 
@@ -46,19 +49,13 @@ interface ReviewDetail {
   mergeScoreReason?: string;
 }
 
-interface Finding {
-  file: string;
-  line: number;
-  severity: "critical" | "warning" | "info";
-  confidence?: number;
-  category: "security" | "bug" | "style";
-  title: string;
-  description: string;
-  suggestion: string;
-}
+// #486 — the shared shape, so the drawer and the page cannot drift apart.
+type Finding = DetailFinding;
 
 interface SettingsUsed {
   severityThreshold: string;
+  /** #486 — the confidence floor in force, shown against each finding's score. */
+  minConfidence?: number;
   commentTypes: { syntax: boolean; logic: boolean; style: boolean };
   maxComments: number;
   summaryEnabled: boolean;
@@ -75,28 +72,11 @@ const statusStyles: Record<string, { bg: string; text: string; label: string }> 
   skipped: { bg: "bg-[#555]/15", text: "text-fg-secondary", label: "Skipped" },
 };
 
-const severityStyles: Record<string, { dot: string; label: string }> = {
-  critical: { dot: "bg-red-500", label: "Critical" },
-  warning: { dot: "bg-yellow-500", label: "Warning" },
-  info: { dot: "bg-blue-500", label: "Info" },
-};
-
 function StatusBadge({ status }: { status: string }) {
   const s = statusStyles[status] ?? statusStyles.pending;
   return (
     <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${s.bg} ${s.text}`}>
       {s.label}
-    </span>
-  );
-}
-
-function SeverityDot({ severity }: { severity?: string }) {
-  if (!severity) return null;
-  const s = severityStyles[severity];
-  if (!s) return null;
-  return (
-    <span className="inline-flex items-center gap-1" title={s.label}>
-      <span className={`inline-block h-2 w-2 rounded-full ${s.dot}`} />
     </span>
   );
 }
@@ -347,44 +327,28 @@ export default function ReviewDrawer({
                 icon={AlertCircle}
                 defaultOpen
               >
+                {/* #486 — the SAME component the detail page renders, so the drawer
+                    carries the full review rather than a summary of it. This was
+                    hand-rolled markup, which is why evidence was unreachable from the
+                    surface people actually click. */}
                 {(!review.findings || review.findings.length === 0) ? (
                   <p className="text-sm text-fg-tertiary">No issues found.</p>
                 ) : (
-                  <div className="space-y-3">
-                    {review.findings.map((f, i) => (
-                      <div key={i} className="rounded-lg border border-border-subtle p-3">
-                        <div className="flex items-start gap-2">
-                          <SeverityDot severity={f.severity} />
-                          <div className="min-w-0 flex-1">
-                            <div className="flex items-center gap-2 flex-wrap">
-                              <span className="text-sm font-medium text-fg-primary">{f.title}</span>
-                              <span className="rounded bg-surface-subtle px-1.5 py-0.5 text-[10px] text-fg-secondary uppercase">
-                                {f.category}
-                              </span>
-                              {f.confidence != null && (
-                                <span className="rounded bg-surface-subtle px-1.5 py-0.5 text-[10px] text-fg-secondary">
-                                  {f.confidence}%
-                                </span>
-                              )}
-                            </div>
-                            <p className="mt-1 text-xs text-fg-secondary">
-                              <code className="text-fg-secondary">{f.file}:{f.line}</code>
-                            </p>
-                            {f.description && (
-                              <p className="mt-1.5 text-xs text-fg-secondary leading-relaxed">{f.description}</p>
-                            )}
-                            {f.suggestion && (
-                              <div className="mt-2 rounded bg-[#0d1a0d] border border-[#1a2e1a] px-2.5 py-1.5 text-xs text-[#6fcc6f]">
-                                {f.suggestion}
-                              </div>
-                            )}
-                          </div>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
+                  <FindingsSection
+                    findings={review.findings as DetailFinding[]}
+                    minConfidence={review.settingsUsed?.minConfidence}
+                  />
                 )}
               </DrawerSection>
+
+              {/* #486 — why every other finding is not above. */}
+              {review.status === "complete" && (
+                <DrawerSection title="Decision trail" icon={AlertCircle}>
+                  <FilterTrail
+                    reviewId={`${review.repoFullName}:${review.prNumber}#${review.commitSha}`}
+                  />
+                </DrawerSection>
+              )}
 
               {review.settingsUsed && (
                 <DrawerSection title="Settings Used" icon={BarChart3}>

--- a/packages/dashboard/components/ReviewDrawer.tsx
+++ b/packages/dashboard/components/ReviewDrawer.tsx
@@ -341,11 +341,16 @@ export default function ReviewDrawer({
                 )}
               </DrawerSection>
 
-              {/* #486 — why every other finding is not above. */}
-              {review.status === "complete" && (
+              {/* #486 — keyed on `id`, which IS the canonical prNumberCommitSha the
+                  trace is stored under. Rebuilding it from prNumber+commitSha was
+                  lossy: commitSha is derived as `split("#")[1] ?? ""`, so a key with
+                  no '#' yields `repo:42#` — a lookup that finds nothing and renders
+                  "No decision trail was recorded", which would be a false statement
+                  rather than an absent trail. */}
+              {review.status === "complete" && review.repoFullName && review.id && (
                 <DrawerSection title="Decision trail" icon={AlertCircle}>
                   <FilterTrail
-                    reviewId={`${review.repoFullName}:${review.prNumber}#${review.commitSha}`}
+                    reviewId={`${review.repoFullName}:${review.id}`}
                   />
                 </DrawerSection>
               )}

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -64,6 +64,7 @@ import {
   findingMatchKeys,
   resolveReviewModelId,
   buildReviewTrace,
+  buildReviewDetailUrl,
 } from '@mergewatch/core';
 import type { RejectCategory, FindingDispositionRecord } from '@mergewatch/core';
 import type {
@@ -879,7 +880,8 @@ export async function handler(
       categoryDisputeRates,
     }, { llm });
 
-    const reviewDetailUrl = `${DASHBOARD_BASE_URL}/dashboard/reviews/${encodeURIComponent(`${repoFullName}:${prNumberCommitSha}`)}`;
+    // #486 — shared with the self-hosted server so the two cannot drift.
+    const reviewDetailUrl = buildReviewDetailUrl(DASHBOARD_BASE_URL, repoFullName, prNumberCommitSha);
 
     // Build work-done section from the FILTERED diff (#358) — the tallies
     // must describe what the agents actually reviewed. Raw PR totals counted

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -21,6 +21,7 @@ import {
   selectOrgAgentsForReview, unionCustomAgents, blockingCriticalAgents, languagesFromFiles,
   findingMatchKeys,
   buildReviewTrace,
+  buildReviewDetailUrl,
 } from '@mergewatch/core';
 import type { WebhookDeps } from './webhook-handler.js';
 // #416 — deployment stage, so review artifacts (comment marker, check-run
@@ -784,9 +785,11 @@ export async function processReviewJob(
       mergeScoreReason: result.mergeScoreReason,
       disputeDisclosure: result.disputeDisclosure,
       commentFooter: instSettings.commentHeader || undefined,
-      reviewDetailUrl: deps.dashboardBaseUrl
-        ? `${deps.dashboardBaseUrl}/dashboard/reviews/${encodeURIComponent(repoFullName)}/${prNumberCommitSha}`
-        : undefined,
+      // #486 — shared with the Lambda. This used to build a two-segment path
+      // with an unencoded '#', which 404'd against the one-segment [id] route
+      // and dropped the SHA into a browser fragment, so self-hosted's
+      // "View full details" never worked.
+      reviewDetailUrl: buildReviewDetailUrl(deps.dashboardBaseUrl, repoFullName, prNumberCommitSha),
       ux: config.ux,
       workDone,
       delta,


### PR DESCRIPTION
Closes #486.

## The gap

#472's evidence panel and decision trail landed on `ReviewDetail` — a page **nothing in the dashboard links to**. `grep` finds zero references to `/dashboard/reviews/<id>` in any component: clicking a review calls `onSelect()` and opens the drawer, full stop.

So the surface people use had *less* information than the one they could not reach. That happened because #472 framed every part around `ReviewDetail` and cast the drawer as the thing to borrow *from*. I followed the framing without asking how a user reaches `ReviewDetail`, which was the question that mattered.

## Extracted, not duplicated

`SeverityDot`, `EvidencePanel` and `FindingsSection` were **local functions inside `ReviewDetail`**. Nothing about them is page-specific — that accident is the only reason the drawer could not show evidence.

```
components/FindingEvidence.tsx   ← the three, now shared
components/FilterTrail.tsx       ← already standalone

ReviewDrawer  → mounts both   (where people click)
ReviewDetail  → mounts both   (link target; see below)
```

**This collapses a fork rather than creating one.** `ReviewDetail`'s severity palette was copied from the drawer during #472; the drawer's now-dead copy is deleted here. One palette, one findings renderer, one evidence panel — which is why the diff is net **−194 lines** across the two components.

## The route stays, and has to

It is the target of three live surfaces:

| surface | reference |
|---|---|
| every review comment footer | `comment-formatter.ts:855` |
| Check Run `details_url` | `review-agent.ts:1218` |
| #468 truncation notice | the only recovery path when a comment is cut |

Deleting it would 404 every comment MergeWatch has already posted. It is now a thin mount of the same shared components — not a second implementation.

## Self-hosted bug found while answering "does this hardcode endpoints?"

It does not — the trail fetches a **relative** path, so it adapts to any host. But the two runtimes built **different** detail URLs:

```
SaaS:        /dashboard/reviews/owner%2Frepo%3A42%23abc     1 segment  ✅
self-hosted: /dashboard/reviews/owner%2Frepo/42#abc         2 segments ❌
```

The route is a single `[id]` segment, so the self-hosted form **404s** — and the unencoded `#` makes the commit SHA a browser fragment:

```
path     : /dashboard/reviews/owner%2Frepo/42
fragment : abc123   ← never sent to the server
```

So *View full details* has **never worked on self-hosted**. That also means **#468's truncation-recovery link was dead there** — the one path to content cut from an oversized comment.

Both runtimes now call `buildReviewDetailUrl` in core, with a test that round-trips through the route's **own parser** so the shapes cannot drift again.

## Verification

```
build      12/12
typecheck  20/20
test       21/21
```

Not claimed: a live `docker-compose` click-through. The URL fix is covered by the round-trip test, and the trail's relative fetch is host-agnostic by construction, but I have not stood a compose stack up.
