### PR TITLE
fix(dashboard): the trace table name never reached the Amplify runtime

### DIFF
--- a/packages/dashboard/next.config.js
+++ b/packages/dashboard/next.config.js
@@ -124,6 +124,13 @@ const nextConfig = {
     GITHUB_CLIENT_SECRET: process.env.GITHUB_CLIENT_SECRET,
     DYNAMODB_TABLE_INSTALLATIONS: process.env.DYNAMODB_TABLE_INSTALLATIONS,
     DYNAMODB_TABLE_REVIEWS: process.env.DYNAMODB_TABLE_REVIEWS,
+    // #471/#472 — the filter-trace table. Set in both Amplify apps, but an env
+    // var absent from THIS block does not exist at runtime, and the read path
+    // degrades silently: `DynamoDashboardReviewStore.getReviewTrace` returns
+    // null when the table name is unset, which the trail panel renders as
+    // "No decision trail was recorded for this review" — identical to a review
+    // that legitimately has none. Same failure shape as #315 below.
+    DYNAMODB_TABLE_REVIEW_TRACES: process.env.DYNAMODB_TABLE_REVIEW_TRACES,
     // FB-F..FB-J — optional; routes degrade to a zero-state when unset.
     DYNAMODB_TABLE_FP_INSIGHTS: process.env.DYNAMODB_TABLE_FP_INSIGHTS,
     // #195 Phase 5 — optional; NPS route reports ineligible when unset.


### PR DESCRIPTION
## What

Adds `DYNAMODB_TABLE_REVIEW_TRACES` to the `env` block in `packages/dashboard/next.config.js`. One line.

## Why

The decision trail panel reports **"No decision trail was recorded for this review"** on every prod review — including ones that do have a trace.

The data is fine. `mergewatch-review-traces-prod` holds **53 rows**; the review Lambda has been writing them successfully since #480.

The variable is set on both Amplify apps:

```
prod → DYNAMODB_TABLE_REVIEW_TRACES = mergewatch-review-traces-prod
dev  → DYNAMODB_TABLE_REVIEW_TRACES = mergewatch-review-traces-dev
```

But it was never added to the `env` block, so **it does not exist at runtime**. `createDynamoDashboardStore` receives `reviewTracesTable: undefined`, and `getReviewTrace` returns null at the table-name guard (`storage-dynamo/src/dashboard-store.ts:488`) before issuing any query.

## Why nothing caught it

`null` is also the correct answer for a review that genuinely has no trace. The trace route's own doc comment says `{ trace: null }` is *"a legitimate answer, not an error"* — which is true, and exactly why a misconfiguration and a legitimate empty state render identically.

This is the same failure mode as #315, whose warning comment already sits eight lines below this fix.

## Verified

- [x] Prod trace table has 53 rows — writes work
- [x] Amplify env var set on both apps
- [x] Amplify SSR IAM already covers it (`table/mergewatch-*` wildcard) — no policy change needed
- [x] `next.config.js` parses and exposes the key

Takes effect on the next Amplify build, since the `env` block is inlined at build time.

## Follow-up worth considering

The read path cannot distinguish "not configured" from "no trace". Having the store log once when `reviewTracesTable` is unset would have turned this into a one-line CloudWatch grep instead of a dig. Happy to add if you want it here rather than separately.