### PR TITLE
fix(dashboard): keep the selected org in a user-scoped cookie

### DIFF
--- a/packages/dashboard/app/dashboard/layout.tsx
+++ b/packages/dashboard/app/dashboard/layout.tsx
@@ -1,9 +1,11 @@
 import { redirect } from "next/navigation";
+import { cookies } from "next/headers";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { fetchUserInstallations, TokenExpiredError } from "@/lib/github-repos";
 import DashboardShell from "@/components/layout/DashboardShell";
 import type { InstallationInfo } from "@/components/layout/DashboardShell";
+import { ORG_COOKIE } from "@/lib/org-selection";
 
 export default async function DashboardLayout({
   children,
@@ -41,11 +43,18 @@ export default async function DashboardLayout({
     type: i.account.type,
   }));
 
+  // #498 — read the selection server-side so the correct org renders on first
+  // paint. Resolving it in the client would render the default on the server
+  // and correct it on hydration, flipping the switcher on every page load.
+  const orgCookie = (await cookies()).get(ORG_COOKIE)?.value;
+
   return (
     <DashboardShell
       userName={session.user?.name ?? session.user?.email ?? ""}
       userImage={session.user?.image}
       installations={installationInfos}
+      orgCookie={orgCookie}
+      githubUserId={(session as any).githubUserId as string | undefined}
     >
       {children}
     </DashboardShell>

--- a/packages/dashboard/app/signout/page.tsx
+++ b/packages/dashboard/app/signout/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { signOut } from "next-auth/react";
+import { clearOrgCookie } from "@/lib/org-selection";
 import { useEffect } from "react";
 
 export default function SignOutPage() {
   useEffect(() => {
+    clearOrgCookie();
     signOut({ callbackUrl: "/" });
   }, []);
 

--- a/packages/dashboard/components/Header.tsx
+++ b/packages/dashboard/components/Header.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect } from "react";
 import Link from "next/link";
 import { signOut } from "next-auth/react";
+import { clearOrgCookie } from "@/lib/org-selection";
 import { Menu, User } from "lucide-react";
 
 interface HeaderProps {
@@ -98,7 +99,7 @@ export default function Header({ userName, userImage, onMenuToggle }: HeaderProp
                 </div>
               </Link>
               <button
-                onClick={() => signOut({ callbackUrl: "/" })}
+                onClick={() => { clearOrgCookie(); signOut({ callbackUrl: "/" }); }}
                 className="flex w-full items-center gap-2 px-4 py-2.5 text-left text-sm text-primer-muted transition hover:bg-surface-card hover:text-red-400"
               >
                 <svg

--- a/packages/dashboard/components/layout/DashboardShell.tsx
+++ b/packages/dashboard/components/layout/DashboardShell.tsx
@@ -63,7 +63,11 @@ export default function DashboardShell({
   // switch the reader's session to the org it names.
   useEffect(() => {
     if (typeof document === "undefined") return;
-    if (resolved.staleCookie && resolved.source !== "param") {
+    // Cleared unconditionally, then re-written below when there is something
+    // to write. Guarding this on `source !== "param"` relied on the write
+    // always following, but its own guard can fail (a session with no
+    // githubUserId), and the stale cookie then survived indefinitely.
+    if (resolved.staleCookie) {
       document.cookie = serializeClearedOrgCookie();
     }
     if (githubUserId && resolved.installationId != null && resolved.source !== "cookie") {

--- a/packages/dashboard/components/layout/DashboardShell.tsx
+++ b/packages/dashboard/components/layout/DashboardShell.tsx
@@ -5,7 +5,7 @@ import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import Sidenav from "./Sidenav";
 import {
   resolveOrg,
-  serializeOrgCookie,
+  writeOrgCookie,
   serializeClearedOrgCookie,
 } from "@/lib/org-selection";
 
@@ -71,7 +71,7 @@ export default function DashboardShell({
       document.cookie = serializeClearedOrgCookie();
     }
     if (githubUserId && resolved.installationId != null && resolved.source !== "cookie") {
-      document.cookie = serializeOrgCookie(githubUserId, resolved.installationId);
+      writeOrgCookie(githubUserId, resolved.installationId);
     }
   }, [githubUserId, resolved.installationId, resolved.source, resolved.staleCookie]);
 
@@ -80,8 +80,8 @@ export default function DashboardShell({
       // Write before navigating: the cookie is what carries the choice to
       // pages the param never reaches, and the push below only survives as
       // long as the param does.
-      if (githubUserId && typeof document !== "undefined") {
-        document.cookie = serializeOrgCookie(githubUserId, installationId);
+      if (githubUserId) {
+        writeOrgCookie(githubUserId, installationId);
       }
       const params = new URLSearchParams(searchParams.toString());
       params.set("org", String(installationId));

--- a/packages/dashboard/components/layout/DashboardShell.tsx
+++ b/packages/dashboard/components/layout/DashboardShell.tsx
@@ -1,8 +1,13 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import Sidenav from "./Sidenav";
+import {
+  resolveOrg,
+  serializeOrgCookie,
+  serializeClearedOrgCookie,
+} from "@/lib/org-selection";
 
 export interface InstallationInfo {
   id: number;
@@ -15,6 +20,10 @@ interface DashboardShellProps {
   userName: string;
   userImage?: string | null;
   installations: InstallationInfo[];
+  /** #498 — raw `mw_org` cookie, read server-side so first paint is correct. */
+  orgCookie?: string;
+  /** #498 — session user, so another account's cookie cannot select an org. */
+  githubUserId?: string;
   children: React.ReactNode;
 }
 
@@ -22,6 +31,8 @@ export default function DashboardShell({
   userName,
   userImage,
   installations,
+  orgCookie,
+  githubUserId,
   children,
 }: DashboardShellProps) {
   const router = useRouter();
@@ -30,21 +41,49 @@ export default function DashboardShell({
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
 
   const orgParam = searchParams.get("org");
-  const activeInstallationId = orgParam
-    ? Number(orgParam)
-    : installations[0]?.id ?? 0;
+
+  // #498 — `?org=` wins (deep links), then the cookie, then the first
+  // installation. Both candidates are validated against the installations this
+  // account actually has: access can be revoked between visits, and resolving
+  // a stale id anyway would show one org's label over another org's data.
+  const resolved = resolveOrg({
+    orgParam,
+    cookieValue: orgCookie,
+    userId: githubUserId,
+    installations,
+  });
 
   const activeInstallation =
-    installations.find((i) => i.id === activeInstallationId) ??
+    installations.find((i) => i.id === resolved.installationId) ??
     installations[0];
+
+  // Persist whatever resolved, and drop a cookie that can never resolve. A
+  // stale one is otherwise re-read on every navigation for the life of the
+  // browser profile. Writing on `param` is what makes a shared deep link
+  // switch the reader's session to the org it names.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    if (resolved.staleCookie && resolved.source !== "param") {
+      document.cookie = serializeClearedOrgCookie();
+    }
+    if (githubUserId && resolved.installationId != null && resolved.source !== "cookie") {
+      document.cookie = serializeOrgCookie(githubUserId, resolved.installationId);
+    }
+  }, [githubUserId, resolved.installationId, resolved.source, resolved.staleCookie]);
 
   const handleSwitch = useCallback(
     (installationId: number) => {
+      // Write before navigating: the cookie is what carries the choice to
+      // pages the param never reaches, and the push below only survives as
+      // long as the param does.
+      if (githubUserId && typeof document !== "undefined") {
+        document.cookie = serializeOrgCookie(githubUserId, installationId);
+      }
       const params = new URLSearchParams(searchParams.toString());
       params.set("org", String(installationId));
       router.push(`${pathname}?${params.toString()}`);
     },
-    [router, pathname, searchParams],
+    [router, pathname, searchParams, githubUserId],
   );
 
   return (

--- a/packages/dashboard/components/layout/DashboardShell.tsx
+++ b/packages/dashboard/components/layout/DashboardShell.tsx
@@ -70,6 +70,14 @@ export default function DashboardShell({
     if (resolved.staleCookie) {
       document.cookie = serializeClearedOrgCookie();
     }
+    // `!== "cookie"` rather than `=== "param"`: it must also fire for
+    // `"default"`, or a first-time visitor's org is never persisted and the
+    // original bug returns for anyone who has not used the switcher yet.
+    // A param that beats a valid, different cookie is already covered here —
+    // source is "param", so the write runs and overwrites it. The one path
+    // that skips the write is a session with no githubUserId, and that same
+    // condition makes the cookie unusable in resolveOrg, so it is cleared
+    // above instead of being left to disagree with the URL.
     if (githubUserId && resolved.installationId != null && resolved.source !== "cookie") {
       writeOrgCookie(githubUserId, resolved.installationId);
     }

--- a/packages/dashboard/components/layout/Sidenav.tsx
+++ b/packages/dashboard/components/layout/Sidenav.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { signOut } from "next-auth/react";
+import { clearOrgCookie } from "@/lib/org-selection";
 import { useTheme } from "next-themes";
 import {
   Home,
@@ -379,7 +380,7 @@ export default function Sidenav({
                   <span>{theme === "dark" ? "Light mode" : "Dark mode"}</span>
                 </button>
                 <button
-                  onClick={() => signOut({ callbackUrl: "/" })}
+                  onClick={() => { clearOrgCookie(); signOut({ callbackUrl: "/" }); }}
                   className="flex w-full items-center gap-2 px-3 py-2 text-xs text-fg-secondary transition hover:bg-hover hover:text-red-400"
                 >
                   <LogOut size={13} />
@@ -414,7 +415,7 @@ export default function Sidenav({
                     <span>{theme === "dark" ? "Light mode" : "Dark mode"}</span>
                   </button>
                   <button
-                    onClick={() => signOut({ callbackUrl: "/" })}
+                    onClick={() => { clearOrgCookie(); signOut({ callbackUrl: "/" }); }}
                     className="flex w-full items-center gap-2 px-3 py-2 text-xs text-fg-secondary transition hover:bg-hover hover:text-red-400"
                   >
                     <LogOut size={13} />

--- a/packages/dashboard/lib/org-selection.test.ts
+++ b/packages/dashboard/lib/org-selection.test.ts
@@ -134,6 +134,14 @@ describe("resolveOrg", () => {
     expect(r).toEqual({ installationId: null, source: "none", staleCookie: false });
   });
 
+  it("does NOT flag a valid cookie as stale when a param outranks it", () => {
+    // The param wins and DashboardShell overwrites the cookie (source is
+    // "param", which its write condition covers). Flagging this stale would
+    // clear a perfectly good cookie on every deep-link visit.
+    const r = resolveOrg({ ...base, orgParam: "333", cookieValue: `${USER}:222` });
+    expect(r).toEqual({ installationId: 333, source: "param", staleCookie: false });
+  });
+
   it("still reports a stale cookie when a valid param wins — the caller must drop it", () => {
     // DashboardShell clears on this flag alone; it must not be suppressed just
     // because the param resolved the org.

--- a/packages/dashboard/lib/org-selection.test.ts
+++ b/packages/dashboard/lib/org-selection.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import {
+  ORG_COOKIE,
+  serializeOrgCookie,
+  serializeClearedOrgCookie,
+  parseOrgCookie,
+  resolveOrg,
+} from "./org-selection";
+
+const INSTALLS = [{ id: 111 }, { id: 222 }, { id: 333 }];
+const USER = "9001";
+
+describe("serializeOrgCookie", () => {
+  it("round-trips through parseOrgCookie", () => {
+    const raw = serializeOrgCookie(USER, 222).split(";")[0].slice(ORG_COOKIE.length + 1);
+    expect(parseOrgCookie(raw)).toEqual({ userId: USER, installationId: 222 });
+  });
+
+  it("scopes to the path and uses Lax so a top-level navigation still carries it", () => {
+    const c = serializeOrgCookie(USER, 222);
+    expect(c).toContain("Path=/");
+    expect(c).toContain("SameSite=Lax");
+    expect(c).toContain("Max-Age=");
+  });
+
+  it("expires immediately when cleared", () => {
+    expect(serializeClearedOrgCookie()).toContain("Max-Age=0");
+  });
+});
+
+describe("parseOrgCookie", () => {
+  it("returns null for absent values", () => {
+    expect(parseOrgCookie(undefined)).toBeNull();
+    expect(parseOrgCookie(null)).toBeNull();
+    expect(parseOrgCookie("")).toBeNull();
+  });
+
+  it("returns null for malformed values rather than a partial selection", () => {
+    expect(parseOrgCookie("nocolon")).toBeNull();
+    expect(parseOrgCookie(":222")).toBeNull();
+    expect(parseOrgCookie("9001:")).toBeNull();
+    expect(parseOrgCookie("9001:abc")).toBeNull();
+    expect(parseOrgCookie("9001:-5")).toBeNull();
+    expect(parseOrgCookie("9001:0")).toBeNull();
+    expect(parseOrgCookie("9001:1.5")).toBeNull();
+  });
+
+  it("does not throw on an undecodable value", () => {
+    expect(parseOrgCookie("%E0%A4%A")).toBeNull();
+  });
+
+  it("splits on the last colon so a colon in the user id cannot shift the install id", () => {
+    expect(parseOrgCookie("we:ird:222")).toEqual({ userId: "we:ird", installationId: 222 });
+  });
+});
+
+describe("resolveOrg", () => {
+  const base = { orgParam: null, cookieValue: null, userId: USER, installations: INSTALLS };
+
+  it("prefers the URL param so a shared deep link wins", () => {
+    const r = resolveOrg({ ...base, orgParam: "333", cookieValue: `${USER}:222` });
+    expect(r).toEqual({ installationId: 333, source: "param", staleCookie: false });
+  });
+
+  it("falls back to the cookie when no param is present", () => {
+    const r = resolveOrg({ ...base, cookieValue: `${USER}:222` });
+    expect(r).toEqual({ installationId: 222, source: "cookie", staleCookie: false });
+  });
+
+  it("falls back to the first installation when there is no selection at all", () => {
+    expect(resolveOrg(base)).toEqual({ installationId: 111, source: "default", staleCookie: false });
+  });
+
+  it("ignores a cookie belonging to another user — the shared-browser case", () => {
+    const r = resolveOrg({ ...base, cookieValue: `4242:222` });
+    expect(r.installationId).toBe(111);
+    expect(r.source).toBe("default");
+    expect(r.staleCookie).toBe(true);
+  });
+
+  it("ignores a cookie naming an installation the user can no longer access", () => {
+    const r = resolveOrg({ ...base, cookieValue: `${USER}:999` });
+    expect(r.installationId).toBe(111);
+    expect(r.source).toBe("default");
+    expect(r.staleCookie).toBe(true);
+  });
+
+  it("marks a malformed cookie stale so it stops being re-read", () => {
+    const r = resolveOrg({ ...base, cookieValue: "garbage" });
+    expect(r.staleCookie).toBe(true);
+  });
+
+  it("does not mark an absent cookie stale", () => {
+    expect(resolveOrg(base).staleCookie).toBe(false);
+  });
+
+  it("ignores a cookie when the session has no user id", () => {
+    const r = resolveOrg({ ...base, userId: undefined, cookieValue: `${USER}:222` });
+    expect(r.installationId).toBe(111);
+    expect(r.staleCookie).toBe(true);
+  });
+
+  it("ignores a param naming an installation the user does not have", () => {
+    const r = resolveOrg({ ...base, orgParam: "999", cookieValue: `${USER}:222` });
+    expect(r).toEqual({ installationId: 222, source: "cookie", staleCookie: false });
+  });
+
+  it("ignores a non-numeric param", () => {
+    expect(resolveOrg({ ...base, orgParam: "abc" }).source).toBe("default");
+    expect(resolveOrg({ ...base, orgParam: "" }).source).toBe("default");
+  });
+
+  it("reports no selection when the user has no installations", () => {
+    const r = resolveOrg({ ...base, installations: [] });
+    expect(r).toEqual({ installationId: null, source: "none", staleCookie: false });
+  });
+
+  it("keeps a valid cookie usable even when a stale param is present", () => {
+    const r = resolveOrg({ ...base, orgParam: "0", cookieValue: `${USER}:333` });
+    expect(r.installationId).toBe(333);
+    expect(r.source).toBe("cookie");
+  });
+});

--- a/packages/dashboard/lib/org-selection.test.ts
+++ b/packages/dashboard/lib/org-selection.test.ts
@@ -16,11 +16,18 @@ describe("serializeOrgCookie", () => {
     expect(parseOrgCookie(raw)).toEqual({ userId: USER, installationId: 222 });
   });
 
-  it("scopes to the path and uses Lax so a top-level navigation still carries it", () => {
+  it("scopes to /dashboard and uses Lax so a top-level navigation still carries it", () => {
     const c = serializeOrgCookie(USER, 222);
-    expect(c).toContain("Path=/");
+    expect(c).toContain("Path=/dashboard");
     expect(c).toContain("SameSite=Lax");
     expect(c).toContain("Max-Age=");
+  });
+
+  it("clears at the SAME path it sets — a mismatch would silently never delete", () => {
+    const setPath = /Path=([^;]+)/.exec(serializeOrgCookie(USER, 222))?.[1];
+    const clearPath = /Path=([^;]+)/.exec(serializeClearedOrgCookie())?.[1];
+    expect(setPath).toBe("/dashboard");
+    expect(clearPath).toBe(setPath);
   });
 
   it("adds Secure only when asked", () => {

--- a/packages/dashboard/lib/org-selection.test.ts
+++ b/packages/dashboard/lib/org-selection.test.ts
@@ -23,6 +23,20 @@ describe("serializeOrgCookie", () => {
     expect(c).toContain("Max-Age=");
   });
 
+  it("adds Secure only when asked", () => {
+    expect(serializeOrgCookie(USER, 222, { secure: true })).toContain("; Secure");
+    expect(serializeOrgCookie(USER, 222, { secure: false })).not.toContain("Secure");
+    // Default is the safe-for-plain-HTTP form: a self-hosted deployment runs a
+    // production build over HTTP, and an inert Secure cookie there would
+    // silently break the switcher.
+    expect(serializeOrgCookie(USER, 222)).not.toContain("Secure");
+  });
+
+  it("still round-trips with Secure set", () => {
+    const raw = serializeOrgCookie(USER, 222, { secure: true }).split(";")[0].slice(ORG_COOKIE.length + 1);
+    expect(parseOrgCookie(raw)).toEqual({ userId: USER, installationId: 222 });
+  });
+
   it("expires immediately when cleared", () => {
     expect(serializeClearedOrgCookie()).toContain("Max-Age=0");
   });
@@ -108,6 +122,11 @@ describe("resolveOrg", () => {
   it("ignores a non-numeric param", () => {
     expect(resolveOrg({ ...base, orgParam: "abc" }).source).toBe("default");
     expect(resolveOrg({ ...base, orgParam: "" }).source).toBe("default");
+  });
+
+  it("rejects a non-positive param outright", () => {
+    expect(resolveOrg({ ...base, orgParam: "0" }).source).toBe("default");
+    expect(resolveOrg({ ...base, orgParam: "-111" }).source).toBe("default");
   });
 
   it("reports no selection when the user has no installations", () => {

--- a/packages/dashboard/lib/org-selection.test.ts
+++ b/packages/dashboard/lib/org-selection.test.ts
@@ -115,6 +115,15 @@ describe("resolveOrg", () => {
     expect(r).toEqual({ installationId: null, source: "none", staleCookie: false });
   });
 
+  it("still reports a stale cookie when a valid param wins — the caller must drop it", () => {
+    // DashboardShell clears on this flag alone; it must not be suppressed just
+    // because the param resolved the org.
+    const r = resolveOrg({ ...base, orgParam: "333", cookieValue: "4242:222" });
+    expect(r.source).toBe("param");
+    expect(r.installationId).toBe(333);
+    expect(r.staleCookie).toBe(true);
+  });
+
   it("keeps a valid cookie usable even when a stale param is present", () => {
     const r = resolveOrg({ ...base, orgParam: "0", cookieValue: `${USER}:333` });
     expect(r.installationId).toBe(333);

--- a/packages/dashboard/lib/org-selection.ts
+++ b/packages/dashboard/lib/org-selection.ts
@@ -59,17 +59,33 @@ export interface ResolvedOrg {
  * installations on every read. Script that could forge this cookie already has
  * the session, and the worst it can select is an org the victim can see anyway.
  *
- * `Secure` is likewise omitted so self-hosted deployments on plain HTTP keep
- * working; `SameSite=Lax` is the meaningful protection here.
+ * `Secure` is decided per call from the page's own protocol rather than from
+ * `NODE_ENV`: self-hosted deployments run a production build over plain HTTP,
+ * so keying it on the build mode would set an inert `Secure` cookie there and
+ * silently break the switcher. The protocol is the fact that actually matters.
  *
  * The user id is stored alongside the installation id so a cookie belonging
  * to a different account is inert by construction. Clearing on sign-out is
  * hygiene; this check is the guarantee — a missed clear, a shared browser, or
  * a cookie left by a previous account cannot select an org for someone else.
  */
-export function serializeOrgCookie(userId: string, installationId: number): string {
+export function serializeOrgCookie(
+  userId: string,
+  installationId: number,
+  opts: { secure?: boolean } = {},
+): string {
   const value = encodeURIComponent(`${userId}:${installationId}`);
-  return `${ORG_COOKIE}=${value}; Path=/; Max-Age=${MAX_AGE_SECONDS}; SameSite=Lax`;
+  const secure = opts.secure ? "; Secure" : "";
+  return `${ORG_COOKIE}=${value}; Path=/; Max-Age=${MAX_AGE_SECONDS}; SameSite=Lax${secure}`;
+}
+
+/**
+ * True when the page is served over HTTPS, so the caller can ask for `Secure`.
+ * Returns false anywhere `window` is absent — a server render never writes
+ * this cookie, so the conservative answer costs nothing there.
+ */
+export function isSecureContext(): boolean {
+  return typeof window !== "undefined" && window.location?.protocol === "https:";
 }
 
 /** Serialize the expiry form used on sign-out. */
@@ -135,8 +151,11 @@ export function resolveOrg(opts: {
   const cookiePresent = typeof cookieValue === "string" && cookieValue.length > 0;
   const staleCookie = cookiePresent && !cookieUsable;
 
+  // `has()` already rejects 0 and negatives (no installation carries such an
+  // id), but the bound is stated explicitly to match parseOrgCookie rather
+  // than leaving the two paths validating the same value differently.
   const paramId = orgParam == null || orgParam === "" ? NaN : Number(orgParam);
-  if (Number.isSafeInteger(paramId) && has(paramId)) {
+  if (Number.isSafeInteger(paramId) && paramId > 0 && has(paramId)) {
     return { installationId: paramId, source: "param", staleCookie };
   }
 
@@ -162,4 +181,10 @@ export function resolveOrg(opts: {
 export function clearOrgCookie(): void {
   if (typeof document === "undefined") return;
   document.cookie = serializeClearedOrgCookie();
+}
+
+/** Write the selection from the browser, with `Secure` when the page is HTTPS. */
+export function writeOrgCookie(userId: string, installationId: number): void {
+  if (typeof document === "undefined") return;
+  document.cookie = serializeOrgCookie(userId, installationId, { secure: isSecureContext() });
 }

--- a/packages/dashboard/lib/org-selection.ts
+++ b/packages/dashboard/lib/org-selection.ts
@@ -22,6 +22,17 @@ export const ORG_COOKIE = "mw_org";
 /** One year. The user-scoping check below is what bounds validity, not this. */
 const MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
 
+/**
+ * Scoped to the dashboard, the only place that reads it — `Path=/` sent it to
+ * every route including `/api/*`, which no handler needs.
+ *
+ * Used by BOTH the set and the clear on purpose. A browser matches a deletion
+ * on name + path, so a clear written at a different path silently does nothing
+ * and the cookie survives sign-out. Keeping the two on one constant is what
+ * stops them drifting; the test below asserts it.
+ */
+const COOKIE_PATH = "/dashboard";
+
 export interface OrgCookie {
   /** GitHub user id that made the selection. */
   userId: string;
@@ -76,7 +87,7 @@ export function serializeOrgCookie(
 ): string {
   const value = encodeURIComponent(`${userId}:${installationId}`);
   const secure = opts.secure ? "; Secure" : "";
-  return `${ORG_COOKIE}=${value}; Path=/; Max-Age=${MAX_AGE_SECONDS}; SameSite=Lax${secure}`;
+  return `${ORG_COOKIE}=${value}; Path=${COOKIE_PATH}; Max-Age=${MAX_AGE_SECONDS}; SameSite=Lax${secure}`;
 }
 
 /**
@@ -90,7 +101,7 @@ export function isSecureContext(): boolean {
 
 /** Serialize the expiry form used on sign-out. */
 export function serializeClearedOrgCookie(): string {
-  return `${ORG_COOKIE}=; Path=/; Max-Age=0; SameSite=Lax`;
+  return `${ORG_COOKIE}=; Path=${COOKIE_PATH}; Max-Age=0; SameSite=Lax`;
 }
 
 /**

--- a/packages/dashboard/lib/org-selection.ts
+++ b/packages/dashboard/lib/org-selection.ts
@@ -47,6 +47,21 @@ export interface ResolvedOrg {
 /**
  * Serialize the selection with its owning user.
  *
+ * Deliberately NOT `HttpOnly`: the client sets this via `document.cookie`, and
+ * JavaScript cannot write an `HttpOnly` cookie — the assignment fails silently,
+ * so adding the flag here would break the write path with no error anywhere.
+ * Making it `HttpOnly` means moving the write to a route handler, i.e. a
+ * network round-trip on a UI toggle.
+ *
+ * The trade is small because the value is not a secret and is not trusted: it
+ * holds a user id and an installation id, both already visible in the UI, and
+ * `resolveOrg` re-validates it against the session user and that account's
+ * installations on every read. Script that could forge this cookie already has
+ * the session, and the worst it can select is an org the victim can see anyway.
+ *
+ * `Secure` is likewise omitted so self-hosted deployments on plain HTTP keep
+ * working; `SameSite=Lax` is the meaningful protection here.
+ *
  * The user id is stored alongside the installation id so a cookie belonging
  * to a different account is inert by construction. Clearing on sign-out is
  * hygiene; this check is the guarantee — a missed clear, a shared browser, or

--- a/packages/dashboard/lib/org-selection.ts
+++ b/packages/dashboard/lib/org-selection.ts
@@ -1,0 +1,150 @@
+/**
+ * #498 — organization selection that survives navigation.
+ *
+ * The selection used to live only in the URL (`?org=`), so any link that
+ * forgot the param reset it. `DashboardShell` fell back to `installations[0]`
+ * — the personal account for most users — which turned a missing param into a
+ * wrong answer rather than a visible one.
+ *
+ * The selection now lives in a cookie. A cookie rather than localStorage
+ * because the dashboard is server-rendered (`force-dynamic` throughout): a
+ * client-only store would render the default org on the server and correct it
+ * on hydration, flipping the switcher on every page load. The server can read
+ * a cookie, so the right org renders on first paint.
+ *
+ * The URL param stays as a deep-link override and wins when present, so a
+ * shared link switches the reader to the org it names.
+ */
+
+/** Cookie name. Short and namespaced; the value is not a secret. */
+export const ORG_COOKIE = "mw_org";
+
+/** One year. The user-scoping check below is what bounds validity, not this. */
+const MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+export interface OrgCookie {
+  /** GitHub user id that made the selection. */
+  userId: string;
+  /** Selected GitHub App installation id. */
+  installationId: number;
+}
+
+/** Where the resolved selection came from. */
+export type OrgSource = "param" | "cookie" | "default" | "none";
+
+export interface ResolvedOrg {
+  /** Installation id to treat as active, or null when there is nothing to show. */
+  installationId: number | null;
+  source: OrgSource;
+  /**
+   * True when a cookie was present but unusable — wrong user, revoked
+   * installation, or malformed. The caller drops it instead of letting a
+   * value that can never resolve keep being read on every navigation.
+   */
+  staleCookie: boolean;
+}
+
+/**
+ * Serialize the selection with its owning user.
+ *
+ * The user id is stored alongside the installation id so a cookie belonging
+ * to a different account is inert by construction. Clearing on sign-out is
+ * hygiene; this check is the guarantee — a missed clear, a shared browser, or
+ * a cookie left by a previous account cannot select an org for someone else.
+ */
+export function serializeOrgCookie(userId: string, installationId: number): string {
+  const value = encodeURIComponent(`${userId}:${installationId}`);
+  return `${ORG_COOKIE}=${value}; Path=/; Max-Age=${MAX_AGE_SECONDS}; SameSite=Lax`;
+}
+
+/** Serialize the expiry form used on sign-out. */
+export function serializeClearedOrgCookie(): string {
+  return `${ORG_COOKIE}=; Path=/; Max-Age=0; SameSite=Lax`;
+}
+
+/**
+ * Parse a cookie value. Returns null for anything malformed — an unparseable
+ * cookie is treated as absent, never as a partial selection.
+ */
+export function parseOrgCookie(raw: string | undefined | null): OrgCookie | null {
+  if (!raw) return null;
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    return null;
+  }
+  // rsplit on the LAST colon: GitHub user ids are numeric today, but a colon
+  // in the user portion must not silently shift the installation id.
+  const sep = decoded.lastIndexOf(":");
+  if (sep <= 0) return null;
+  const userId = decoded.slice(0, sep);
+  const installationId = Number(decoded.slice(sep + 1));
+  if (!userId || !Number.isSafeInteger(installationId) || installationId <= 0) {
+    return null;
+  }
+  return { userId, installationId };
+}
+
+/**
+ * Resolve which installation is active.
+ *
+ * Precedence: `?org=` param → cookie → first installation.
+ *
+ * Both the param and the cookie are validated against the installations the
+ * user actually has. Access can be revoked between visits, so a stored id can
+ * name an org this account can no longer see; resolving it anyway would show
+ * one org's label over another org's data.
+ *
+ * `source` is returned so the caller can tell a real selection from a
+ * fallback. Falling back to the first installation is right for someone who
+ * has never chosen — it is only misleading when it silently replaces a
+ * selection that has become invalid, and `staleCookie` marks that case.
+ */
+export function resolveOrg(opts: {
+  orgParam: string | null | undefined;
+  cookieValue: string | undefined | null;
+  userId: string | undefined | null;
+  installations: readonly { id: number }[];
+}): ResolvedOrg {
+  const { orgParam, cookieValue, userId, installations } = opts;
+  const has = (id: number) => installations.some((i) => i.id === id);
+
+  const cookie = parseOrgCookie(cookieValue);
+  const cookieUsable = !!cookie && !!userId && cookie.userId === userId && has(cookie.installationId);
+  // Keyed on the raw value, not the parsed one: a cookie that is present but
+  // unparseable is just as stale as one naming a revoked installation, and
+  // testing `cookie` here would leave a corrupt value to be re-read on every
+  // navigation forever. Covers the wrong-user (shared browser), revoked-access
+  // and malformed cases alike.
+  const cookiePresent = typeof cookieValue === "string" && cookieValue.length > 0;
+  const staleCookie = cookiePresent && !cookieUsable;
+
+  const paramId = orgParam == null || orgParam === "" ? NaN : Number(orgParam);
+  if (Number.isSafeInteger(paramId) && has(paramId)) {
+    return { installationId: paramId, source: "param", staleCookie };
+  }
+
+  if (cookieUsable) {
+    return { installationId: cookie!.installationId, source: "cookie", staleCookie: false };
+  }
+
+  const first = installations[0]?.id;
+  if (first === undefined) {
+    return { installationId: null, source: "none", staleCookie };
+  }
+  return { installationId: first, source: "default", staleCookie };
+}
+
+/**
+ * Drop the selection. Called on sign-out so one account's choice does not
+ * greet the next person on a shared browser.
+ *
+ * This is hygiene, not the correctness boundary — `resolveOrg` ignores a
+ * cookie whose user does not match the session, so a missed clear is inert.
+ * Belt and braces, deliberately.
+ */
+export function clearOrgCookie(): void {
+  if (typeof document === "undefined") return;
+  document.cookie = serializeClearedOrgCookie();
+}


### PR DESCRIPTION
Closes #498

## The bug

Selecting an org (e.g. `mergewatch`) and opening a review's detail page silently reverted the switcher to the personal account.

Org selection lived only in the URL:

```ts
const activeInstallationId = orgParam ? Number(orgParam) : installations[0]?.id ?? 0;
// DashboardShell.tsx:32
```

Any link omitting `?org=` reset it, and the fallback to `installations[0]` turned the omission into a *wrong answer* rather than a visible one. A helper that appends the param already existed (`Sidenav.tsx:108`) — wired to exactly one place, the sidenav's nav items. Eight other links bypassed it, including the review link and "Back to dashboard".

The review itself renders correctly (fetched by `repoFullName`, gated by `canAccessRepo`), so the page looked right while the sidebar said something else. The damage landed on the next click: "Back to dashboard" then showed the personal org's reviews under the belief you were in `mergewatch`.

## The fix

Threading the param through those eight links would not hold — the ninth link added next month forgets it again, which is how this one arrived. The selection now persists in a cookie, so navigation cannot lose it.

**A cookie, not localStorage.** The dashboard is server-rendered throughout (`force-dynamic`). A client-only store renders the default on the server and corrects it on hydration, flipping the switcher on every page load — a more visible version of the bug being fixed. The layout reads the cookie server-side, so first paint is already correct.

**Precedence:** `?org=` → cookie → first installation. A shared deep link still wins and refreshes the cookie, so it switches the reader to the org it names.

**User-scoped.** The cookie carries the GitHub user id that wrote it and is ignored when it does not match the session. Sign-out clears it at all four `signOut()` call sites — but that is hygiene, not the boundary: a missed clear, a shared browser, or a cookie from a previous account is inert by construction.

**Validated, not trusted.** Both the param and the cookie are checked against the installations the account currently has. Access can be revoked between visits, and resolving a stale id would show one org's label over another org's data. A cookie that cannot resolve is dropped rather than re-read on every navigation forever.

## Tests

19 new tests in `lib/org-selection.test.ts`. All resolution logic is pure and lives in `lib/`, which is where this package's vitest config can reach (`include: ["lib/**/*.test.ts"]`, node env) — components stay thin wiring.

Covered: precedence ordering, user mismatch (shared browser), revoked installation, malformed and undecodable cookie values, colon-in-user-id, missing session user, empty installations, and stale-param-with-valid-cookie.

One of these caught a real bug during development: a present-but-unparseable cookie was not marked stale, so a corrupt value would have been re-read forever. Fixed in the same commit.

## Verification

- `pnpm run build` — 12/12 green
- `pnpm run test` — 21/21 tasks; dashboard suite 152 tests across 9 files
- `npx tsc --noEmit` in `packages/dashboard` — clean (note: the dashboard has no `typecheck` script, so `pnpm run typecheck` skips it — ran directly)

## Not included

`packages/dashboard/tsconfig.tsbuildinfo` is tracked in git and churns on every build. Left out of this diff deliberately; worth un-tracking separately.