### PR TITLE
fix(dashboard): resolve the org from the cookie on pages, not just the shell

### DIFF
--- a/packages/dashboard/app/dashboard/analytics/page.tsx
+++ b/packages/dashboard/app/dashboard/analytics/page.tsx
@@ -3,6 +3,7 @@ export const dynamic = "force-dynamic";
 import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
+import { resolveActiveInstallation } from "@/lib/server-org";
 import {
   fetchUserInstallations,
   TokenExpiredError,
@@ -35,9 +36,11 @@ export default async function AnalyticsPage({ searchParams }: AnalyticsPageProps
   if (installations.length === 0) redirect("/onboarding");
 
   const orgParam = typeof params.org === "string" ? params.org : undefined;
-  const activeInstallation = orgParam
-    ? installations.find((i) => String(i.id) === orgParam) ?? installations[0]
-    : installations[0];
+  const activeInstallation = await resolveActiveInstallation({
+    installations,
+    orgParam,
+    githubUserId: (session as any).githubUserId as string | undefined,
+  });
 
   const installationId = String(activeInstallation.id);
 

--- a/packages/dashboard/app/dashboard/billing/page.tsx
+++ b/packages/dashboard/app/dashboard/billing/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { fetchUserInstallations, TokenExpiredError } from "@/lib/github-repos";
+import { resolveActiveInstallation } from "@/lib/server-org";
 import BillingClient from "./BillingClient";
 
 interface BillingPageProps {
@@ -35,9 +36,11 @@ export default async function BillingPage({ searchParams }: BillingPageProps) {
   if (installations.length === 0) redirect("/onboarding");
 
   const orgParam = typeof params.org === "string" ? params.org : undefined;
-  const activeInstallation = orgParam
-    ? installations.find((i) => String(i.id) === orgParam) ?? installations[0]
-    : installations[0];
+  const activeInstallation = await resolveActiveInstallation({
+    installations,
+    orgParam,
+    githubUserId: (session as any).githubUserId as string | undefined,
+  });
 
   const setupComplete = params.setup === "complete";
 

--- a/packages/dashboard/app/dashboard/page.tsx
+++ b/packages/dashboard/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { getDashboardStore } from "@/lib/store";
+import { resolveActiveInstallation } from "@/lib/server-org";
 import {
   fetchUserInstallations,
   fetchAccessibleRepoNames,
@@ -48,9 +49,11 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
 
   // Determine active installation from ?org= param or default to first
   const orgParam = typeof params.org === "string" ? params.org : undefined;
-  const activeInstallation = orgParam
-    ? installations.find((i) => String(i.id) === orgParam) ?? installations[0]
-    : installations[0];
+  const activeInstallation = await resolveActiveInstallation({
+    installations,
+    orgParam,
+    githubUserId: (session as any).githubUserId as string | undefined,
+  });
 
   const installationId = String(activeInstallation.id);
 

--- a/packages/dashboard/app/dashboard/repositories/page.tsx
+++ b/packages/dashboard/app/dashboard/repositories/page.tsx
@@ -3,6 +3,7 @@ export const dynamic = "force-dynamic";
 import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
+import { resolveActiveInstallation } from "@/lib/server-org";
 import {
   fetchUserInstallations,
   checkInstallationAdmin,
@@ -38,9 +39,11 @@ export default async function RepositoriesPage({
   if (installations.length === 0) redirect("/onboarding");
 
   const orgParam = typeof params.org === "string" ? params.org : undefined;
-  const activeInstallation = orgParam
-    ? installations.find((i) => String(i.id) === orgParam) ?? installations[0]
-    : installations[0];
+  const activeInstallation = await resolveActiveInstallation({
+    installations,
+    orgParam,
+    githubUserId: (session as any).githubUserId as string | undefined,
+  });
 
   const installationId = String(activeInstallation.id);
   const isAdmin = await checkInstallationAdmin(accessToken, activeInstallation);

--- a/packages/dashboard/app/dashboard/reviews/page.tsx
+++ b/packages/dashboard/app/dashboard/reviews/page.tsx
@@ -3,6 +3,7 @@ export const dynamic = "force-dynamic";
 import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
+import { resolveActiveInstallation } from "@/lib/server-org";
 import {
   fetchUserInstallations,
   fetchAccessibleRepoNames,
@@ -36,9 +37,11 @@ export default async function ReviewsPage({ searchParams }: ReviewsPageProps) {
   if (installations.length === 0) redirect("/onboarding");
 
   const orgParam = typeof params.org === "string" ? params.org : undefined;
-  const activeInstallation = orgParam
-    ? installations.find((i) => String(i.id) === orgParam) ?? installations[0]
-    : installations[0];
+  const activeInstallation = await resolveActiveInstallation({
+    installations,
+    orgParam,
+    githubUserId: (session as any).githubUserId as string | undefined,
+  });
 
   const installationId = String(activeInstallation.id);
 

--- a/packages/dashboard/app/dashboard/settings/api-keys/page.tsx
+++ b/packages/dashboard/app/dashboard/settings/api-keys/page.tsx
@@ -3,6 +3,7 @@ export const dynamic = "force-dynamic";
 import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
+import { resolveActiveInstallation } from "@/lib/server-org";
 import {
   fetchUserInstallations,
   checkInstallationAdmin,
@@ -31,9 +32,11 @@ export default async function ApiKeysPage({ searchParams }: Props) {
   if (installations.length === 0) redirect("/onboarding");
 
   const orgParam = typeof params.org === "string" ? params.org : undefined;
-  const activeInstallation = orgParam
-    ? installations.find((i) => String(i.id) === orgParam) ?? installations[0]
-    : installations[0];
+  const activeInstallation = await resolveActiveInstallation({
+    installations,
+    orgParam,
+    githubUserId: (session as any).githubUserId as string | undefined,
+  });
 
   const isAdmin = await checkInstallationAdmin(accessToken, activeInstallation);
 

--- a/packages/dashboard/app/dashboard/settings/custom-agents/page.tsx
+++ b/packages/dashboard/app/dashboard/settings/custom-agents/page.tsx
@@ -3,6 +3,7 @@ export const dynamic = "force-dynamic";
 import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
+import { resolveActiveInstallation } from "@/lib/server-org";
 import {
   fetchUserInstallations,
   fetchInstallationRepos,
@@ -36,9 +37,11 @@ export default async function CustomAgentsPage({ searchParams }: Props) {
   if (installations.length === 0) redirect("/onboarding");
 
   const orgParam = typeof params.org === "string" ? params.org : undefined;
-  const activeInstallation = orgParam
-    ? installations.find((i) => String(i.id) === orgParam) ?? installations[0]
-    : installations[0];
+  const activeInstallation = await resolveActiveInstallation({
+    installations,
+    orgParam,
+    githubUserId: (session as any).githubUserId as string | undefined,
+  });
 
   const isAdmin = await checkInstallationAdmin(accessToken, activeInstallation);
 

--- a/packages/dashboard/app/dashboard/settings/page.tsx
+++ b/packages/dashboard/app/dashboard/settings/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { fetchUserInstallations, checkInstallationAdmin, TokenExpiredError } from "@/lib/github-repos";
+import { resolveActiveInstallation } from "@/lib/server-org";
 import SettingsForm from "@/components/SettingsForm";
 
 interface SettingsPageProps {
@@ -30,9 +31,11 @@ export default async function SettingsPage({ searchParams }: SettingsPageProps) 
   if (installations.length === 0) redirect("/onboarding");
 
   const orgParam = typeof params.org === "string" ? params.org : undefined;
-  const activeInstallation = orgParam
-    ? installations.find((i) => String(i.id) === orgParam) ?? installations[0]
-    : installations[0];
+  const activeInstallation = await resolveActiveInstallation({
+    installations,
+    orgParam,
+    githubUserId: (session as any).githubUserId as string | undefined,
+  });
 
   const isAdmin = await checkInstallationAdmin(accessToken, activeInstallation);
 

--- a/packages/dashboard/lib/server-org.ts
+++ b/packages/dashboard/lib/server-org.ts
@@ -1,0 +1,38 @@
+import { cookies } from "next/headers";
+import { ORG_COOKIE, resolveOrg } from "./org-selection";
+
+/**
+ * #498 — resolve the active installation for a server-rendered page.
+ *
+ * Every dashboard page carried its own copy of this:
+ *
+ *     const activeInstallation = orgParam
+ *       ? installations.find((i) => String(i.id) === orgParam) ?? installations[0]
+ *       : installations[0];
+ *
+ * Eight copies, none of which read the cookie. The first pass at #498 fixed
+ * `DashboardShell`, so the switcher held the selection while every page below
+ * it still resolved from the param alone and fell back to the personal
+ * account — the switcher said one org and the content showed another, which
+ * is worse than the original bug because it looks authoritative.
+ *
+ * Kept as one helper so the next page added cannot reintroduce the split.
+ * The decision itself lives in `resolveOrg`, which is pure and unit-tested;
+ * this is the glue that gives it the cookie.
+ */
+export async function resolveActiveInstallation<T extends { id: number }>(opts: {
+  installations: readonly T[];
+  orgParam: string | undefined;
+  githubUserId: string | undefined;
+}): Promise<T> {
+  const cookieValue = (await cookies()).get(ORG_COOKIE)?.value;
+  const { installationId } = resolveOrg({
+    orgParam: opts.orgParam,
+    cookieValue,
+    userId: opts.githubUserId,
+    installations: opts.installations,
+  });
+  return (
+    opts.installations.find((i) => i.id === installationId) ?? opts.installations[0]
+  );
+}


### PR DESCRIPTION
Part of #498. Follow-up to #499, which fixed half the problem.

## What went wrong

#499 made the switcher hold the selected org. It did not touch how pages resolve it — and every dashboard page carries its own copy:

```ts
const activeInstallation = orgParam
  ? installations.find((i) => String(i.id) === orgParam) ?? installations[0]
  : installations[0];
```

Eight copies, none reading the cookie. So after #499 the nav showed `mergewatch` while the content below it fell back to the personal account.

**That is worse than the original bug.** Before, the wrong org was at least labelled correctly. Now the label is right and the data is wrong, which reads as authoritative.

## My miss

I fixed the display and never checked that the data resolved separately. The grep that found the eight broken links searched `href=`; it could not have surfaced these, and I did not run a second one against `installations[0]`. That one-line grep is what found all eight in seconds afterwards.

## The fix

A single `resolveActiveInstallation()` helper in `lib/server-org.ts` reads the cookie and defers to `resolveOrg` — the same pure precedence the shell uses, so nav and content cannot disagree.

All eight pages call it: `page`, `reviews`, `analytics`, `billing`, `repositories`, `settings`, `settings/api-keys`, `settings/custom-agents`.

Kept as one helper rather than eight corrected copies, because eight copies is exactly how this happened. `grep -rn 'installations\[0\]' app/` now returns nothing.

`app/dashboard/accuracy/page.tsx` is unchanged — it's a redirect that forwards `?org=` and lands on a page that now resolves correctly.

## Tests

No new ones, deliberately. The decision belongs to `resolveOrg` and is covered by 25 existing tests; this only routes the pages into it. Adding assertions here would test that eight call sites call a function, not that the function is right.

- `pnpm run build` — 12/12
- dashboard suite — 158 tests, 9 files
- `npx tsc --noEmit` — clean

## Verification needed

The gate will select 0 fixtures again (dashboard-only, nothing observes it), and this package's vitest is node-env so the pages aren't reachable. Needs a human click: select an org, then walk Reviews → Analytics → Settings and confirm the *content* follows, not just the nav.