### PR TITLE
fix(dashboard): an unconfigured trace table now fails visibly

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,6 +34,9 @@ export type {
   ReviewStats,
   RepoStats,
 } from './storage/dashboard-types.js';
+// A class, so a value export — `export type` would compile and then fail at
+// runtime on the `instanceof` the API route uses to name this failure (#494).
+export { TraceStorageNotConfiguredError } from './storage/dashboard-types.js';
 
 // ─── Agents ─────────────────────────────────────────────────────────────────
 export {

--- a/packages/core/src/storage/dashboard-types.ts
+++ b/packages/core/src/storage/dashboard-types.ts
@@ -15,6 +15,34 @@ import type { InstallationItem, InstallationSettings, ReviewItem, InstallationFP
   ReviewTraceItem,
 } from '../types/db.js';
 
+/**
+ * #494 — trace storage is not configured for this deployment.
+ *
+ * Thrown rather than returning `null` because the two are not the same answer:
+ * `null` means "this review has no trail", and a reader shown that when the
+ * dashboard could not look is being told something false. The trail panel
+ * already renders the distinction — a failed fetch says "could not be loaded",
+ * a null says "none was recorded" — so the only thing missing was a store that
+ * stopped conflating them.
+ *
+ * Found in production: a review whose trace existed in DynamoDB the whole time
+ * displayed "No decision trail was recorded" because the table name never
+ * reached the runtime (#497). Nothing in any log said otherwise.
+ *
+ * SaaS only in practice. The Postgres implementation queries its table
+ * directly, so a missing table already throws — there is no name to forget.
+ */
+export class TraceStorageNotConfiguredError extends Error {
+  constructor() {
+    super(
+      'Review trace storage is not configured — no trace table name was provided. ' +
+      'On Amplify, check that DYNAMODB_TABLE_REVIEW_TRACES is set AND declared in ' +
+      'the next.config.js env block; a var absent from that block does not exist at runtime.',
+    );
+    this.name = 'TraceStorageNotConfiguredError';
+  }
+}
+
 // ─── Paginated result wrapper ───────────────────────────────────────────────
 
 export interface PaginatedResult<T> {
@@ -85,6 +113,8 @@ export interface IDashboardReviewStore {
     repoFullName: string,
     prNumberCommitSha: string,
   ): Promise<ReviewTraceItem | null>;
+  // #494 — `null` means "this review has no trail". An implementation that
+  // cannot look at all must throw TraceStorageNotConfiguredError instead.
 
   /** Set or clear feedback on a review. */
   updateFeedback(

--- a/packages/dashboard/app/api/reviews/[id]/trace/route.ts
+++ b/packages/dashboard/app/api/reviews/[id]/trace/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { getDashboardStore } from "@/lib/store";
 import { canAccessRepo, TokenExpiredError } from "@/lib/access-control";
+import { TraceStorageNotConfiguredError } from "@mergewatch/core";
 
 /** Parse the [id] param into repoFullName + prNumberCommitSha. */
 function parseReviewId(id: string): { repoFullName: string; prNumberCommitSha: string } | null {
@@ -28,6 +29,10 @@ function parseReviewId(id: string): { repoFullName: string; prNumberCommitSha: s
  *
  * `{ trace: null }` is a legitimate answer, not an error: reviews from before
  * #471 have no ledger, and a trace write is best-effort by design.
+ *
+ * #494 — "the store cannot look" is NOT that answer. An unconfigured trace
+ * table now throws, so it surfaces as a 500 the panel renders as "could not be
+ * loaded" instead of borrowing the reassuring "none was recorded".
  */
 export async function GET(
   req: NextRequest,
@@ -75,6 +80,16 @@ export async function GET(
     const trace = await store.reviews.getReviewTrace(repoFullName, prNumberCommitSha);
     return NextResponse.json({ trace });
   } catch (err) {
+    // #494 — separated from the generic branch so the operator log names a
+    // deployment problem as one, instead of burying it in a stack trace that
+    // looks like a transient DynamoDB fault.
+    if (err instanceof TraceStorageNotConfiguredError) {
+      console.error("[trace] %s", err.message);
+      return NextResponse.json(
+        { error: "Trace storage is not configured" },
+        { status: 500 },
+      );
+    }
     console.error(
       "[trace] getReviewTrace failed for %s %s:",
       repoFullName,

--- a/packages/storage-dynamo/src/dashboard-store.test.ts
+++ b/packages/storage-dynamo/src/dashboard-store.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { QueryCommand } from '@aws-sdk/lib-dynamodb';
 import { DynamoDashboardReviewStore, REVIEWS_BY_CREATED_AT_INDEX } from './dashboard-store.js';
+import { TraceStorageNotConfiguredError } from '@mergewatch/core';
 
 /** Build a review item; createdAt is the field under test everywhere here. */
 function review(repoFullName: string, prNumber: number, createdAt: string, over: Record<string, unknown> = {}) {
@@ -265,5 +266,67 @@ describe('DynamoDashboardReviewStore.listReviews — legacy fallback', () => {
     const { items } = await reviews.listReviews(['octo/repo'], 10, 'not-base64-json');
     expect(items).toHaveLength(1);
     expect(gsiQueries(client)).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #494 — an unconfigured trace table must not read as "no trail"
+// ---------------------------------------------------------------------------
+
+describe('DynamoDashboardReviewStore.getReviewTrace — trace storage configuration', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('throws when no trace table is configured — never returns null', async () => {
+    const send = vi.fn();
+    // Third constructor arg omitted: the deployment has no trace table name.
+    const store = new DynamoDashboardReviewStore({ send } as any, 'test-reviews');
+
+    await expect(store.getReviewTrace('o/r', '1#abc')).rejects.toThrow(
+      TraceStorageNotConfiguredError,
+    );
+    // The distinction that matters: it must fail before querying, and it must
+    // not quietly answer "no trace" the way it did through the whole of #494.
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('logs the cause so an operator can find it without reading the source', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const store = new DynamoDashboardReviewStore({ send: vi.fn() } as any, 'test-reviews');
+
+    await store.getReviewTrace('o/r', '1#abc').catch(() => {});
+
+    expect(errSpy).toHaveBeenCalled();
+    expect(String(errSpy.mock.calls[0][0])).toContain('DYNAMODB_TABLE_REVIEW_TRACES');
+  });
+
+  it('returns null — not an error — when configured and the trace is genuinely absent', async () => {
+    // The case the throw must stay distinguishable from.
+    const send = vi.fn(async () => ({ Item: undefined }));
+    const store = new DynamoDashboardReviewStore({ send } as any, 'test-reviews', 'test-traces');
+
+    await expect(store.getReviewTrace('o/r', '1#abc')).resolves.toBeNull();
+    expect(send).toHaveBeenCalled();
+  });
+
+  it('returns the trace when configured and present', async () => {
+    const send = vi.fn(async () => ({
+      Item: { repoFullName: 'o/r', prNumberCommitSha: '1#abc', outcomes: [] },
+    }));
+    const store = new DynamoDashboardReviewStore({ send } as any, 'test-reviews', 'test-traces');
+
+    const trace = await store.getReviewTrace('o/r', '1#abc');
+    expect(trace).toMatchObject({ repoFullName: 'o/r', outcomes: [] });
+  });
+
+  it('an empty-string table name counts as unconfigured, not as a table named ""', async () => {
+    const send = vi.fn();
+    const store = new DynamoDashboardReviewStore({ send } as any, 'test-reviews', '');
+
+    await expect(store.getReviewTrace('o/r', '1#abc')).rejects.toThrow(
+      TraceStorageNotConfiguredError,
+    );
+    expect(send).not.toHaveBeenCalled();
   });
 });

--- a/packages/storage-dynamo/src/dashboard-store.ts
+++ b/packages/storage-dynamo/src/dashboard-store.ts
@@ -25,7 +25,7 @@ import type {
   OrgCustomAgent,
   ReviewTraceItem,
 } from '@mergewatch/core';
-import { DEFAULT_INSTALLATION_SETTINGS as DEFAULTS, sanitizeOrgCustomAgents, usableOutcomes } from '@mergewatch/core';
+import { DEFAULT_INSTALLATION_SETTINGS as DEFAULTS, sanitizeOrgCustomAgents, usableOutcomes, TraceStorageNotConfiguredError } from '@mergewatch/core';
 
 // ─── Installation store ─────────────────────────────────────────────────────
 
@@ -171,8 +171,13 @@ export class DynamoDashboardReviewStore implements IDashboardReviewStore {
     private readonly tableName: string,
     /**
      * #472 — the filter-trace table (#471). Optional here so a deployment
-     * provisioned before #471 still serves the rest of the dashboard;
-     * getReviewTrace reports "no trace" rather than throwing.
+     * provisioned before #471 still serves the rest of the dashboard.
+     *
+     * #494 — when it is unset, getReviewTrace THROWS rather than reporting
+     * "no trace". Reporting no trace was a lie the reader could not detect:
+     * it is the same answer a review with nothing filtered produces, so a
+     * misconfiguration read as a clean result. Everything else on the
+     * dashboard still works; only the trail fails, and it fails visibly.
      */
     private readonly tracesTable?: string,
   ) {}
@@ -485,7 +490,16 @@ export class DynamoDashboardReviewStore implements IDashboardReviewStore {
     repoFullName: string,
     prNumberCommitSha: string,
   ): Promise<ReviewTraceItem | null> {
-    if (!this.tracesTable) return null;
+    if (!this.tracesTable) {
+      // Logged as well as thrown: the throw reaches the reader as "could not
+      // be loaded", but an operator needs to find the cause without reading
+      // the source. This is the signal that was missing for the whole of #494.
+      console.error(
+        '[trace] no trace table configured — the decision trail cannot be served. ' +
+        'Set DYNAMODB_TABLE_REVIEW_TRACES and declare it in the next.config.js env block.',
+      );
+      throw new TraceStorageNotConfiguredError();
+    }
     const result = await this.client.send(
       new GetCommand({
         TableName: this.tracesTable,


### PR DESCRIPTION
Closes #494

## The bug

A review whose trace existed in DynamoDB the whole time displayed **"No decision trail was recorded for this review."**

```ts
if (!this.tracesTable) return null;   // storage-dynamo/src/dashboard-store.ts:488
```

`null` is also the correct answer for a review with no trail — so a misconfiguration and a clean result rendered identically, and nothing in any log said otherwise. #497 restored the table name; this removes that class of failure's ability to hide.

## The fix

`getReviewTrace` throws `TraceStorageNotConfiguredError` when no table is configured.

**Nothing else needed to change.** `FilterTrail.tsx` already distinguishes three states — a failed fetch renders *"The decision trail could not be loaded"* (line 47), `null` renders *"No decision trail was recorded"* (line 65). The store conflating "cannot look" with "nothing to see" was the entire bug.

Two logging additions, because the point of the issue is operator visibility: the store logs at the throw site, and the API route gains a dedicated catch so the log names a deployment problem rather than burying it in a stack trace that reads like a transient DynamoDB fault.

## Correction to the issue's premise

The issue says the env var "was never set on either Amplify app". It **was** set on both — it was missing from the `env` block in `next.config.js`, so it never reached the runtime.

That distinction picks the fix. The issue's option 2 (a startup warning when the var is unset) **would not have caught this**: a check reading the same environment the console shows would have seen the var present. Only a failure in the runtime, where the value was actually absent, surfaces it. Hence option 1.

The error message names both halves so the next person doesn't repeat the diagnosis.

## Scope

**Postgres is untouched and already correct** — it queries `review_traces` directly, so a missing table throws. No table name to forget, which is why this is SaaS-only.

The core export is a **value** export, not `export type` — the route narrows on `instanceof`, which a type-only export compiles past and then fails at runtime.

## Tests

5 new, in `storage-dynamo/src/dashboard-store.test.ts`:

- unconfigured throws, **and does not query** — it must fail before reaching DynamoDB
- logs a cause naming `DYNAMODB_TABLE_REVIEW_TRACES`
- **returns `null` when configured and the trace is genuinely absent** — the case the throw has to stay distinguishable from
- returns the trace when present
- an empty-string table name counts as unconfigured, not a table literally named `""`

- `pnpm run build` — 12/12
- `pnpm run typecheck` — 20/20
- `pnpm run test` — 21/21

## Verification

The E2E gate will select 0 fixtures (no fixture observes dashboard config). The behaviour is covered by unit tests at the store boundary, which is where the bug was — but the end-to-end proof would be unsetting the var in dev and seeing "could not be loaded" instead of "none recorded".