### PR TITLE
fix(release): publish images only from a gated release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,20 +1,22 @@
 name: Publish Docker Images
 
+# Images ship ONLY from a release (#513).
+#
+# There used to be a `push: branches: [main]` trigger, and it meant `latest`
+# tracked main: every qualifying merge published straight to GHCR with no
+# graded suite, no manual verification and no approval. The release gate was
+# built so images could not ship without those, and this trigger meant it never
+# stood between a merge and the registry — while `release-gate.yml`'s own header
+# claimed the opposite.
+#
+# `release: published` alone is NOT sufficient, and that is not obvious: GitHub
+# does not dispatch workflow triggers for events created with the default
+# GITHUB_TOKEN, so a release cut by the gate fires nothing. That is exactly how
+# v0.6.0 shipped a tag and a release with no images. The gate therefore invokes
+# this workflow EXPLICITLY — an API call is not an event, so the suppression
+# does not apply — and waits for it. The trigger below stays for releases a
+# human publishes by hand.
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'packages/core/**'
-      - 'packages/server/**'
-      - 'packages/dashboard/**'
-      - 'packages/storage-postgres/**'
-      - 'packages/storage-dynamo/**'
-      - 'packages/llm-*/**'
-      - 'Dockerfile'
-      - 'Dockerfile.dashboard'
-      - 'docker-compose.yml'
-      - 'pnpm-lock.yaml'
-      - '.github/workflows/docker-publish.yml'
   release:
     types: [published]
   workflow_dispatch:
@@ -60,8 +62,16 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ matrix.image }}
+          # `latest` now means "the most recent gated release", not "current
+          # main". `is_default_branch` is false for a tag ref, so leaving it
+          # would have published no `latest` at all once the push trigger went —
+          # a silent regression for anyone following the README.
+          #
+          # This comment sits ABOVE `tags:` on purpose: the value is a literal
+          # block scalar, so a `#` line indented under it is not a comment, it
+          # is a tag definition handed to metadata-action.
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=sha,prefix=
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1,8 +1,14 @@
 # Release Gate (#505).
 #
 # Cuts a release ONLY after the graded fixture suite passes and a human has
-# verified the manual set. Nothing reaches a `v*` tag — and therefore nothing
-# reaches docker-publish, which fires on `release: published` — without both.
+# verified the manual set. Nothing reaches a `v*` tag without both — and since
+# #513, nothing reaches GHCR without a tag either.
+#
+# That second half used to be asserted here and was false: docker-publish also
+# fired on every qualifying push to main, so `latest` tracked main with no gate
+# at all, while the gate's own release published nothing (GITHUB_TOKEN
+# suppresses the `release: published` event). Images now ship only from the
+# `release` job below, which dispatches docker-publish explicitly and waits.
 #
 # This replaces the previous ordering, where `fixtures/release-suite.yml`
 # triggered ON `push: tags: v*`. That validated a release that already existed:
@@ -328,8 +334,42 @@ jobs:
           # HEAD, which is only correct as long as nothing moved it.
           git tag -a "$VERSION" -m "$VERSION" "$SHA"
           git push origin "$VERSION"
-          # Publishing the release is what triggers docker-publish.
           gh release create "$VERSION" \
             --title "$VERSION" \
             --target "$SHA" \
             --notes-file /tmp/notes.md
+
+      - name: Publish the images
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -uo pipefail
+          # Publishing the release does NOT trigger docker-publish, however much
+          # it looks like it should: GitHub suppresses workflow triggers for
+          # events created with the default GITHUB_TOKEN, to stop workflows
+          # recursing. v0.6.0 shipped a tag and a GitHub release with no images
+          # because of exactly this, and nothing reported it (#513).
+          #
+          # An explicit dispatch is an API call, not an event, so the
+          # suppression does not apply.
+          gh workflow run docker-publish.yml --ref "$VERSION"
+
+          # And then WAIT. Fire-and-forget would mean a release whose images
+          # failed to build still reports success — the same shape of hole this
+          # whole gate exists to close.
+          echo "waiting for docker-publish on $VERSION"
+          RUN_ID=""
+          for _ in $(seq 1 30); do
+            sleep 10
+            RUN_ID="$(gh run list --workflow=docker-publish.yml --branch "$VERSION" \
+              --limit 1 --json databaseId --jq '.[0].databaseId // empty')"
+            [ -n "$RUN_ID" ] && break
+          done
+          if [ -z "$RUN_ID" ]; then
+            echo "::error::docker-publish never started for $VERSION — the release exists without images"
+            exit 1
+          fi
+          echo "docker-publish run: $RUN_ID"
+          gh run watch "$RUN_ID" --exit-status --interval 20
+          echo "images published for $VERSION"

--- a/README.md
+++ b/README.md
@@ -316,12 +316,21 @@ gh release create v0.2.0 --generate-notes
 
 Images are published to `ghcr.io/mergewatch/mergewatch` and `ghcr.io/mergewatch/mergewatch-dashboard`:
 
+Every tag comes from a **released** version. Nothing is published from `main`.
+
 | Tag | When |
 |-----|------|
 | `0.2.0` | On GitHub Release for `v0.2.0` |
 | `0.2` | On GitHub Release for `v0.2.x` (tracks latest patch) |
-| `latest` | On every push to `main` |
-| `abc1234` | On every push to `main` (commit SHA) |
+| `latest` | The most recent release |
+| `abc1234` | The released commit's SHA |
+
+> **`latest` changed meaning after `v0.6.0`.** It used to be built on every push to
+> `main`, so it could carry code that had not been through the release gate —
+> no graded fixture suite, no manual verification, no approval. It now tracks
+> the most recent release, like the version tags. If you were relying on `latest`
+> to follow `main`, build from source instead; pinning an exact version in
+> `docker-compose.yml` (as the shipped file does) is unaffected.
 
 ### Upgrading self-hosted
 

--- a/packages/lambda/src/docker-publish.test.ts
+++ b/packages/lambda/src/docker-publish.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import yaml from 'js-yaml';
+
+/**
+ * #513 — images ship only from a gated release.
+ *
+ * `docker-publish.yml` used to carry a `push: branches: [main]` trigger, so
+ * `latest` tracked main: every qualifying merge went straight to GHCR with no
+ * graded suite, no manual verification and no approval. Meanwhile the gate's
+ * OWN release published nothing, because GitHub suppresses workflow triggers
+ * for events created with the default GITHUB_TOKEN — v0.6.0 shipped a tag and
+ * a GitHub release with no images at all.
+ *
+ * Both halves were the inverse of what release-gate.yml claimed, and neither
+ * failed anything: the ungated path succeeded, and the gated path silently did
+ * nothing. Which is why the invariants are asserted here rather than trusted to
+ * a comment.
+ */
+const WORKFLOWS = resolve(__dirname, '../../../.github/workflows');
+const load = (f: string) => yaml.load(readFileSync(resolve(WORKFLOWS, f), 'utf8')) as any;
+
+const docker = load('docker-publish.yml');
+const gate = load('release-gate.yml');
+
+describe('docker-publish — only a release ships images', () => {
+  it('has no push trigger', () => {
+    // The whole defect. A push trigger means the registry is reachable without
+    // passing the gate, no matter what the gate does.
+    expect(docker.on.push).toBeUndefined();
+  });
+
+  it('still publishes on a release someone cuts by hand', () => {
+    expect(docker.on.release?.types).toEqual(['published']);
+  });
+
+  it('is dispatchable, which is how the gate reaches it', () => {
+    // Not optional: `release: published` never fires for a release the gate
+    // creates, so this is the only path that works for an automated release.
+    expect(docker.on).toHaveProperty('workflow_dispatch');
+  });
+
+  it('tags `latest` from a version tag, not from the default branch', () => {
+    // Removing the push trigger while leaving `enable={{is_default_branch}}`
+    // would publish NO `latest` at all — a tag ref is never the default branch.
+    // Silent, and it breaks the README's own pull instructions.
+    const tags = String(
+      docker.jobs['build-and-push'].steps.find((s: any) => s.id === 'meta').with.tags,
+    );
+    expect(tags).not.toMatch(/is_default_branch/);
+    expect(tags).toMatch(/refs\/tags\/v/);
+  });
+
+  it('still emits the semver tags a pinned deployment needs', () => {
+    // docker-compose.yml pins an exact version rather than `latest`.
+    const tags = String(
+      docker.jobs['build-and-push'].steps.find((s: any) => s.id === 'meta').with.tags,
+    );
+    expect(tags).toMatch(/type=semver,pattern=\{\{version\}\}/);
+    expect(tags).toMatch(/type=semver,pattern=\{\{major\}\}\.\{\{minor\}\}/);
+  });
+});
+
+describe('release gate — the release actually ships images', () => {
+  const publish = () =>
+    gate.jobs.release.steps.find((s: any) => s.name === 'Publish the images');
+
+  it('dispatches docker-publish explicitly rather than relying on the event', () => {
+    // GITHUB_TOKEN suppression means publishing the release fires nothing. An
+    // explicit dispatch is an API call, not an event, so it is exempt.
+    expect(publish(), 'the publish step is gone').toBeDefined();
+    expect(publish().run).toMatch(/gh workflow run docker-publish\.yml --ref "\$VERSION"/);
+  });
+
+  it('waits for the images, and fails the release if they fail', () => {
+    // Fire-and-forget would let a release whose images never built report
+    // success — the same hole the gate exists to close, one step further on.
+    expect(publish().run).toMatch(/gh run watch .*--exit-status/);
+  });
+
+  it('fails when docker-publish never starts at all', () => {
+    // The dispatch can be accepted and still produce no run. Silence there
+    // would be indistinguishable from success.
+    expect(publish().run).toMatch(/never started/);
+  });
+
+  it('publishes only after the release exists', () => {
+    // docker-publish resolves the version from the tag, so dispatching before
+    // the tag is pushed would build the wrong thing — or nothing.
+    const steps = gate.jobs.release.steps.map((s: any) => s.name);
+    expect(steps.indexOf('Publish the images')).toBeGreaterThan(
+      steps.indexOf('Tag and release'),
+    );
+  });
+
+  it('no longer claims docker-publish is reached by the release event', () => {
+    // The header asserted a guarantee that was false in both directions. A
+    // comment cannot be tested, but its absence can.
+    const header = readFileSync(resolve(WORKFLOWS, 'release-gate.yml'), 'utf8').slice(0, 2000);
+    expect(header).not.toMatch(/which fires on `release: published`/);
+  });
+});


### PR DESCRIPTION
Closes #513.

`v0.6.0` was released cleanly — graded suite, approval, tag, GitHub release — and **published no images**. Meanwhile `latest` had been tracking `main` the whole time. Both are the inverse of what `release-gate.yml` claimed, and **neither failed anything**: the ungated path succeeded, and the gated path silently did nothing.

## Two independent causes

**The registry was reachable without the gate.** `docker-publish.yml` carried `push: branches: [main]`, so every qualifying merge published `latest` + sha straight to GHCR — no suite, no manual verification, no approval. `latest` is what self-hosters pull. The gate has never stood between a merge and the registry.

**And the gated path could not publish.** GitHub does not dispatch workflow triggers for events created with the default `GITHUB_TOKEN`, to stop workflows recursing. The release job creates the release with exactly that token, so `release: published` never fires when it matters.

## What changes

| | before | after |
|---|---|---|
| push to `main` | publishes `latest` + sha | **nothing** |
| gate cuts a release | publishes nothing | publishes `latest`, `0.6.0`, `0.6`, sha |
| human cuts a release by hand | publishes | publishes (trigger kept) |

The release job now dispatches `docker-publish` **explicitly** — an API call is not an event, so the suppression does not apply — and **waits** with `gh run watch --exit-status`. Fire-and-forget would let a release whose images failed to build still report success: the same hole, one step further on. It also fails loudly if the run never starts, since silence there is indistinguishable from success.

`latest` moves to the version tag rather than the default branch. Leaving `enable={{is_default_branch}}` while dropping the push trigger would have published **no `latest` at all** — a tag ref is never the default branch — which is silent and breaks the README's own pull instructions.

I also deleted the header comment asserting the guarantee that was false in both directions, and there is a test that fails if it comes back.

## Behaviour change for self-hosters

`latest` now means **the most recent release**, not "current `main`". `docker-compose.yml` pins an exact version and is unaffected; the README documents the change and points anyone who wanted `main` at building from source.

## The tests caught a bug in this PR

The explanation I wrote for the `latest` rule sat *inside* `tags: |` — a literal block scalar, so four `#` lines were being handed to `metadata-action` as tag definitions:

```
× tags `latest` from a version tag, not from the default branch
```

Moved above the key, with a note saying why. That is the kind of thing that would have shipped and then been debugged from a confusing registry state.

11 assertions across the two workflows: no push trigger, dispatchability (not optional — it is the only path that works for an automated release), `latest` sourced from the tag, semver tags preserved for pinned deployments, explicit dispatch, the wait, the never-started guard, and ordering after the tag exists.

```
Test Files  2 passed (2)
     Tests  31 passed (31)
```

`build` / `typecheck` / `test` green across the workspace.

## v0.6.0 images

Backfilled by dispatching `docker-publish` at the `v0.6.0` tag — [run 33122823134](https://github.com/mergewatch/mergewatch.ai/actions/runs/33122823134), both images succeeded. That ran the workflow **as it exists at the tag**, so it produced `0.6.0`, `0.6` and the sha but **not** `latest`; `latest` still points at the last ungated `main` build and will move on the next release under this PR's rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp