### PR TITLE
fix(core): check runs update instead of accumulating

### DIFF
--- a/packages/core/src/github/client.test.ts
+++ b/packages/core/src/github/client.test.ts
@@ -1026,6 +1026,107 @@ describe('check run summary size guard (#468)', () => {
   });
 });
 
+describe('check runs update rather than accumulate (#526)', () => {
+  /** An octokit whose `listForRef` returns `runs` and records create/update calls. */
+  function stub(runs: Array<{ id: number }>, listThrows = false) {
+    const created: Array<Record<string, unknown>> = [];
+    const updated: Array<Record<string, unknown>> = [];
+    const octokit = {
+      checks: {
+        listForRef: vi.fn(async (args: Record<string, unknown>) => {
+          if (listThrows) throw new Error('boom');
+          return { data: { check_runs: runs }, args };
+        }),
+        create: vi.fn(async (a: Record<string, unknown>) => { created.push(a); return { data: {} }; }),
+        update: vi.fn(async (a: Record<string, unknown>) => { updated.push(a); return { data: {} }; }),
+      },
+    } as unknown as Octokit;
+    return { octokit, created, updated };
+  }
+
+  const completed = {
+    status: 'completed' as const,
+    conclusion: 'success' as const,
+    title: 'ok',
+    summary: 'done',
+  };
+
+  it('updates the existing run instead of creating a second one', async () => {
+    // The reported symptom: a later clean review added a green run BESIDE the
+    // red one, so the PR never looked resolved.
+    const { octokit, created, updated } = stub([{ id: 4242 }]);
+    await createCheckRun(octokit, 'o', 'r', 'sha', completed);
+
+    expect(created).toHaveLength(0);
+    expect(updated).toHaveLength(1);
+    expect(updated[0].check_run_id).toBe(4242);
+    expect(updated[0].conclusion).toBe('success');
+  });
+
+  it('creates when no run exists for this sha', async () => {
+    const { octokit, created, updated } = stub([]);
+    await createCheckRun(octokit, 'o', 'r', 'sha', completed);
+
+    expect(updated).toHaveLength(0);
+    expect(created).toHaveLength(1);
+    expect(created[0].head_sha).toBe('sha');
+  });
+
+  it('falls back to create when the lookup fails — never worse than before', async () => {
+    // A transient list failure must not skip the write. Routing it to the
+    // outer catch would make this optimisation strictly worse than not
+    // having it.
+    const { octokit, created } = stub([], true);
+    await createCheckRun(octokit, 'o', 'r', 'sha', completed);
+
+    expect(created).toHaveLength(1);
+  });
+
+  it('the in_progress -> completed pair touches ONE run, not two', async () => {
+    // Every caller follows this pair. Before #526 it left a run stuck at
+    // in_progress on every PR, forever.
+    let runs: Array<{ id: number }> = [];
+    const created: Array<Record<string, unknown>> = [];
+    const updated: Array<Record<string, unknown>> = [];
+    const octokit = {
+      checks: {
+        listForRef: vi.fn(async () => ({ data: { check_runs: runs } })),
+        create: vi.fn(async (a: Record<string, unknown>) => {
+          created.push(a); runs = [{ id: 7 }]; return { data: {} };
+        }),
+        update: vi.fn(async (a: Record<string, unknown>) => { updated.push(a); return { data: {} }; }),
+      },
+    } as unknown as Octokit;
+
+    await createCheckRun(octokit, 'o', 'r', 'sha', {
+      status: 'in_progress', title: 'Review in progress', summary: 'working',
+    });
+    await createCheckRun(octokit, 'o', 'r', 'sha', completed);
+
+    expect(created).toHaveLength(1);
+    expect(updated).toHaveLength(1);
+    expect(updated[0].check_run_id).toBe(7);
+    expect(updated[0].status).toBe('completed');
+  });
+
+  it('scopes the lookup by stage name so dev and prod do not collide', async () => {
+    const { octokit } = stub([{ id: 1 }]);
+    await createCheckRun(octokit, 'o', 'r', 'sha', completed, 'dev');
+
+    const list = (octokit.checks.listForRef as unknown as { mock: { calls: any[][] } }).mock.calls[0][0];
+    expect(list.check_name).toContain('dev');
+    expect(list.filter).toBe('latest');
+  });
+
+  it('still clamps an oversized summary on the update path', async () => {
+    const { octokit, updated } = stub([{ id: 9 }]);
+    await createCheckRun(octokit, 'o', 'r', 'sha', { ...completed, summary: 's'.repeat(70_000) });
+
+    const output = updated[0].output as { summary: string };
+    expect(output.summary.length).toBeLessThanOrEqual(65_535);
+  });
+});
+
 describe('inline comment body size guard (#468)', () => {
   const changedFiles = ['src/app.ts'];
 

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -432,26 +432,61 @@ export async function createCheckRun(
   },
   stage?: Stage,
 ): Promise<void> {
+  const name = checkRunName(stage);
+  const body = {
+    status: params.status,
+    ...(params.conclusion && { conclusion: params.conclusion }),
+    ...(params.detailsUrl && { details_url: params.detailsUrl }),
+    output: {
+      title: params.title,
+      // The catch below is deliberately non-fatal, so an oversized summary
+      // fails invisibly today — the check run simply never appears.
+      // Truncating before the call is the only way this stays visible.
+      summary: clampField(params.summary, MAX_CHECK_SUMMARY),
+    },
+  };
+
   try {
-    await octokit.checks.create({
-      owner,
-      repo,
-      head_sha: headSha,
-      name: checkRunName(stage),
-      status: params.status,
-      ...(params.conclusion && { conclusion: params.conclusion }),
-      ...(params.detailsUrl && { details_url: params.detailsUrl }),
-      output: {
-        title: params.title,
-        // The catch below is deliberately non-fatal, so an oversized summary
-        // fails invisibly today — the check run simply never appears.
-        // Truncating before the call is the only way this stays visible.
-        summary: clampField(params.summary, MAX_CHECK_SUMMARY),
-      },
-    });
+    // #526 — UPDATE the run for this (sha, name) if one exists.
+    //
+    // This function's contract has always said "create or update", and every
+    // caller follows the documented `in_progress` → `completed` pair. But it
+    // only ever called `checks.create`, and `create` never replaces: it adds.
+    // So every review left a second run behind, stuck at `in_progress`
+    // forever, and a re-review added another pair. A user reported the visible
+    // half — a PR that never returns to a clean state after findings are
+    // withdrawn, because the green run sits *beside* the red one rather than
+    // replacing it.
+    //
+    // `filter: 'latest'` returns the most recent run per name, which is the
+    // one we own for this SHA. Stage-scoped names keep dev and prod separate.
+    //
+    // The lookup has its OWN catch: a failure here must fall through to
+    // `create`, which is exactly today's behaviour. Letting it reach the outer
+    // catch would skip the write entirely and make a transient list failure
+    // strictly worse than not having this optimisation at all.
+    let target: { id: number } | undefined;
+    try {
+      const existing = await octokit.checks.listForRef({
+        owner,
+        repo,
+        ref: headSha,
+        check_name: name,
+        filter: 'latest',
+      });
+      target = existing.data.check_runs[0];
+    } catch (lookupErr) {
+      console.warn('Check-run lookup failed for %s/%s@%s — creating instead:', owner, repo, headSha, lookupErr);
+    }
+
+    if (target) {
+      await octokit.checks.update({ owner, repo, check_run_id: target.id, name, ...body });
+      return;
+    }
+    await octokit.checks.create({ owner, repo, head_sha: headSha, name, ...body });
   } catch (err) {
     // Non-critical — don't fail the review if the check run fails.
-    console.warn('Failed to create check run for %s/%s@%s:', owner, repo, headSha, err);
+    console.warn('Failed to write check run for %s/%s@%s:', owner, repo, headSha, err);
   }
 }
 


### PR DESCRIPTION
Part of #526 (Phase 1 of 2). Milestone **v0.6.1**.

## The bug is in the gap between the docstring and the code

`createCheckRun` has always been documented as:

> **Create or update** a GitHub Check Run on a specific commit.
> Call once with status `in_progress` when the review starts, then again with status `completed` + conclusion when done.

Every caller follows that pair faithfully. But the implementation only ever called `checks.create`, and **create never replaces — it adds.**

So the documented usage produced **two check runs per review**, one stuck at `in_progress` forever, and a re-review added another pair. The reporter saw the downstream half: a PR that never returns to a clean state after findings are withdrawn, because the green run sits *beside* the red one rather than replacing it.

Neither symptom ever failed anything. They just accumulated.

## The fix

Look up the latest run for `(headSha, name)` and **update** it; create only when none exists.

```
before:  in_progress → create #1        completed → create #2   (#1 pends forever)
after:   in_progress → create #1        completed → update #1
```

Stage-scoped names (`checkRunName(stage)`) keep dev and prod separate, which is also what makes scoping the lookup by name safe.

## A bug in my own first draft, and the test that catches it

The lookup initially sat inside the existing outer `try`. That meant a transient `listForRef` failure would be swallowed and **no check run written at all** — strictly worse than not having the optimisation.

It now has its own `catch` and falls through to `create`, which is exactly today's behaviour. `falls back to create when the lookup fails — never worse than before` is the guard.

## Tests

Six new. Verified they fail against create-only:

```
× updates the existing run instead of creating a second one
× the in_progress -> completed pair touches ONE run, not two
× still clamps an oversized summary on the update path
  Tests  3 failed | 112 passed (115)
```

The pre-existing #468 summary-clamp test stubs **only** `checks.create`, so it now exercises the fallback path for free — useful back-compat evidence that a caller with no `listForRef` still gets a check run.

## Explicitly not in this PR

**The merge-score floor stays.** `reviewer.ts:2620`/`:2679` deliberately hold the score at 3 when the orchestrator raised criticals and post-orchestrator filtering dropped them all. That guard exists because of #382/#385 — silent filtering produced a confident 5/5 on a PR with a self-admitted SQL injection. "All the criticals vanished, therefore clean" is exactly the inference that caused it.

**Phase 2** closes the other half of #526: inline comment threads for withdrawn findings are never resolved (`deleteReviewComment` and `minimizeComment` appear nowhere; `resolveReviewThread` fires only on a human `/resolve`). Separated because it touches user-visible threads and needs care not to close a human's.

`build` / `typecheck` / `test` green — 21/21 tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp