### PR TITLE
fix(core): close our inline threads when a finding is withdrawn

### DIFF
--- a/packages/core/src/github/client.test.ts
+++ b/packages/core/src/github/client.test.ts
@@ -1146,6 +1146,40 @@ describe('withdrawn finding threads are closed (#526)', () => {
     expect(withdrawnThreadKey('src/app.ts', '  SQL Injection In The Query Builder  ')).toBe(KEY);
   });
 
+  it('leaves a thread alone when its comment list is truncated', async () => {
+    // >100 comments means the "ours alone" check answers a question about the
+    // first page, not the thread. A human reply at position 101 would be
+    // invisible and the thread resolved out from under them.
+    const t = thread();
+    (t.comments as Record<string, unknown>).pageInfo = { hasNextPage: true };
+    const { octokit, mutations } = stub([t]);
+
+    expect(await resolveWithdrawnFindingThreads(octokit, 'o', 'r', 7, new Set(), ours)).toBe(0);
+    expect(mutations).toEqual([]);
+  });
+
+  it('still resolves when the comment list is explicitly NOT truncated', async () => {
+    const t = thread();
+    (t.comments as Record<string, unknown>).pageInfo = { hasNextPage: false };
+    const { octokit, mutations } = stub([t]);
+
+    expect(await resolveWithdrawnFindingThreads(octokit, 'o', 'r', 7, new Set(), ours)).toBe(1);
+    expect(mutations).toEqual(['T1']);
+  });
+
+  it('leaves a thread alone when the title cannot be parsed', async () => {
+    // An empty title yields a key in no active set, which reads as
+    // "withdrawn" — resolving a thread we failed to identify. This is the
+    // exact mistake the original fixture made by accident.
+    const t = thread({
+      comments: { nodes: [{ databaseId: 40, body: `${bodyFor('x').split('**')[0]}### 🔴 wrong format`, author: { login: ours } }] },
+    });
+    const { octokit, mutations } = stub([t]);
+
+    expect(await resolveWithdrawnFindingThreads(octokit, 'o', 'r', 7, new Set(), ours)).toBe(0);
+    expect(mutations).toEqual([]);
+  });
+
   it('survives a lookup failure without throwing', async () => {
     const octokit = { graphql: vi.fn(async () => { throw new Error('boom'); }) } as unknown as Octokit;
     expect(await resolveWithdrawnFindingThreads(octokit, 'o', 'r', 7, new Set(), ours)).toBe(0);

--- a/packages/core/src/github/client.test.ts
+++ b/packages/core/src/github/client.test.ts
@@ -9,6 +9,8 @@ import {
   postReviewComment,
   updateReviewComment,
   createCheckRun,
+  resolveWithdrawnFindingThreads,
+  withdrawnThreadKey,
   enforceCommentBodyLimit,
   MAX_COMMENT_BODY,
   parseRepoConfigYaml,
@@ -1023,6 +1025,152 @@ describe('check run summary size guard (#468)', () => {
     // summary fails invisibly — truncating is what keeps the check visible.
     expect(output.summary.length).toBeLessThanOrEqual(65_535);
     expect(output.summary.endsWith('…')).toBe(true);
+  });
+});
+
+describe('withdrawn finding threads are closed (#526)', () => {
+  const ours = 'mergewatch[bot]';
+  const TITLE = 'SQL injection in the query builder';
+
+  /**
+   * Build the comment body with the REAL emitter rather than a hand-written
+   * string. A hand-rolled fixture passed while using `### 🔴 title`, which
+   * `extractInlineCommentTitle` does not match (it wants `**🔴 title**`) — so
+   * the test asserted against a format the product never produces.
+   */
+  function bodyFor(title: string): string {
+    const [c] = buildInlineComments(
+      [{ file: 'src/app.ts', line: 10, severity: 'critical' as const, title, description: 'd', suggestion: '' }],
+      ['src/app.ts'],
+    );
+    return c.body;
+  }
+
+  function thread(over: Record<string, unknown> = {}) {
+    return {
+      id: 'T1',
+      isResolved: false,
+      path: 'src/app.ts',
+      comments: {
+        nodes: [{ databaseId: 11, body: bodyFor(TITLE), author: { login: ours } }],
+      },
+      ...over,
+    };
+  }
+
+  function stub(threads: unknown[]) {
+    const replies: unknown[] = [];
+    const mutations: string[] = [];
+    const octokit = {
+      graphql: vi.fn(async (q: string, vars: Record<string, unknown>) => {
+        if (q.includes('resolveReviewThread')) { mutations.push(String(vars.threadId)); return {}; }
+        return { repository: { pullRequest: { reviewThreads: { nodes: threads } } } };
+      }),
+      pulls: {
+        createReplyForReviewComment: vi.fn(async (a: unknown) => { replies.push(a); return { data: { id: 1 } }; }),
+      },
+    } as unknown as Octokit;
+    return { octokit, replies, mutations };
+  }
+
+  const KEY = withdrawnThreadKey('src/app.ts', TITLE);
+
+  it('the fixture body is one the extractor actually understands', () => {
+    // Guards the guard: if this is empty, every assertion below passes
+    // vacuously because nothing ever matches an active key.
+    expect(extractInlineCommentTitle(bodyFor(TITLE))).toBe(TITLE);
+  });
+
+  it('resolves a thread whose finding is no longer raised', async () => {
+    const { octokit, replies, mutations } = stub([thread()]);
+    const n = await resolveWithdrawnFindingThreads(octokit, 'o', 'r', 7, new Set(), ours);
+
+    expect(n).toBe(1);
+    expect(mutations).toEqual(['T1']);
+    expect(replies).toHaveLength(1);
+  });
+
+  it('leaves a thread alone while its finding is still raised', async () => {
+    const { octokit, mutations } = stub([thread()]);
+    const n = await resolveWithdrawnFindingThreads(octokit, 'o', 'r', 7, new Set([KEY]), ours);
+
+    expect(n).toBe(0);
+    expect(mutations).toEqual([]);
+  });
+
+  it('never closes a thread a human has replied in', async () => {
+    // The one that matters. Leaving a stale thread open is a nuisance;
+    // closing someone's live conversation is not.
+    const t = thread();
+    t.comments.nodes.push({ databaseId: 12, body: 'I disagree, here is why', author: { login: 'a-developer' } });
+    const { octokit, mutations } = stub([t]);
+
+    expect(await resolveWithdrawnFindingThreads(octokit, 'o', 'r', 7, new Set(), ours)).toBe(0);
+    expect(mutations).toEqual([]);
+  });
+
+  it('never closes a thread started by someone else', async () => {
+    const t = thread({ comments: { nodes: [{ databaseId: 20, body: 'a human review note', author: { login: 'a-developer' } }] } });
+    const { octokit, mutations } = stub([t]);
+
+    expect(await resolveWithdrawnFindingThreads(octokit, 'o', 'r', 7, new Set(), ours)).toBe(0);
+    expect(mutations).toEqual([]);
+  });
+
+  it('ignores a comment of ours that is not an inline finding', async () => {
+    // No marker — not something this pipeline posted as a finding.
+    const t = thread({ comments: { nodes: [{ databaseId: 21, body: 'just a note, no marker', author: { login: ours } }] } });
+    const { octokit, mutations } = stub([t]);
+
+    expect(await resolveWithdrawnFindingThreads(octokit, 'o', 'r', 7, new Set(), ours)).toBe(0);
+    expect(mutations).toEqual([]);
+  });
+
+  it('skips threads already resolved', async () => {
+    const { octokit, replies } = stub([thread({ isResolved: true })]);
+    expect(await resolveWithdrawnFindingThreads(octokit, 'o', 'r', 7, new Set(), ours)).toBe(0);
+    expect(replies).toEqual([]);
+  });
+
+  it('does nothing when our identity is unknown', async () => {
+    // Same guard as dismissStaleReviews (#418): without identity we cannot
+    // tell our threads from anyone else's, so we touch none.
+    const { octokit, mutations } = stub([thread()]);
+    expect(await resolveWithdrawnFindingThreads(octokit, 'o', 'r', 7, new Set(), null)).toBe(0);
+    expect(mutations).toEqual([]);
+  });
+
+  it('matches on path + title, not line — a shifted thread still matches', async () => {
+    // GitHub moves a thread's line as the PR changes. A line-sensitive key
+    // would silently stop matching after a push and resolve a live finding.
+    expect(withdrawnThreadKey('src/app.ts', '  SQL Injection In The Query Builder  ')).toBe(KEY);
+  });
+
+  it('survives a lookup failure without throwing', async () => {
+    const octokit = { graphql: vi.fn(async () => { throw new Error('boom'); }) } as unknown as Octokit;
+    expect(await resolveWithdrawnFindingThreads(octokit, 'o', 'r', 7, new Set(), ours)).toBe(0);
+  });
+
+  it('one stuck thread does not abandon the rest', async () => {
+    const t2 = { ...thread(), id: 'T2', comments: { nodes: [{ databaseId: 31, body: bodyFor('Second finding'), author: { login: ours } }] } };
+    const replies: unknown[] = [];
+    const mutations: string[] = [];
+    let first = true;
+    const octokit = {
+      graphql: vi.fn(async (q: string, vars: Record<string, unknown>) => {
+        if (q.includes('resolveReviewThread')) { mutations.push(String(vars.threadId)); return {}; }
+        return { repository: { pullRequest: { reviewThreads: { nodes: [thread(), t2] } } } };
+      }),
+      pulls: {
+        createReplyForReviewComment: vi.fn(async (a: unknown) => {
+          if (first) { first = false; throw new Error('rate limited'); }
+          replies.push(a); return { data: { id: 1 } };
+        }),
+      },
+    } as unknown as Octokit;
+
+    expect(await resolveWithdrawnFindingThreads(octokit, 'o', 'r', 7, new Set(), ours)).toBe(1);
+    expect(mutations).toEqual(['T2']);
   });
 });
 

--- a/packages/core/src/github/client.test.ts
+++ b/packages/core/src/github/client.test.ts
@@ -1185,22 +1185,60 @@ describe('withdrawn finding threads are closed (#526)', () => {
     expect(await resolveWithdrawnFindingThreads(octokit, 'o', 'r', 7, new Set(), ours)).toBe(0);
   });
 
-  it('one stuck thread does not abandon the rest', async () => {
-    const t2 = { ...thread(), id: 'T2', comments: { nodes: [{ databaseId: 31, body: bodyFor('Second finding'), author: { login: ours } }] } };
-    const replies: unknown[] = [];
-    const mutations: string[] = [];
-    let first = true;
+  it('the note never claims an outcome the resolve has not delivered', async () => {
+    // If the reply lands and the resolve throws, the thread stays OPEN. A note
+    // saying "resolving" would be a comment claiming a state that does not
+    // exist, on the thread it is wrong about.
+    const replies: Array<Record<string, unknown>> = [];
     const octokit = {
-      graphql: vi.fn(async (q: string, vars: Record<string, unknown>) => {
-        if (q.includes('resolveReviewThread')) { mutations.push(String(vars.threadId)); return {}; }
-        return { repository: { pullRequest: { reviewThreads: { nodes: [thread(), t2] } } } };
+      graphql: vi.fn(async (q: string) => {
+        if (q.includes('resolveReviewThread')) throw new Error('resolve failed');
+        return { repository: { pullRequest: { reviewThreads: { nodes: [thread()] } } } };
       }),
       pulls: {
-        createReplyForReviewComment: vi.fn(async (a: unknown) => {
-          if (first) { first = false; throw new Error('rate limited'); }
+        createReplyForReviewComment: vi.fn(async (a: Record<string, unknown>) => {
           replies.push(a); return { data: { id: 1 } };
         }),
       },
+    } as unknown as Octokit;
+
+    expect(await resolveWithdrawnFindingThreads(octokit, 'o', 'r', 7, new Set(), ours)).toBe(0);
+    expect(replies).toHaveLength(1);
+    const body = String(replies[0].body);
+    expect(body).toMatch(/no longer raising this finding/);
+    expect(body).not.toMatch(/resolving|resolved/i);
+  });
+
+  it('still resolves when the courtesy note fails to post', async () => {
+    // The note is a courtesy; resolving is the point.
+    const mutations: string[] = [];
+    const octokit = {
+      graphql: vi.fn(async (q: string, vars: Record<string, unknown>) => {
+        if (q.includes('resolveReviewThread')) { mutations.push(String(vars.threadId)); return {}; }
+        return { repository: { pullRequest: { reviewThreads: { nodes: [thread()] } } } };
+      }),
+      pulls: { createReplyForReviewComment: vi.fn(async () => { throw new Error('reply failed'); }) },
+    } as unknown as Octokit;
+
+    expect(await resolveWithdrawnFindingThreads(octokit, 'o', 'r', 7, new Set(), ours)).toBe(1);
+    expect(mutations).toEqual(['T1']);
+  });
+
+  it('one stuck thread does not abandon the rest', async () => {
+    // A thread whose RESOLVE fails must not stop the next one. (A failed
+    // courtesy note no longer aborts a thread at all — see the test above.)
+    const t2 = { ...thread(), id: 'T2', comments: { nodes: [{ databaseId: 31, body: bodyFor('Second finding'), author: { login: ours } }] } };
+    const mutations: string[] = [];
+    const octokit = {
+      graphql: vi.fn(async (q: string, vars: Record<string, unknown>) => {
+        if (q.includes('resolveReviewThread')) {
+          if (String(vars.threadId) === 'T1') throw new Error('stuck');
+          mutations.push(String(vars.threadId));
+          return {};
+        }
+        return { repository: { pullRequest: { reviewThreads: { nodes: [thread(), t2] } } } };
+      }),
+      pulls: { createReplyForReviewComment: vi.fn(async () => ({ data: { id: 1 } })) },
     } as unknown as Octokit;
 
     expect(await resolveWithdrawnFindingThreads(octokit, 'o', 'r', 7, new Set(), ours)).toBe(1);

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -1135,6 +1135,123 @@ export async function findReviewThreadIdForComment(
   return null;
 }
 
+/**
+ * Close our own inline threads whose finding is no longer being raised (#526).
+ *
+ * A withdrawn finding used to leave its inline comment open forever. Nothing
+ * deleted, minimised or resolved it — `resolveReviewThread` fired only when a
+ * human replied `/resolve`. Worse, a re-review deliberately skips re-posting a
+ * finding it still holds, so the original comment is the ONLY artifact: the PR
+ * kept showing unresolved blocking feedback for something the review no longer
+ * said.
+ *
+ * `activeKeys` is what the current review still raises, keyed by
+ * {@link withdrawnThreadKey}. Anything of ours not in that set is withdrawn.
+ *
+ * Three deliberate restrictions, all in the under-resolve direction — leaving a
+ * thread open is a nuisance, closing someone's live conversation is not:
+ *
+ *  1. **Only threads where every comment is ours.** One reply from anyone else
+ *     and we leave it alone; a human is using it.
+ *  2. **Only when we can prove identity.** No `selfLogin`, no resolving — the
+ *     same guard `dismissStaleReviews` uses, for the same reason (#418).
+ *  3. **Matched on path + title, never line.** GitHub shifts a thread's line as
+ *     the PR moves, so a line-sensitive key would silently stop matching after
+ *     a push. If a title genuinely recurs twice in one file, the still-raised
+ *     one keeps BOTH open, which is the safe way to be wrong.
+ *
+ * Returns the number of threads resolved. Never throws — a failure here must
+ * not fail a review that has otherwise succeeded.
+ */
+export function withdrawnThreadKey(path: string, title: string): string {
+  return `${path}::${title.trim().toLowerCase()}`;
+}
+
+export async function resolveWithdrawnFindingThreads(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  activeKeys: Set<string>,
+  selfLogin: string | null,
+  stage?: Stage,
+): Promise<number> {
+  if (!selfLogin) {
+    console.warn(
+      `[review] skipping withdrawn-thread cleanup for ${owner}/${repo}#${prNumber} — own App login unknown`,
+    );
+    return 0;
+  }
+  const want = normalizeLogin(selfLogin);
+  const marker = inlineMarker(stage);
+
+  const query = `
+    query WithdrawnThreads($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) {
+          reviewThreads(first: 100) {
+            nodes {
+              id
+              isResolved
+              path
+              comments(first: 100) {
+                nodes { databaseId body author { login } }
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+  type Thread = {
+    id: string;
+    isResolved: boolean;
+    path: string | null;
+    comments: { nodes: Array<{ databaseId: number; body: string; author: { login: string } | null }> };
+  };
+  type Resp = { repository: { pullRequest: { reviewThreads: { nodes: Thread[] } } } };
+
+  let threads: Thread[];
+  try {
+    const data = await octokit.graphql<Resp>(query, { owner, repo, number: prNumber });
+    threads = data.repository.pullRequest.reviewThreads.nodes;
+  } catch (err) {
+    console.warn('Withdrawn-thread lookup failed for %s/%s#%d:', owner, repo, prNumber, err);
+    return 0;
+  }
+
+  let resolved = 0;
+  for (const thread of threads) {
+    if (thread.isResolved || !thread.path) continue;
+
+    const comments = thread.comments.nodes;
+    const root = comments[0];
+    if (!root) continue;
+
+    // Ours, and ours alone.
+    if (normalizeLogin(root.author?.login) !== want) continue;
+    if (!root.body.includes(marker)) continue;
+    if (comments.some((c) => normalizeLogin(c.author?.login) !== want)) continue;
+
+    const key = withdrawnThreadKey(thread.path, extractInlineCommentTitle(root.body));
+    if (activeKeys.has(key)) continue;
+
+    try {
+      await replyToReviewComment(
+        octokit, owner, repo, prNumber, root.databaseId,
+        'This finding is no longer raised on the latest commit — resolving. '
+          + 'Reopen the thread if you think that is wrong.',
+      );
+      await resolveReviewThread(octokit, thread.id);
+      resolved++;
+    } catch (err) {
+      // One stuck thread must not abandon the rest.
+      console.warn('Failed to resolve withdrawn thread %s on %s/%s#%d:', thread.id, owner, repo, prNumber, err);
+    }
+  }
+  return resolved;
+}
+
 // ---------------------------------------------------------------------------
 // Repository config (.mergewatch.yml)
 // ---------------------------------------------------------------------------

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -1274,17 +1274,34 @@ export async function resolveWithdrawnFindingThreads(
     const key = withdrawnThreadKey(thread.path, title);
     if (activeKeys.has(key)) continue;
 
+    // The note must be true whether or not the resolve below succeeds. An
+    // earlier draft said "— resolving", which becomes a lie the instant
+    // resolveReviewThread throws: an OPEN thread carrying a comment claiming
+    // it was closed. Stating only what is already true removes that state by
+    // construction, rather than relying on the two calls both landing.
+    let noted = false;
     try {
       await replyToReviewComment(
         octokit, owner, repo, prNumber, root.databaseId,
-        'This finding is no longer raised on the latest commit — resolving. '
-          + 'Reopen the thread if you think that is wrong.',
+        'MergeWatch is no longer raising this finding on the latest commit.',
       );
+      noted = true;
+    } catch (err) {
+      // The note is a courtesy; resolving is the point. Carry on without it.
+      console.warn('Failed to note withdrawal on thread %s (%s/%s#%d):', thread.id, owner, repo, prNumber, err);
+    }
+
+    try {
       await resolveReviewThread(octokit, thread.id);
       resolved++;
     } catch (err) {
+      // Separate catch, and it says whether the note landed — "both failed"
+      // and "note posted, thread still open" need different follow-up.
       // One stuck thread must not abandon the rest.
-      console.warn('Failed to resolve withdrawn thread %s on %s/%s#%d:', thread.id, owner, repo, prNumber, err);
+      console.warn(
+        'Failed to resolve withdrawn thread %s (%s/%s#%d) — note %s:',
+        thread.id, owner, repo, prNumber, noted ? 'was posted' : 'was not posted', err,
+      );
     }
   }
   return resolved;

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -1190,11 +1190,13 @@ export async function resolveWithdrawnFindingThreads(
       repository(owner: $owner, name: $repo) {
         pullRequest(number: $number) {
           reviewThreads(first: 100) {
+            pageInfo { hasNextPage }
             nodes {
               id
               isResolved
               path
               comments(first: 100) {
+                pageInfo { hasNextPage }
                 nodes { databaseId body author { login } }
               }
             }
@@ -1207,14 +1209,31 @@ export async function resolveWithdrawnFindingThreads(
     id: string;
     isResolved: boolean;
     path: string | null;
-    comments: { nodes: Array<{ databaseId: number; body: string; author: { login: string } | null }> };
+    comments: {
+      pageInfo?: { hasNextPage: boolean };
+      nodes: Array<{ databaseId: number; body: string; author: { login: string } | null }>;
+    };
   };
-  type Resp = { repository: { pullRequest: { reviewThreads: { nodes: Thread[] } } } };
+  type Resp = {
+    repository: {
+      pullRequest: { reviewThreads: { pageInfo?: { hasNextPage: boolean }; nodes: Thread[] } };
+    };
+  };
 
   let threads: Thread[];
   try {
     const data = await octokit.graphql<Resp>(query, { owner, repo, number: prNumber });
-    threads = data.repository.pullRequest.reviewThreads.nodes;
+    const conn = data.repository.pullRequest.reviewThreads;
+    threads = conn.nodes;
+    if (conn.pageInfo?.hasNextPage) {
+      // Under-resolve, so not a safety problem — we simply see fewer threads
+      // than exist. Worth saying out loud so "why is that one still open" has
+      // an answer.
+      console.warn(
+        `[review] %s/%s#%d has more than 100 review threads — only the first page was considered`,
+        owner, repo, prNumber,
+      );
+    }
   } catch (err) {
     console.warn('Withdrawn-thread lookup failed for %s/%s#%d:', owner, repo, prNumber, err);
     return 0;
@@ -1224,16 +1243,35 @@ export async function resolveWithdrawnFindingThreads(
   for (const thread of threads) {
     if (thread.isResolved || !thread.path) continue;
 
-    const comments = thread.comments.nodes;
-    const root = comments[0];
+    const nodes = thread.comments.nodes;
+    const comments = { pageInfoTruncated: thread.comments.pageInfo?.hasNextPage === true };
+    const root = nodes[0];
     if (!root) continue;
 
     // Ours, and ours alone.
     if (normalizeLogin(root.author?.login) !== want) continue;
     if (!root.body.includes(marker)) continue;
-    if (comments.some((c) => normalizeLogin(c.author?.login) !== want)) continue;
 
-    const key = withdrawnThreadKey(thread.path, extractInlineCommentTitle(root.body));
+    // A truncated comment list means the "ours alone" check below is answering
+    // a question about the first 100 comments, not the thread. A human reply
+    // at position 101 would be invisible and the thread would be resolved out
+    // from under them. Cannot prove it is ours, so leave it.
+    if (comments.pageInfoTruncated) {
+      console.warn(
+        `[review] thread %s on %s/%s#%d has >100 comments — leaving it alone`,
+        thread.id, owner, repo, prNumber,
+      );
+      continue;
+    }
+    if (nodes.some((c) => normalizeLogin(c.author?.login) !== want)) continue;
+
+    // An unparseable title yields an empty key, which is in no active set and
+    // therefore reads as "withdrawn" — resolving a thread we failed to
+    // identify. Same rule as everywhere else here: no identity, no action.
+    const title = extractInlineCommentTitle(root.body);
+    if (!title.trim()) continue;
+
+    const key = withdrawnThreadKey(thread.path, title);
     if (activeKeys.has(key)) continue;
 
     try {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -120,6 +120,8 @@ export {
   findExistingBotComment,
   getCommentReactions,
   createCheckRun,
+  resolveWithdrawnFindingThreads,
+  withdrawnThreadKey,
   MERGEWATCH_CHECK_RUN_NAME,
   postReplyComment,
   fetchReviewCommentThread,

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -1052,9 +1052,16 @@ export async function handler(
       // raises. Without it a withdrawn critical leaves its comment open
       // forever, so the PR keeps showing blocking feedback the review itself
       // has already dropped. Never throws; returns 0 when it cannot act.
+      // Only findings with a usable file AND title contribute a key. An
+      // undefined field would yield `undefined::…`, which matches no real
+      // thread — so the live thread would look withdrawn and be resolved.
+      // Dropping the malformed entry keeps its thread OPEN, which is the safe
+      // direction to be wrong in.
       const activeThreadKeys = new Set(
-        (result.findings as Array<{ file: string; title: string }>)
-          .map((f) => withdrawnThreadKey(f.file, f.title)),
+        (result.findings as Array<{ file?: unknown; title?: unknown }>)
+          .filter((f) => typeof f.file === 'string' && f.file.length > 0
+            && typeof f.title === 'string' && f.title.trim().length > 0)
+          .map((f) => withdrawnThreadKey(f.file as string, f.title as string)),
       );
       const closed = await resolveWithdrawnFindingThreads(
         octokit, owner, repo, prNumber, activeThreadKeys, selfLogin, STAGE,

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -23,6 +23,8 @@ import {
   getCommentReactions,
   postReplyComment,
   createCheckRun,
+  resolveWithdrawnFindingThreads,
+  withdrawnThreadKey,
   runReviewPipeline,
   formatReviewComment,
   countBlockingCriticals,
@@ -1046,6 +1048,18 @@ export async function handler(
         : null;
       await dismissStaleReviews(octokit, owner, repo, prNumber, selfLogin);
       await submitPRReview(octokit, owner, repo, prNumber, reviewBody, reviewEvent, inlineComments);
+      // #526 — close our own inline threads for findings this review no longer
+      // raises. Without it a withdrawn critical leaves its comment open
+      // forever, so the PR keeps showing blocking feedback the review itself
+      // has already dropped. Never throws; returns 0 when it cannot act.
+      const activeThreadKeys = new Set(
+        (result.findings as Array<{ file: string; title: string }>)
+          .map((f) => withdrawnThreadKey(f.file, f.title)),
+      );
+      const closed = await resolveWithdrawnFindingThreads(
+        octokit, owner, repo, prNumber, activeThreadKeys, selfLogin, STAGE,
+      );
+      if (closed > 0) console.log(`[review] resolved ${closed} withdrawn finding thread(s)`);
     } catch (err) {
       console.warn('PR review submission failed — issue comment has the full review:', err);
     }

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -2,6 +2,7 @@ import type { ReviewJobPayload, IInstallationStore, IReviewStore, IGitHubAuthPro
 import {
   getPRDiff, getPRContext, addPRReaction, removePRReaction, postReviewComment, updateReviewComment,
   findExistingBotComment, getCommentReactions, createCheckRun,
+  resolveWithdrawnFindingThreads, withdrawnThreadKey,
   formatReviewComment, countBlockingCriticals, buildCheckTitle, isThrottleError, computeDiffStats, runReviewPipeline, shouldSkipPR, shouldSkipByRules, isAutoReviewOff, extractIncludePatterns,
   loadCategoryDisputeRates,
   filterDiff,
@@ -883,6 +884,18 @@ export async function processReviewJob(
         : null;
       await dismissStaleReviews(octokit, owner, repo, prNumber, selfLogin);
       await submitPRReview(octokit, owner, repo, prNumber, reviewBody, reviewEvent, inlineComments);
+      // #526 — close our own inline threads for findings this review no longer
+      // raises. Without it a withdrawn critical leaves its comment open
+      // forever, so the PR keeps showing blocking feedback the review itself
+      // has already dropped. Never throws; returns 0 when it cannot act.
+      const activeThreadKeys = new Set(
+        (result.findings as Array<{ file: string; title: string }>)
+          .map((f) => withdrawnThreadKey(f.file, f.title)),
+      );
+      const closed = await resolveWithdrawnFindingThreads(
+        octokit, owner, repo, prNumber, activeThreadKeys, selfLogin, STAGE,
+      );
+      if (closed > 0) console.log(`[review] resolved ${closed} withdrawn finding thread(s)`);
     } catch (err) {
       console.warn('PR review submission failed — issue comment has the full review:', err);
     }

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -888,9 +888,16 @@ export async function processReviewJob(
       // raises. Without it a withdrawn critical leaves its comment open
       // forever, so the PR keeps showing blocking feedback the review itself
       // has already dropped. Never throws; returns 0 when it cannot act.
+      // Only findings with a usable file AND title contribute a key. An
+      // undefined field would yield `undefined::…`, which matches no real
+      // thread — so the live thread would look withdrawn and be resolved.
+      // Dropping the malformed entry keeps its thread OPEN, which is the safe
+      // direction to be wrong in.
       const activeThreadKeys = new Set(
-        (result.findings as Array<{ file: string; title: string }>)
-          .map((f) => withdrawnThreadKey(f.file, f.title)),
+        (result.findings as Array<{ file?: unknown; title?: unknown }>)
+          .filter((f) => typeof f.file === 'string' && f.file.length > 0
+            && typeof f.title === 'string' && f.title.trim().length > 0)
+          .map((f) => withdrawnThreadKey(f.file as string, f.title as string)),
       );
       const closed = await resolveWithdrawnFindingThreads(
         octokit, owner, repo, prNumber, activeThreadKeys, selfLogin, STAGE,


### PR DESCRIPTION
Closes #526. Phase 2 of 2 — Phase 1 (#529) landed as `6beb8d4`. Milestone **v0.6.1**.

## The other half of the report

A withdrawn finding left its inline comment open **forever**:

- `pulls.deleteReviewComment` — does not exist in the codebase
- `minimizeComment` — does not exist
- `resolveReviewThread` — exists, but called from exactly one place: an explicit human `/resolve` reply

And a re-review *deliberately skips re-posting* a finding it still holds, so the original inline comment is the **only** artifact. The PR kept showing unresolved blocking feedback for something the review itself had already dropped — the reporter's "authors and reviewers are left unsure whether there is still real blocking feedback".

## What it does

`resolveWithdrawnFindingThreads` walks our own threads and closes the ones the current review no longer raises, **replying first** so the reason is discoverable rather than the thread silently vanishing.

## Three restrictions, all in the under-resolve direction

Leaving a stale thread open is a nuisance. Closing someone's live conversation is not.

| | |
|---|---|
| **Only threads where every comment is ours** | one reply from anyone else and we leave it alone |
| **Only when identity is provable** | no `selfLogin`, no resolving — the same guard `dismissStaleReviews` uses (#418) |
| **Matched on path + title, never line** | GitHub shifts a thread's line as the PR moves; a line-sensitive key would silently stop matching after a push and could resolve a **live** finding |

A title that genuinely recurs twice in one file keeps **both** threads open — the safe way to be wrong.

It never throws, and one stuck thread does not abandon the rest.

## A test that earned its place immediately

My first fixture hand-wrote the comment body as `### 🔴 title`. The real emitter produces `**🔴 title**`, which is what `extractInlineCommentTitle` matches.

**Every assertion still passed.** An unmatched title yields an empty string, which yields a key that is never in `activeKeys`, which means "withdrawn" — so the block was testing a format the product never produces, and would have gone green forever.

Two changes came out of that:

- the fixture now builds its body with **`buildInlineComments`**, the real emitter, so it cannot drift from what ships
- a `the fixture body is one the extractor actually understands` test guards the guard — without it the whole block passes vacuously

That is the same shape as #516 and fixtures#1076: something that looks like coverage and cannot fail.

## Tests

11 new, including the ones that must **not** fire — a human reply in the thread, a thread someone else started, a comment of ours without the marker, an already-resolved thread, and unknown identity.

```
Test Files  1 passed (1)
     Tests  126 passed (126)
```

`build` / `typecheck` / `test` green — 21/21 tasks.

## What #526 does not include, and why

**The score floor stays.** `reviewer.ts:2620`/`:2679` hold the score at 3 when the orchestrator raised criticals and filtering dropped them all — #382/#385's guard, which exists because silent filtering once produced a 5/5 on a self-admitted SQL injection.

**Withdrawn vs. Resolved in the rendered output** is v0.7.0 shaped. A withdrawn finding currently renders as "✅ Resolved on this commit", indistinguishable from one the author fixed (`review-delta.ts:108`). Tracked as P13 in `docs/review-quality-plan.md:158`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp