### PR TITLE
fix(core): discard a review whose head moved instead of publishing it

### DIFF
--- a/packages/core/src/github/client.test.ts
+++ b/packages/core/src/github/client.test.ts
@@ -9,6 +9,7 @@ import {
   postReviewComment,
   updateReviewComment,
   createCheckRun,
+  isStillPRHead,
   resolveWithdrawnFindingThreads,
   withdrawnThreadKey,
   enforceCommentBodyLimit,
@@ -1243,6 +1244,47 @@ describe('withdrawn finding threads are closed (#526)', () => {
 
     expect(await resolveWithdrawnFindingThreads(octokit, 'o', 'r', 7, new Set(), ours)).toBe(1);
     expect(mutations).toEqual(['T2']);
+  });
+});
+
+describe('a stale review is superseded, not published (#527)', () => {
+  function stub(headSha, { throws = false } = {}) {
+    return {
+      pulls: {
+        get: vi.fn(async () => {
+          if (throws) throw new Error('boom');
+          return { data: { head: headSha === undefined ? {} : { sha: headSha } } };
+        }),
+      },
+    } as unknown as Octokit;
+  }
+
+  it('is still head when the sha matches', async () => {
+    expect(await isStillPRHead(stub('abc123'), 'o', 'r', 7, 'abc123')).toBe(true);
+  });
+
+  it('is NOT still head when a newer push landed', async () => {
+    // The reported symptom: a review of commit A finishing after a review of
+    // commit B, and overwriting the fresher verdict.
+    expect(await isStillPRHead(stub('newer99'), 'o', 'r', 7, 'abc123')).toBe(false);
+  });
+
+  it('publishes anyway when the API call fails', async () => {
+    // Fail-open on purpose. A possibly-stale verdict is recoverable — the
+    // newer review overwrites it moments later. Discarding the result on a
+    // transient error loses work and leaves the PR with nothing at all.
+    expect(await isStillPRHead(stub('x', { throws: true }), 'o', 'r', 7, 'abc123')).toBe(true);
+  });
+
+  it('publishes anyway when the payload has no head sha', async () => {
+    // Same reasoning: an unreadable answer is not evidence that it moved.
+    expect(await isStillPRHead(stub(undefined), 'o', 'r', 7, 'abc123')).toBe(true);
+  });
+
+  it('compares exactly — a prefix is not a match', async () => {
+    // Short vs full SHA would otherwise read as "moved" and discard every
+    // review, or as "same" and discard none.
+    expect(await isStillPRHead(stub('abc123def456'), 'o', 'r', 7, 'abc123')).toBe(false);
   });
 });
 

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -162,6 +162,39 @@ export async function getPRDiff(
 }
 
 /**
+ * Is `sha` still this PR's head commit? (#527)
+ *
+ * A review takes tens of seconds and nothing cancels it when a newer push
+ * arrives — the in-flight claim is keyed by SHA, so a new push is a new key and
+ * two reviews run concurrently. Whichever finishes last wins the comment,
+ * which is not necessarily the newer one. The PR then shows a verdict computed
+ * against code that is no longer there.
+ *
+ * Returns **true when it cannot tell**. A transient API failure must not
+ * discard a completed review: publishing a possibly-stale verdict is
+ * recoverable — the newer review overwrites it moments later — whereas
+ * throwing the result away loses work the user is waiting for and leaves the
+ * PR with nothing at all.
+ */
+export async function isStillPRHead(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  sha: string,
+): Promise<boolean> {
+  try {
+    const { data } = await octokit.pulls.get({ owner, repo, pull_number: prNumber });
+    const head = data.head?.sha;
+    if (!head) return true;
+    return head === sha;
+  } catch (err) {
+    console.warn('Head-SHA check failed for %s/%s#%d — publishing anyway:', owner, repo, prNumber, err);
+    return true;
+  }
+}
+
+/**
  * Fetch high-level context about a pull request: title, description,
  * base/head branches, and the list of changed file paths.
  *

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -120,6 +120,7 @@ export {
   findExistingBotComment,
   getCommentReactions,
   createCheckRun,
+  isStillPRHead,
   resolveWithdrawnFindingThreads,
   withdrawnThreadKey,
   MERGEWATCH_CHECK_RUN_NAME,

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -25,6 +25,7 @@ import {
   createCheckRun,
   resolveWithdrawnFindingThreads,
   withdrawnThreadKey,
+  isStillPRHead,
   runReviewPipeline,
   formatReviewComment,
   countBlockingCriticals,
@@ -968,6 +969,25 @@ export async function handler(
     const orgBlocked = orgBlockedBy.length > 0;
     if (orgBlocked) {
       console.log('[org-agents] blocking gate fired for %s#%d via: %s', repoFullName, prNumber, orgBlockedBy.join(', '));
+    }
+
+    // #527 — is this verdict still about the current code?
+    //
+    // Nothing cancels an in-flight review when a newer push arrives: the
+    // claim is keyed by SHA, so a new push is a new key and two reviews run
+    // concurrently. Whichever finishes LAST wins the comment, which is not
+    // necessarily the newer one — so a review of an older commit can overwrite
+    // a fresher verdict, and the PR then shows findings about code that is no
+    // longer there. It also re-blocks a PR the newer run had just cleared.
+    //
+    // Checked once, here, before ANY artifact is written — comment, inline
+    // comments, review event and check run all sit below this line. The newer
+    // review is already running and will publish its own.
+    if (!(await isStillPRHead(octokit, owner, repo, prNumber, headSha))) {
+      console.log(
+        `[supersede] ${repoFullName}#${prNumber}: head moved since ${headSha} — discarding this review, a newer one is in flight`,
+      );
+      return { statusCode: 200, body: JSON.stringify({ message: 'Superseded by a newer commit' }) };
     }
 
     // ── Step A: Upsert issue comment (full review — primary artifact) ──────

--- a/packages/server/src/review-processor.test.ts
+++ b/packages/server/src/review-processor.test.ts
@@ -15,6 +15,8 @@ vi.mock('@mergewatch/core', async (importOriginal) => {
     addPRReaction: vi.fn().mockResolvedValue(12345),
     removePRReaction: vi.fn().mockResolvedValue(undefined),
     createCheckRun: vi.fn().mockResolvedValue(undefined),
+    // #527 — default to "still the head" so every existing test publishes as before.
+    isStillPRHead: vi.fn().mockResolvedValue(true),
     shouldSkipPR: vi.fn().mockReturnValue(null),
     shouldSkipByRules: vi.fn().mockReturnValue(null),
     fetchRepoConfig: vi.fn().mockResolvedValue(null),
@@ -55,7 +57,7 @@ import {
   runReviewPipeline, postReplyComment, fetchRepoConfig, handleInlineReply,
   addPRReaction, removePRReaction, submitPRReview, mergeScoreToReviewEvent,
   fetchTriageComments, computeDisputedKeys,
-  postReviewComment, updateReviewComment, findExistingBotComment,
+  postReviewComment, updateReviewComment, findExistingBotComment, isStillPRHead,
 } from '@mergewatch/core';
 import { processReviewJob } from './review-processor.js';
 
@@ -134,6 +136,56 @@ const basePipelineResult = {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+describe('processReviewJob — superseded by a newer push (#527)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getPRContext as any).mockResolvedValue(basePRContext);
+    (getPRDiff as any).mockResolvedValue('diff content');
+    (shouldSkipPR as any).mockReturnValue(null);
+    (shouldSkipByRules as any).mockReturnValue(null);
+    (runReviewPipeline as any).mockResolvedValue(basePipelineResult);
+    (fetchRepoConfig as any).mockResolvedValue(null);
+    (isStillPRHead as any).mockResolvedValue(true);
+  });
+
+  /** Check runs written with a terminal conclusion — the ones a user sees as a verdict. */
+  const completedChecks = () =>
+    (createCheckRun as any).mock.calls.filter((c: any[]) => c[4]?.status === 'completed');
+
+  it('publishes NOTHING when the head moved during the review', async () => {
+    // A review of commit A finishing after a review of commit B would
+    // otherwise overwrite the fresher verdict, and re-block a PR the newer
+    // run had just cleared.
+    (isStillPRHead as any).mockResolvedValue(false);
+    await processReviewJob(makeJob(), makeDeps());
+
+    expect(postReviewComment).not.toHaveBeenCalled();
+    expect(updateReviewComment).not.toHaveBeenCalled();
+    expect(submitPRReview).not.toHaveBeenCalled();
+    // The in-progress check run is written before the guard and is expected;
+    // the terminal one is a verdict and must not appear.
+    expect(completedChecks()).toHaveLength(0);
+  });
+
+  it('publishes normally when the head is unchanged', async () => {
+    // Back-compat: the guard must not change the ordinary single-push path.
+    await processReviewJob(makeJob(), makeDeps());
+
+    expect(postReviewComment).toHaveBeenCalled();
+    expect(submitPRReview).toHaveBeenCalled();
+    expect(completedChecks().length).toBeGreaterThan(0);
+  });
+
+  it('checks the head against the sha it actually reviewed', async () => {
+    // Comparing against anything else would either never fire or always fire.
+    await processReviewJob(makeJob(), makeDeps());
+
+    expect(isStillPRHead).toHaveBeenCalledWith(
+      mockOctokit, 'test', 'repo', 1, basePRContext.headSha,
+    );
+  });
+});
 
 describe('processReviewJob — check runs', () => {
   beforeEach(() => {

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -2,7 +2,7 @@ import type { ReviewJobPayload, IInstallationStore, IReviewStore, IGitHubAuthPro
 import {
   getPRDiff, getPRContext, addPRReaction, removePRReaction, postReviewComment, updateReviewComment,
   findExistingBotComment, getCommentReactions, createCheckRun,
-  resolveWithdrawnFindingThreads, withdrawnThreadKey,
+  resolveWithdrawnFindingThreads, withdrawnThreadKey, isStillPRHead,
   formatReviewComment, countBlockingCriticals, buildCheckTitle, isThrottleError, computeDiffStats, runReviewPipeline, shouldSkipPR, shouldSkipByRules, isAutoReviewOff, extractIncludePatterns,
   loadCategoryDisputeRates,
   filterDiff,
@@ -817,6 +817,25 @@ export async function processReviewJob(
     const orgBlocked = orgBlockedBy.length > 0;
     if (orgBlocked) {
       console.log('[org-agents] blocking gate fired for %s#%d via: %s', repoFullName, prNumber, orgBlockedBy.join(', '));
+    }
+
+    // #527 — is this verdict still about the current code?
+    //
+    // Nothing cancels an in-flight review when a newer push arrives: the
+    // claim is keyed by SHA, so a new push is a new key and two reviews run
+    // concurrently. Whichever finishes LAST wins the comment, which is not
+    // necessarily the newer one — so a review of an older commit can overwrite
+    // a fresher verdict, and the PR then shows findings about code that is no
+    // longer there. It also re-blocks a PR the newer run had just cleared.
+    //
+    // Checked once, here, before ANY artifact is written — comment, inline
+    // comments, review event and check run all sit below this line. The newer
+    // review is already running and will publish its own.
+    if (!(await isStillPRHead(octokit, owner, repo, prNumber, headSha))) {
+      console.log(
+        `[supersede] ${repoFullName}#${prNumber}: head moved since ${headSha} — discarding this review, a newer one is in flight`,
+      );
+      return;
     }
 
     // ── Step A: Upsert issue comment (full review — primary artifact) ──────


### PR DESCRIPTION
Closes #527. Milestone **v0.6.1**.

## The bug

Nothing cancels an in-flight review when a newer push arrives. The claim is keyed by SHA:

```ts
const prNumberCommitSha = `${prNumber}#${shortSha}`;
```

A new push is a new key, so the guard never fires and **two reviews run concurrently**. Whichever finishes *last* wins the comment — which is not necessarily the newer one.

So a review of commit `A` can overwrite a fresher verdict from commit `B`, and the PR shows findings about code that is no longer there. It also compounds #526: an older run's `REQUEST_CHANGES` landing after a newer clean one **re-blocks a PR on a finding that no longer applies**.

Externally this looked like `catalog-service#109` — dismissed → approved → commented → commented inside an hour.

## The fix

One extra API call. `isStillPRHead` re-reads the head, and the guard sits immediately before **Step A** in both runtimes, so a single early return covers all four artifacts: summary comment, inline comments, review event, terminal check run.

```
result ready → GET pull head → moved? → drop, log, return
```

The newer review is already running and publishes its own.

## Two deliberate asymmetries

**Fail-open.** If the head check errors, or the payload has no head SHA, the review **publishes**. A possibly-stale verdict is recoverable — the newer review overwrites it moments later — whereas discarding the result loses work and leaves the PR with nothing at all.

That is the *opposite* default from #526's thread cleanup, and the difference is which action is destructive. There, acting was destructive, so unknown meant don't act. Here, discarding is destructive, so unknown means publish.

**The in-progress check run still appears.** It is written before the guard, deliberately — it is not a verdict, and suppressing it would make a superseded review indistinguishable from one that never started.

## Tests

**Five on the helper**, including exact-not-prefix: a short-vs-full SHA comparison would either never fire or always fire, and both failure modes are silent.

**Three drive `processReviewJob` itself** with a moved head — the acceptance criterion the issue asked for — asserting `postReviewComment`, `updateReviewComment`, `submitPRReview` and any terminal check run are all absent, plus a back-compat test that the ordinary single-push path is unchanged, plus one that the check compares against *the SHA actually reviewed*.

Verified they fail without the guard:

```
× publishes NOTHING when the head moved during the review
× checks the head against the sha it actually reviewed
  Tests  2 failed | 64 passed (66)
```

`build` / `typecheck` / `test` green — 21/21 tasks, 136 core + 66 server.

## Not in scope

Debounce on `synchronize`, the diff-unchanged short-circuit, and moving the dedup key from SHA to PR stay in **#519**. Those are cost optimisations with a latency trade-off; this is the correctness half and should not wait on that discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp