### PR TITLE
fix(core): annotate the test stub parameter that broke typecheck on main

### DIFF
--- a/packages/core/src/github/client.test.ts
+++ b/packages/core/src/github/client.test.ts
@@ -1248,7 +1248,7 @@ describe('withdrawn finding threads are closed (#526)', () => {
 });
 
 describe('a stale review is superseded, not published (#527)', () => {
-  function stub(headSha, { throws = false } = {}) {
+  function stub(headSha: string | undefined, { throws = false } = {}) {
     return {
       pulls: {
         get: vi.fn(async () => {


### PR DESCRIPTION
**`main` is red.** #531 merged with a typecheck error that Build & Test caught only after the merge:

```
src/github/client.test.ts(1251,17): error TS7006:
Parameter 'headSha' implicitly has an 'any' type
```

The deploy for `ab63d28` then failed at Build & Test and **correctly skipped dev, the E2E gate and prod.** Nothing broken reached production — #527's fix simply has not deployed. This restores that.

## One line

```diff
-  function stub(headSha, { throws = false } = {}) {
+  function stub(headSha: string | undefined, { throws = false } = {}) {
```

## How it got through, which matters more than the fix

The pre-PR gate was run as:

```bash
pnpm run build >/dev/null 2>&1 && pnpm run typecheck >/dev/null 2>&1 && pnpm run test 2>&1 | tail -3; git status --short
```

The chain broke at `typecheck`. With its output suppressed, the only thing that printed was the `git status` after the `;`. `pnpm run test` was then run **on its own**, passed, and was read as the gate passing.

**Vitest does not typecheck.** A green test run could never have caught this, so it was evidence for nothing — and it looked exactly like evidence.

That is the same shape as the defects this PR's parent was fixing: something that looks like verification and cannot fail. Applied to my own process rather than the product.

## Verified differently this time

Each command run visibly and separately, then the chain re-run with its exit code checked explicitly:

```
typecheck   Tasks: 20 successful, 20 total   (Cached: 0 — ran fresh)
build       Tasks: 21 successful
test        Tasks: 21 successful
chain exit=0
```

The `Cached: 0` matters: a cached typecheck result is indistinguishable from a passing one in the summary line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp