### PR TITLE
fix(core): the reject footer promised more than the system delivers

### DIFF
--- a/docs/false-positive-feedback-plan.md
+++ b/docs/false-positive-feedback-plan.md
@@ -191,7 +191,9 @@ The bot's inline-comment ID is already linked to a finding via `ReviewItem.findi
 - **Categories:** closed set — `already-handled`, `out-of-scope`, `wrong-target`, `style-disagreement`, `other`. Free-text after the category is optional and persisted as `text`.
 - **Unrecognised category fallback:** silently coerce to `other`, with the original token preserved as the leading word of `text`. Example: `/mergewatch reject typo-cat foo` persists as `{ category: 'other', text: 'typo-cat foo' }`. Preserves the signal even when the reviewer types something unexpected; the dashboard surfaces these as `other`-category rejections for triage.
 
-The bot posts a confirming reply (`Got it — recording as <category>. This pattern won't be re-raised on similar code unless conditions change.`) and increments `disputeCount` + appends to `rejectReasons[]`.
+The bot confirms by appending a footer to the finding comment (a reply would be auto-wrapped into a standalone COMMENTED review, #190) and increments `disputeCount` + appends to `rejectReasons[]`.
+
+> **Corrected (#528).** This originally read *"won't be re-raised on similar code unless conditions change"*, and the shipped footer said the same. It promised more than the system delivers: suppression is scoped to **this PR** (`disputedKeys` come from the PR's own triage and inline replies), and the key embeds the cited code line as a fingerprint — so editing that line ends the suppression, which is the opposite of *"similar code"*. The footer now says `won't re-raise on this PR while the code is unchanged`. Making the original sentence true is per-key cross-PR suppression, which is tracked in #503 and is a much bigger change than making it honest.
 
 **Code targets:** `packages/core/src/agents/inline-reply.ts` (new parser + handler branch), `packages/core/src/agents/prompts.ts` (confirmation reply template), `packages/server/src/review-processor.ts` + `packages/lambda/src/handlers/review-agent.ts` (write through).
 **E2E target:** [E2E-40](./../e2e/RUNBOOK.md#e2e-40-fb-d--mergewatch-reject-slash-command-target).

--- a/packages/core/src/agents/inline-reply.test.ts
+++ b/packages/core/src/agents/inline-reply.test.ts
@@ -10,6 +10,7 @@ import {
   MAX_INLINE_RESOLVED_KEYS,
   REJECT_CATEGORIES,
   MAX_BOT_REPLIES,
+  REJECT_SCOPE_NOTE,
 } from './inline-reply.js';
 import { buildInlineComments } from '../github/client.js';
 import { findingMatchKeys } from '../review-delta.js';
@@ -828,6 +829,11 @@ describe('handleInlineReply', () => {
     expect(editArg.body).toContain('already-handled');
     expect(editArg.body).toContain('Marked **rejected**');
     expect(editArg.body).toContain('<!-- mergewatch-rejected -->');
+    // #528 — the footer must describe the suppression the system actually
+    // performs. It is per-PR and keyed on the cited code line's fingerprint,
+    // so "similar code" and "unless conditions change" both overpromised.
+    expect(editArg.body).toContain(REJECT_SCOPE_NOTE);
+    expect(editArg.body).not.toMatch(/similar code|unless conditions change/i);
     expect(result.botCommentId).toBe(100);
     // Does NOT auto-resolve the thread (orthogonal verbs).
     expect(calls.graphql).not.toHaveBeenCalled();

--- a/packages/core/src/agents/inline-reply.ts
+++ b/packages/core/src/agents/inline-reply.ts
@@ -252,6 +252,30 @@ export interface InlineReplyResult {
  * the worst case is a future review re-raises the same concern, which
  * is no worse than pre-FP-F behavior.
  */
+/**
+ * What rejecting a finding actually buys you (#528).
+ *
+ * The old wording — "won't re-raise on similar code unless conditions change" —
+ * promised far more than the system delivers, in two ways:
+ *
+ *  - **Scope.** `disputedKeys` are computed from THIS PR's triage and inline
+ *    replies, so the suppression is per-PR. On a different PR the identical
+ *    finding comes back at full strength.
+ *  - **"Similar code".** The key is `file::F::<fingerprint>`, and the
+ *    fingerprint is the cited code line. Edit that line and the key changes,
+ *    so the suppression stops applying — the opposite of "similar code".
+ *
+ * Cross-review learning does exist (FP-J L1) but is much weaker than the
+ * sentence implied: gated on 5+ surfacings, per CATEGORY rather than per
+ * finding, and it softens the verdict tier rather than suppressing anything.
+ *
+ * The footer is the only feedback a developer gets for rejecting something. If
+ * they reject the same finding on three PRs and it keeps returning, the
+ * product looks like it ignored them — because the message said it had
+ * learned. Overpromising here costs trust faster than saying nothing.
+ */
+export const REJECT_SCOPE_NOTE = "won't re-raise on this PR while the code is unchanged";
+
 function deriveResolvedFindingKeys(root: ReviewThreadComment): string[] {
   if (!root.path) return [];
   const title = extractInlineCommentTitle(root.body);
@@ -549,8 +573,8 @@ export async function handleInlineReply(
       // timeline / W6). The footer names the persisted category AND, when
       // coerced, explains the fallback so the user sees what happened.
       const footer = rejectIntent.coerced
-        ? `\n\n${REJECT_FOOTER_SENTINEL}\n---\n> ✅ Marked **rejected** (\`other\`) — your reply didn't match a known reject category. Recognised: \`already-handled\`, \`out-of-scope\`, \`wrong-target\`, \`style-disagreement\`, \`other\`. Won't re-raise on similar code unless conditions change.`
-        : `\n\n${REJECT_FOOTER_SENTINEL}\n---\n> ✅ Marked **rejected** (\`${rejectIntent.category}\`) — won't re-raise on similar code unless conditions change.`;
+        ? `\n\n${REJECT_FOOTER_SENTINEL}\n---\n> ✅ Marked **rejected** (\`other\`) — your reply didn't match a known reject category. Recognised: \`already-handled\`, \`out-of-scope\`, \`wrong-target\`, \`style-disagreement\`, \`other\`. ${REJECT_SCOPE_NOTE[0].toUpperCase()}${REJECT_SCOPE_NOTE.slice(1)}.`
+        : `\n\n${REJECT_FOOTER_SENTINEL}\n---\n> ✅ Marked **rejected** (\`${rejectIntent.category}\`) — ${REJECT_SCOPE_NOTE}.`;
       await editInlineReviewComment(deps.octokit, ctx.owner, ctx.repo, root.id, `${root.body}${footer}`);
       return {
         action: 'rejected',


### PR DESCRIPTION
Closes #528. Milestone **v0.6.1**.

## The overpromise

Rejecting a finding said:

> ✅ Marked **rejected** (`out-of-scope`) — won't re-raise on similar code unless conditions change.

Only the first clause was true. I checked the code rather than trusting the issue's own summary, and the rest is wrong in **two** directions:

| claim | reality |
|---|---|
| implied scope | **This PR only.** `disputedKeys` are computed from the PR's own triage and inline replies. On a different PR the identical finding returns at full strength |
| "similar code" | **The opposite.** The key is `file::F::<fingerprint>` and the fingerprint is the cited code line — editing it changes the key and **ends** the suppression |
| "unless conditions change" | Cross-review learning exists (FP-J L1) but is gated on 5+ surfacings, works per **category** not per finding, and softens the verdict *tier* rather than suppressing anything. One rejection out of five changes nothing |

New wording:

> ✅ Marked **rejected** (`out-of-scope`) — won't re-raise on this PR while the code is unchanged.

## Why a copy fix is worth shipping on its own

The footer is the **only** feedback a developer gets for rejecting something. If they reject the same finding on three PRs and it keeps returning, the product looks like it ignored them — *because the message said it had learned*. Overpromising costs trust faster than saying nothing would.

## Both variants, one constant

The normal footer and the coerced-`other` fallback each carried the sentence. They now share `REJECT_SCOPE_NOTE`, so they cannot drift apart — which is how one of them would otherwise keep the old promise after the other was fixed.

## The docs repeated it

`docs/false-positive-feedback-plan.md` carried the same sentence. Corrected in place with a note on what changed and why: it describes a feature that was **never built**, not one that regressed, so silently editing it would erase the fact that the plan and the product disagreed.

## Drift guard

```ts
expect(editArg.body).toContain(REJECT_SCOPE_NOTE);
expect(editArg.body).not.toMatch(/similar code|unless conditions change/i);
```

The negative half matters as much as the positive one. Verified it fails against the old string:

```
× FB-D — `/mergewatch reject <category>` returns action=rejected with category + match keys
  Tests  1 failed | 49 passed (50)
```

## Verification

Run with `TURBO_FORCE=true` so the results are genuinely fresh rather than cached:

```
typecheck   Tasks: 20 successful   Cached: 0
test        Tasks: 21 successful   Cached: 0
```

That is deliberate. #531 broke `main` this session because a cached/suppressed signal was read as a passing one, and `Cached: 0` is the only way the summary line distinguishes the two.

## Not in scope

Per-key cross-PR suppression — making the original sentence **true** — stays in **#503**. That is a design decision about how much authority a single rejection carries, and a permanently suppressed finding is exactly the invisible-filtering problem #467 exists to prevent. Making the sentence honest is a much smaller change than making it true, and only one of them is a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp