### PR TITLE
fix(core): the verdict says what it examined

### DIFF
--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -3175,6 +3175,50 @@ describe('reconcileMergeScore', () => {
       expect(r.mergeScoreReason).toBe('No issues found on changed lines.');
     });
 
+    it('#516 — findings raised and all filtered do not read as "no issues found"', () => {
+      // The quieter half of #385. Nothing blocking, so the advisory clamp does
+      // not fire — but four findings were raised and every one was discarded
+      // downstream. "No issues found" and "we dropped everything we found"
+      // rendered identically, and #510 is a confirmed case of that machinery
+      // dropping a legitimate finding.
+      const r = reconcileMergeScore({
+        filteredFindings: [],
+        previousFindings: undefined,
+        orchestratorScore: 5,
+        orchestratorReason: 'Looks fine.',
+        orchestratorCriticalsCount: 0,
+        orchestratorWarningsCount: 4,
+      });
+
+      // Score stays 5 — nothing survived scrutiny, which is a real outcome.
+      expect(r.mergeScore).toBe(5);
+      expect(r.mergeScoreReason).toContain('4 findings were raised and filtered out');
+      expect(r.mergeScoreReason).not.toContain('No issues found');
+    });
+
+    it('#516 — singular reads correctly for one filtered finding', () => {
+      const r = reconcileMergeScore({
+        filteredFindings: [],
+        previousFindings: undefined,
+        orchestratorScore: 5,
+        orchestratorReason: 'Looks fine.',
+        orchestratorCriticalsCount: 0,
+        orchestratorWarningsCount: 1,
+      });
+      expect(r.mergeScoreReason).toContain('1 finding was raised');
+    });
+
+    it('#516 — a caller that omits the counts keeps the old wording', () => {
+      // Back-compat: both counts are optional and pre-date this change.
+      const r = reconcileMergeScore({
+        filteredFindings: [],
+        previousFindings: undefined,
+        orchestratorScore: 5,
+        orchestratorReason: 'No issues found on changed lines.',
+      });
+      expect(r.mergeScoreReason).toBe('No issues found on changed lines.');
+    });
+
     it('does NOT fire when even one Critical survives post-filter (the surviving one still blocks)', () => {
       const r = reconcileMergeScore({
         filteredFindings: [critical({ verification: 'verified' }), warning()],

--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -1154,7 +1154,12 @@ describe('runReviewPipeline', () => {
 
     expect(result.findings).toEqual([]);
     expect(result.mergeScore).toBe(5);
-    expect(result.mergeScoreReason).toContain('No issues');
+    // #516 — this used to assert the reason contained "No issues", which is
+    // the misleading wording this scenario produces: a finding WAS raised and
+    // then line-filtered. The score reconciliation is still the thing under
+    // test; the reason now names what happened instead of denying it.
+    expect(result.mergeScoreReason).toContain('1 finding was raised and filtered out');
+    expect(result.mergeScoreReason).not.toContain('No issues');
   });
 
   // #385 — W10 clustering runs BEFORE the FP-A confidence floor.
@@ -3172,7 +3177,9 @@ describe('reconcileMergeScore', () => {
       });
 
       expect(r.mergeScore).toBe(5);
-      expect(r.mergeScoreReason).toBe('No issues found on changed lines.');
+      // #516 — no reason on the clean path: the label carries it, and the
+      // formatter omits an empty reason rather than restating the label.
+      expect(r.mergeScoreReason).toBe('');
     });
 
     it('#516 — findings raised and all filtered do not read as "no issues found"', () => {
@@ -3208,15 +3215,19 @@ describe('reconcileMergeScore', () => {
       expect(r.mergeScoreReason).toContain('1 finding was raised');
     });
 
-    it('#516 — a caller that omits the counts keeps the old wording', () => {
-      // Back-compat: both counts are optional and pre-date this change.
+    it('#516 — a caller that omits the counts reads as clean, not as filtered', () => {
+      // Both counts are optional and pre-date this change. Absent means "we do
+      // not know what the orchestrator raised" — which must fall to the clean
+      // path, not to a filtered-out claim we cannot substantiate.
       const r = reconcileMergeScore({
         filteredFindings: [],
         previousFindings: undefined,
         orchestratorScore: 5,
         orchestratorReason: 'No issues found on changed lines.',
       });
-      expect(r.mergeScoreReason).toBe('No issues found on changed lines.');
+      expect(r.mergeScore).toBe(5);
+      expect(r.mergeScoreReason).toBe('');
+      expect(r.mergeScoreReason).not.toContain('filtered');
     });
 
     it('does NOT fire when even one Critical survives post-filter (the surviving one still blocks)', () => {

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -2627,6 +2627,25 @@ export function reconcileMergeScore(input: {
   }
 
   if (noActionItems) {
+    // #516 — "No issues found" and "everything we found was filtered out"
+    // rendered identically. The first is a review that came back clean; the
+    // second is a review whose findings were all discarded by grounding, W2
+    // verification, line proximity, dedup or clustering — and #510 is a
+    // confirmed case of that machinery dropping a legitimate finding.
+    //
+    // The #385 clamp above already covers the sharp end of this (orchestrator
+    // scored blocking on criticals that then vanished → 3/5, advisory). What
+    // is left is the quieter case: findings raised, none blocking, all
+    // filtered. The score stays 5 — nothing survived scrutiny, which is a real
+    // outcome — but the sentence says so rather than claiming emptiness.
+    const orchestratorRaised =
+      (orchestratorCriticalsCount ?? 0) + (orchestratorWarningsCount ?? 0);
+    if (filteredFindings.length === 0 && orchestratorRaised > 0) {
+      return {
+        mergeScore: 5,
+        mergeScoreReason: `No issues surfaced — ${orchestratorRaised} finding${orchestratorRaised === 1 ? ' was' : 's were'} raised and filtered out before rendering. Nothing was left to act on; the decision trail shows why each was dropped.`,
+      };
+    }
     return {
       mergeScore: 5,
       mergeScoreReason: filteredFindings.length === 0

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -2643,14 +2643,18 @@ export function reconcileMergeScore(input: {
     if (filteredFindings.length === 0 && orchestratorRaised > 0) {
       return {
         mergeScore: 5,
-        mergeScoreReason: `No issues surfaced — ${orchestratorRaised} finding${orchestratorRaised === 1 ? ' was' : 's were'} raised and filtered out before rendering. Nothing was left to act on; the decision trail shows why each was dropped.`,
+        mergeScoreReason: `${orchestratorRaised} finding${orchestratorRaised === 1 ? ' was' : 's were'} raised and filtered out before rendering. Nothing was left to act on; the decision trail shows why each was dropped.`,
       };
     }
+    // #516 — no reason on the genuinely clean path. The label already says
+    // "No issues found in the diff" and the stats bar above it already gives
+    // files and lines, so a reason here only restates one of them. The
+    // formatter omits an empty reason, so this renders as label + scope note.
     return {
       mergeScore: 5,
       mergeScoreReason: filteredFindings.length === 0
-        ? 'No issues found on changed lines.'
-        : 'No action items — only informational notes.',
+        ? ''
+        : 'Only informational notes.',
     };
   }
   if (isPureSecurityImprovement) {

--- a/packages/core/src/comment-formatter.test.ts
+++ b/packages/core/src/comment-formatter.test.ts
@@ -119,6 +119,19 @@ describe('formatReviewComment', () => {
     expect(result).not.toContain('Safe to merge');
   });
 
+  it('5/5 with info findings does not claim none were found', () => {
+    // #516 — "No issues found in the diff" contradicted the info notes
+    // rendered directly below it. Only score 5 varies; the other labels are
+    // statements about the review's opinion and were already accurate.
+    const info: Finding = { severity: 'info', title: 'A note', description: 'd', file: 'a.ts', line: 1, category: 'style', suggestion: '' };
+    const withInfo = formatReviewComment(baseOptions({ mergeScore: 5, findings: [info] }));
+    expect(withInfo).toContain('No action items in the diff');
+    expect(withInfo).not.toContain('No issues found in the diff');
+
+    const clean = formatReviewComment(baseOptions({ mergeScore: 5, findings: [] }));
+    expect(clean).toContain('No issues found in the diff');
+  });
+
   it('states the review scope on clean verdicts, and not on blocking ones', () => {
     // The note exists because a green verdict beside a failing CI check invites
     // exactly the wrong inference. On 1-3 the verdict already says stop, so the

--- a/packages/core/src/comment-formatter.test.ts
+++ b/packages/core/src/comment-formatter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatReviewComment, buildWorkDoneSection, countBlockingCriticals, buildCheckTitle, escapeUserContent, COMMENT_BODY_BUDGET, mergeScoreMeta, buildReviewDetailUrl, type Finding } from './comment-formatter.js';
+import { formatReviewComment, buildWorkDoneSection, countBlockingCriticals, buildCheckTitle, escapeUserContent, COMMENT_BODY_BUDGET, mergeScoreMeta, buildReviewDetailUrl, REVIEW_SCOPE_NOTE, type Finding } from './comment-formatter.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -108,10 +108,40 @@ describe('formatReviewComment', () => {
   });
 
   // Merge score rendering
-  it('renders merge score badge with score 5 as green safe-to-merge', () => {
+  it('renders merge score badge with score 5 scoped to the diff', () => {
+    // #516 — the label used to read "Safe to merge", a claim about the PR that
+    // this review has no basis for: it reads the diff and never builds, tests,
+    // or looks at another check. catalog-service#103 got that green label on a
+    // PR that did not compile.
     const result = formatReviewComment(baseOptions({ mergeScore: 5 }));
     expect(result).toContain('5/5');
-    expect(result).toContain('Safe to merge');
+    expect(result).toContain('No issues found in the diff');
+    expect(result).not.toContain('Safe to merge');
+  });
+
+  it('states the review scope on clean verdicts, and not on blocking ones', () => {
+    // The note exists because a green verdict beside a failing CI check invites
+    // exactly the wrong inference. On 1-3 the verdict already says stop, so the
+    // note would be noise on every blocked PR.
+    for (const score of [5, 4]) {
+      expect(formatReviewComment(baseOptions({ mergeScore: score }))).toContain(REVIEW_SCOPE_NOTE);
+    }
+    for (const score of [3, 2, 1]) {
+      expect(formatReviewComment(baseOptions({ mergeScore: score }))).not.toContain(REVIEW_SCOPE_NOTE);
+    }
+  });
+
+  it('the check title distinguishes nothing-found from everything-filtered', () => {
+    // #516 — a review that raised six findings and filtered all six read
+    // "No issues found" in the Checks tab, identically to one that found none.
+    // #510 is a confirmed case of that filtering dropping a real finding.
+    expect(buildCheckTitle({ mergeScore: 5, findingCount: 0, blockingCriticalCount: 0 }))
+      .toBe('5/5 — No issues found');
+    expect(buildCheckTitle({ mergeScore: 5, findingCount: 0, blockingCriticalCount: 0, suppressedCount: 6 }))
+      .toBe('5/5 — No issues surfaced (6 filtered)');
+    // Back-compat: callers that do not pass the count get exactly today's text.
+    expect(buildCheckTitle({ mergeScore: 5, findingCount: 0, blockingCriticalCount: 0, suppressedCount: 0 }))
+      .toBe('5/5 — No issues found');
   });
 
   it('renders merge score badge with score 1 as do-not-merge', () => {

--- a/packages/core/src/comment-formatter.ts
+++ b/packages/core/src/comment-formatter.ts
@@ -270,12 +270,24 @@ export function buildReviewDetailUrl(
  * Two copies of this table would drift, and a review that reads "Needs fixes"
  * on GitHub and something else on the dashboard is worse than either alone.
  */
-export function mergeScoreMeta(score: number): { emoji: string; label: string; score: number } {
+export function mergeScoreMeta(
+  score: number,
+  /**
+   * #516 — does this review have anything to report? A 5/5 fires both for a
+   * review that found nothing and for one whose findings are all
+   * informational, and "No issues found in the diff" contradicts the notes
+   * rendered directly below it in the second case. Only score 5 varies.
+   */
+  hasNotes = false,
+): { emoji: string; label: string; score: number } {
   // Round before the lookup. MERGE_SCORE_META is keyed 1–5, so a fractional
   // score — the orchestrator clamps but does not round, so a model returning
   // 2.5 reaches here — missed the table entirely and produced
   // `undefined **2.5/5 — undefined**` in the rendered comment.
   const clamped = Math.max(1, Math.min(5, Math.round(score)));
+  if (clamped === 5 && hasNotes) {
+    return { ...MERGE_SCORE_META[5], label: 'No action items in the diff', score: 5 };
+  }
   return { ...MERGE_SCORE_META[clamped], score: clamped };
 }
 
@@ -295,8 +307,8 @@ export const REVIEW_SCOPE_NOTE =
   'Reviewed the diff only — MergeWatch does not build, run tests, or read other checks.';
 
 /** Render the merge score as a prominent badge line. */
-function renderMergeScore(score: number): string {
-  const { emoji, label, score: clamped } = mergeScoreMeta(score);
+function renderMergeScore(score: number, hasNotes: boolean): string {
+  const { emoji, label, score: clamped } = mergeScoreMeta(score, hasNotes);
   return `${emoji} **${clamped}/5 — ${label}**`;
 }
 
@@ -645,7 +657,10 @@ export function formatReviewComment(options: FormatOptions): string {
   // 4. Merge readiness score — highly visible
   if (mergeScore != null) {
     const score = section('score', KEEP);
-    const scoreDisplay = renderMergeScore(mergeScore);
+    // Anything to report — a rendered finding, or a reason explaining what
+    // happened to the ones there were.
+    const hasNotes = findings.length > 0 || Boolean(mergeScoreReason);
+    const scoreDisplay = renderMergeScore(mergeScore, hasNotes);
     const reasonSuffix = mergeScoreReason ? ` \u2014 ${mergeScoreReason}` : '';
     score.push(`> ${scoreDisplay}${reasonSuffix}`);
     // FP-J L3 \u2014 dispute-rate disclosure renders as a quieter sub-line so the
@@ -661,7 +676,7 @@ export function formatReviewComment(options: FormatOptions): string {
     // has to infer the scope; catalog-service#103 shows the inference goes the
     // wrong way. Restricted to 4-5 because a 1-3 verdict already tells the
     // reader to stop, so the note would be noise on every blocked PR.
-    if (mergeScoreMeta(mergeScore).score >= 4) {
+    if (mergeScoreMeta(mergeScore, hasNotes).score >= 4) {
       score.push(`> <sub>${REVIEW_SCOPE_NOTE}</sub>`);
     }
     score.push('');

--- a/packages/core/src/comment-formatter.ts
+++ b/packages/core/src/comment-formatter.ts
@@ -101,8 +101,15 @@ export function buildCheckTitle(input: {
   blockingCriticalCount: number;
   orgBlocked?: boolean;
   orgBlockedBy?: string[];
+  /**
+   * #516 — findings raised and then dropped by post-orchestrator filtering.
+   * Without it a review that found six things and filtered all six reads
+   * "No issues found" in the Checks tab, identically to one that found none.
+   * Optional: callers that do not pass it get exactly today's wording.
+   */
+  suppressedCount?: number;
 }): string {
-  const { mergeScore, findingCount, blockingCriticalCount, orgBlocked, orgBlockedBy } = input;
+  const { mergeScore, findingCount, blockingCriticalCount, orgBlocked, orgBlockedBy, suppressedCount } = input;
   const prefix = mergeScore != null
     ? `${Math.max(1, Math.min(5, mergeScore))}/5 — `
     : '';
@@ -112,6 +119,9 @@ export function buildCheckTitle(input: {
   }
   if (findingCount > 0) {
     return `${prefix}${findingCount} finding${findingCount > 1 ? 's' : ''} (no blocking critical)`;
+  }
+  if ((suppressedCount ?? 0) > 0) {
+    return `${prefix}No issues surfaced (${suppressedCount} filtered)`;
   }
   return `${prefix}No issues found`;
 }
@@ -214,8 +224,16 @@ const SEVERITY_META: Record<Finding['severity'], { emoji: string; label: string;
 
 // ─── Helpers ───────────────────────────────────────────────────────────────
 
+// #516 — 5/5 said "Safe to merge", which is a claim about the PR. This review
+// reads the diff: it does not build, run tests, or look at any other check.
+// catalog-service#103 got a green "Safe to merge" on a PR that did not compile,
+// and the words were the promise. The label now states what was examined.
+//
+// Only 5/5 changed. The other four describe the review's own opinion —
+// "Needs fixes", "Do not merge" — and assert nothing about merge-safety that
+// the review did not establish.
 const MERGE_SCORE_META: Record<number, { emoji: string; label: string }> = {
-  5: { emoji: '\uD83D\uDFE2', label: 'Safe to merge' },
+  5: { emoji: '\uD83D\uDFE2', label: 'No issues found in the diff' },
   4: { emoji: '\uD83D\uDFE2', label: 'Generally safe' },
   3: { emoji: '\uD83D\uDFE1', label: 'Review recommended' },
   2: { emoji: '\uD83D\uDFE0', label: 'Needs fixes' },
@@ -260,6 +278,21 @@ export function mergeScoreMeta(score: number): { emoji: string; label: string; s
   const clamped = Math.max(1, Math.min(5, Math.round(score)));
   return { ...MERGE_SCORE_META[clamped], score: clamped };
 }
+
+/**
+ * What this review actually examined (#516).
+ *
+ * MergeWatch reads the diff with LLM agents. It does not compile anything, run
+ * tests, or read any other check on the commit — a fact that is invisible from
+ * a green verdict, and which catalog-service#103 turned into a "Safe to merge"
+ * on a PR containing an undeclared variable.
+ *
+ * Shown only on 4-5. Below that the verdict already tells the reader to stop,
+ * so the note would be noise on exactly the PRs where nobody is inferring
+ * merge-safety anyway.
+ */
+export const REVIEW_SCOPE_NOTE =
+  'Reviewed the diff only — MergeWatch does not build, run tests, or read other checks.';
 
 /** Render the merge score as a prominent badge line. */
 function renderMergeScore(score: number): string {
@@ -622,6 +655,14 @@ export function formatReviewComment(options: FormatOptions): string {
     // over the 30d window). Omitted on the clean path.
     if (disputeDisclosure && disputeDisclosure.trim()) {
       score.push(`> <sub>\ud83d\udcca ${disputeDisclosure.trim()}</sub>`);
+    }
+    // #516 — say what this review looked at, on the verdicts that read as an
+    // all-clear. A reader seeing a green 4/5 or 5/5 next to a failing CI check
+    // has to infer the scope; catalog-service#103 shows the inference goes the
+    // wrong way. Restricted to 4-5 because a 1-3 verdict already tells the
+    // reader to stop, so the note would be noise on every blocked PR.
+    if (mergeScoreMeta(mergeScore).score >= 4) {
+      score.push(`> <sub>${REVIEW_SCOPE_NOTE}</sub>`);
     }
     score.push('');
   }

--- a/packages/dashboard/components/ReviewDrawer.tsx
+++ b/packages/dashboard/components/ReviewDrawer.tsx
@@ -19,7 +19,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { FindingsSection } from "./FindingEvidence";
-import { reviewKey, isCompleted } from "../lib/review-findings";
+import { reviewKey, isCompleted, mergeScoreMeta } from "../lib/review-findings";
 import FilterTrail from "./FilterTrail";
 import type { DetailFinding } from "../lib/review-findings";
 
@@ -87,16 +87,22 @@ function StatusBadge({ status }: { status: string }) {
   );
 }
 
-const mergeScoreMeta: Record<number, { color: string; bg: string; label: string }> = {
-  5: { color: "text-primer-green", bg: "bg-primer-green/10", label: "Safe to merge" },
-  4: { color: "text-primer-green", bg: "bg-primer-green/10", label: "Generally safe" },
-  3: { color: "text-primer-orange", bg: "bg-primer-orange/10", label: "Review recommended" },
-  2: { color: "text-orange-500", bg: "bg-orange-500/10", label: "Needs fixes" },
-  1: { color: "text-primer-red", bg: "bg-primer-red/10", label: "Do not merge" },
+// #516 — colours only. The LABEL comes from `mergeScoreMeta`, which is
+// drift-tested against core, so the drawer cannot disagree with the PR
+// comment. This map used to carry its own copy of the wording and was the one
+// place the drift test could not see: core and lib/review-findings were
+// guarded against each other while a third copy sat here.
+const scoreColors: Record<number, { color: string; bg: string }> = {
+  5: { color: "text-primer-green", bg: "bg-primer-green/10" },
+  4: { color: "text-primer-green", bg: "bg-primer-green/10" },
+  3: { color: "text-primer-orange", bg: "bg-primer-orange/10" },
+  2: { color: "text-orange-500", bg: "bg-orange-500/10" },
+  1: { color: "text-primer-red", bg: "bg-primer-red/10" },
 };
 
 function MergeScoreBadge({ score, reason }: { score: number; reason?: string }) {
-  const s = mergeScoreMeta[score] ?? mergeScoreMeta[3];
+  const clamped = Math.max(1, Math.min(5, Math.round(score)));
+  const s = { ...(scoreColors[clamped] ?? scoreColors[3]), label: mergeScoreMeta(score).label };
   return (
     <div className={`mx-5 mt-4 rounded-lg border border-border-default ${s.bg} px-4 py-3`}>
       <div className="flex items-center justify-between">

--- a/packages/dashboard/components/ReviewDrawer.tsx
+++ b/packages/dashboard/components/ReviewDrawer.tsx
@@ -100,9 +100,9 @@ const scoreColors: Record<number, { color: string; bg: string }> = {
   1: { color: "text-primer-red", bg: "bg-primer-red/10" },
 };
 
-function MergeScoreBadge({ score, reason }: { score: number; reason?: string }) {
+function MergeScoreBadge({ score, reason, hasNotes }: { score: number; reason?: string; hasNotes: boolean }) {
   const clamped = Math.max(1, Math.min(5, Math.round(score)));
-  const s = { ...(scoreColors[clamped] ?? scoreColors[3]), label: mergeScoreMeta(score).label };
+  const s = { ...(scoreColors[clamped] ?? scoreColors[3]), label: mergeScoreMeta(score, hasNotes).label };
   return (
     <div className={`mx-5 mt-4 rounded-lg border border-border-default ${s.bg} px-4 py-3`}>
       <div className="flex items-center justify-between">
@@ -247,7 +247,13 @@ export default function ReviewDrawer({
           ) : review ? (
             <>
               {review.mergeScore != null && (
-                <MergeScoreBadge score={review.mergeScore} reason={review.mergeScoreReason} />
+                <MergeScoreBadge
+                  score={review.mergeScore}
+                  reason={review.mergeScoreReason}
+                  // #516 — same input the PR comment uses: a rendered finding,
+                  // or a reason explaining what happened to the ones there were.
+                  hasNotes={(review.findings?.length ?? 0) > 0 || Boolean(review.mergeScoreReason)}
+                />
               )}
               <DrawerSection title="Overview" icon={FileText} defaultOpen>
                 <div className="space-y-3">

--- a/packages/dashboard/lib/review-findings.test.ts
+++ b/packages/dashboard/lib/review-findings.test.ts
@@ -91,7 +91,12 @@ describe("mergeScoreMeta", () => {
     // Integers AND fractionals: the #481 review found the dashboard rounded
     // while core did not, and an integer-only check could never see it.
     for (const score of [1, 1.4, 2, 2.5, 3, 3.7, 4, 4.9, 5, 0, 99]) {
-      expect(mergeScoreMeta(score)).toEqual(core.mergeScoreMeta(score));
+      // #516 — BOTH branches. Score 5 now has two labels, and testing only the
+      // default would leave the info-only wording unguarded — which is exactly
+      // how ReviewDrawer's third copy drifted unnoticed.
+      for (const hasNotes of [false, true]) {
+        expect(mergeScoreMeta(score, hasNotes)).toEqual(core.mergeScoreMeta(score, hasNotes));
+      }
     }
   });
 });

--- a/packages/dashboard/lib/review-findings.ts
+++ b/packages/dashboard/lib/review-findings.ts
@@ -142,8 +142,16 @@ const MERGE_SCORE_LABELS: Record<number, { emoji: string; label: string }> = {
   1: { emoji: "🔴", label: "Do not merge" },
 };
 
-export function mergeScoreMeta(score: number): { emoji: string; label: string; score: number } {
+export function mergeScoreMeta(
+  score: number,
+  /** #516 — see core. Only score 5 varies: findings present means the review
+   * has notes, and "No issues found" would contradict them. */
+  hasNotes = false,
+): { emoji: string; label: string; score: number } {
   const clamped = Math.max(1, Math.min(5, Math.round(score)));
+  if (clamped === 5 && hasNotes) {
+    return { ...MERGE_SCORE_LABELS[5], label: "No action items in the diff", score: 5 };
+  }
   return { ...MERGE_SCORE_LABELS[clamped], score: clamped };
 }
 

--- a/packages/dashboard/lib/review-findings.ts
+++ b/packages/dashboard/lib/review-findings.ts
@@ -135,7 +135,7 @@ export function findingsSummaryLine(findings: Array<{ severity?: string }>): str
  * dashboard whose verdict disagrees with the PR comment.
  */
 const MERGE_SCORE_LABELS: Record<number, { emoji: string; label: string }> = {
-  5: { emoji: "🟢", label: "Safe to merge" },
+  5: { emoji: "🟢", label: "No issues found in the diff" },
   4: { emoji: "🟢", label: "Generally safe" },
   3: { emoji: "🟡", label: "Review recommended" },
   2: { emoji: "🟠", label: "Needs fixes" },

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -1254,6 +1254,7 @@ export async function handler(
         blockingCriticalCount,
         orgBlocked,
         orgBlockedBy,
+        suppressedCount: result.suppressedCount,
       }),
       summary: findingSummaryParts.length > 0
         ? `Found: ${findingSummaryParts.join(', ')}`

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -1062,6 +1062,7 @@ export async function processReviewJob(
         blockingCriticalCount,
         orgBlocked,
         orgBlockedBy,
+        suppressedCount: result.suppressedCount,
       }),
       summary: findingSummaryParts.length > 0
         ? `Found: ${findingSummaryParts.join(', ')}`


### PR DESCRIPTION
Closes #516. Milestone **v0.6.1**.

> 🟢 **5/5 — Safe to merge** — No issues found on changed lines.

`catalog-service#103` got that on a PR containing an **undeclared variable**. "Safe to merge" is a claim about the PR; this review reads the diff with LLM agents and never compiles anything, runs a test, or looks at another check on the commit.

## Deliberately not reading CI

Checking it is hard to validate. At verdict time the review has taken ~30s and Build & Test takes ~2m, so **pending is the normal state** — a clamp on pending would cap nearly every review, and a clamp only on already-failed would miss the common ordering entirely. Softening the words needs no API call, no new permission, and no timing assumption.

## What renders now

```
> **12** files scanned · **340** lines reviewed · **6** specialized agents ran
> 🟢 **5/5 — No issues found in the diff**
> <sub>Reviewed the diff only — MergeWatch does not build, run tests, or read other checks.</sub>
```

| case | verdict line |
|---|---|
| genuinely clean | `5/5 — No issues found in the diff` |
| info findings only | `5/5 — No action items in the diff — Only informational notes.` |
| all findings filtered | `5/5 — No action items in the diff — 4 findings were raised and filtered out…` |
| blocking | `2/5 — Needs fixes — One critical.` *(no scope note)* |

**Two labels for 5/5.** It also fires when only info findings exist, where "No issues found" contradicts the notes rendered directly below it. Only score 5 varies — the other four describe the review's own opinion and were already accurate.

**Scope note on 4–5 only.** Below that the verdict already says stop, so the note would be noise on every blocked PR.

**No reason on the clean path.** The label says it and the stats bar above already gives files and lines; a reason there only restated one of them.

## The second false claim in the same sentence

`No issues found on changed lines` fired when findings were raised and **every one was discarded downstream** — and #510 is a confirmed case of that machinery dropping a legitimate finding. The reason now names the count. The score stays 5, because nothing surviving scrutiny is a real outcome; #385's clamp still covers the blocking end.

The **check-run title** had the identical ambiguity — `No issues found` for a review that found six and filtered six — and now reports the count. Optional parameter, so a caller that omits it gets exactly today's text.

## The label lived in three places

```
packages/core/src/comment-formatter.ts        ← source of truth
packages/dashboard/lib/review-findings.ts     ← drift-tested against core
packages/dashboard/components/ReviewDrawer.tsx ← third copy, unguarded
```

…beneath a comment warning that *"two copies of this table would drift"*. The drawer now takes its label from the drift-tested helper and keeps only its colours, and the drift test exercises **both** label branches rather than only the default — testing one would have left the new wording exactly as unguarded as the drawer was.

## A test that was locking in the bug

One pre-existing test asserted the reason contained `"No issues"` for a review whose single finding was **line-filtered** — the precise scenario this issue corrects. Updated, with a comment saying what it used to assert and why that changed, rather than quietly flipped.

## Verification

Run with `TURBO_FORCE=true` so the results are fresh rather than cached:

```
typecheck   Tasks: 20 successful   Cached: 0
test        Tasks: 21 successful   Cached: 0
build       Tasks: 12 successful   Cached: 0
```

That mattered here: an untyped test fixture passed **vitest** and failed **typecheck**, which is exactly how #531 put a broken commit on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp