### PR TITLE
fix(core): verify findings from blocking custom agents (#510)

### DIFF
--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -1809,6 +1809,123 @@ describe('runReviewPipeline', () => {
     expect(todo!.verification).toBeUndefined();
   });
 
+  it('#510 — a BLOCKING agent\'s finding is verified, and a refuted one is demoted not dropped', async () => {
+    // The reported case: a `no-todo` agent asserting "a new TODO comment has
+    // been added" against a file containing no TODO. With enforcement:
+    // blocking that fails the check and requests changes on a false claim.
+    const blockingAgent = {
+      name: 'no-todo', prompt: 'Flag any new TODO comment',
+      severityDefault: 'critical' as const, enabled: true,
+      enforcement: 'blocking' as const,
+    };
+    const customResponse = validFindingsJson([
+      { file: 'foo.ts', line: 3, severity: 'critical', title: 'New TODO comment added', confidence: 95 },
+    ]);
+    const orchestrator = JSON.stringify({ findings: [], mergeScore: 5, mergeScoreReason: 'Clean.' });
+    const llm = createMockLLM([
+      JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }),
+      JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }),
+      JSON.stringify({ summary: 'Adds code.' }), '%% overview\nflowchart TD\n  A-->B',
+      customResponse, orchestrator,
+      // The verifier refutes it — no TODO construct at the cited line.
+      JSON.stringify({ valid: false, reason: 'No TODO marker at or near foo.ts:3.' }),
+    ]);
+
+    // The verifier SKIPS a finding whose file content it does not have, leaving
+    // `verification` undefined — deliberately, so callers without a grounding
+    // fetch never get the W7 clamp. Without this the test would pass for the
+    // wrong reason: verification never ran at all.
+    const fileWithoutAnyTodo = ['const a = 1;', 'const b = 2;', 'const c = 3;', 'const d = 4;'].join('\n');
+    const octokit = {
+      repos: {
+        getContent: vi.fn(async () => ({
+          data: { type: 'file', content: Buffer.from(fileWithoutAnyTodo, 'utf-8').toString('base64') },
+        })),
+      },
+    } as any;
+
+    const result = await runReviewPipeline(
+      {
+        diff: sampleDiff, context: sampleContext, modelId: 'heavy', lightModelId: 'light',
+        maxFindings: 25, enabledAgents: allAgentsEnabled, customAgents: [blockingAgent],
+        groundingFetch: { octokit, owner: 'o', repo: 'r', ref: 'sha', maxContextKB: 256, maxRounds: 1 },
+      },
+      { llm },
+    );
+
+    const todo = result.findings.find((f) => f.title === 'New TODO comment added');
+    // DEMOTED, never deleted: user-legislated policy must not silently vanish,
+    // which is what #385 exists to prevent (fixtures#515).
+    expect(todo).toBeDefined();
+    expect(todo!.verification).toBe('unverified');
+
+    // The trap this feature nearly shipped into: the shared grounding fetch is
+    // keyed off the ORCHESTRATOR's findings, and custom findings bypass the
+    // orchestrator (#385) — so foo.ts was never fetched, verifyFindings SKIPPED
+    // (a skip is not a refutation, so it tags nothing), and the whole feature
+    // was a no-op that logged "verifying 1" and returned the finding untouched.
+    // Verification succeeding looks exactly like verification never running
+    // unless something asserts the file was actually read.
+    expect(octokit.repos.getContent).toHaveBeenCalled();
+  });
+
+  it('#510 — an ADVISORY agent keeps the #385 bypass untouched', async () => {
+    // A wrong advisory finding is noise; a wrong blocking one stops a merge.
+    // Verification follows the consequence, so advisory pays no LLM cost and
+    // takes exactly today's path.
+    const advisoryAgent = {
+      name: 'no-todo', prompt: 'Flag any new TODO comment',
+      severityDefault: 'critical' as const, enabled: true,
+      enforcement: 'advisory' as const,
+    };
+    const customResponse = validFindingsJson([
+      { file: 'foo.ts', line: 3, severity: 'critical', title: 'New TODO comment added', confidence: 95 },
+    ]);
+    const orchestrator = JSON.stringify({ findings: [], mergeScore: 5, mergeScoreReason: 'Clean.' });
+    // NOTE: no verifier response queued. If the pipeline called the verifier
+    // for an advisory agent, the mock would run dry and this would fail.
+    const llm = createMockLLM([
+      JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }),
+      JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }),
+      JSON.stringify({ summary: 'Adds code.' }), '%% overview\nflowchart TD\n  A-->B',
+      customResponse, orchestrator,
+    ]);
+
+    const result = await runReviewPipeline(
+      { diff: sampleDiff, context: sampleContext, modelId: 'heavy', lightModelId: 'light', maxFindings: 25, enabledAgents: allAgentsEnabled, customAgents: [advisoryAgent] },
+      { llm },
+    );
+
+    const todo = result.findings.find((f) => f.title === 'New TODO comment added');
+    expect(todo).toBeDefined();
+    expect(todo!.verification).toBeUndefined();
+  });
+
+  it('#510 — a repo-level agent with no enforcement field is treated as advisory', async () => {
+    // Back-compat: `.mergewatch.yml` customAgents cannot block and carry no
+    // enforcement, so absent must never mean "verify".
+    const repoAgent = { name: 'house-rule', prompt: 'Flag X', severityDefault: 'critical' as const, enabled: true };
+    const customResponse = validFindingsJson([
+      { file: 'foo.ts', line: 3, severity: 'critical', title: 'House rule broken', confidence: 95 },
+    ]);
+    const orchestrator = JSON.stringify({ findings: [], mergeScore: 5, mergeScoreReason: 'Clean.' });
+    const llm = createMockLLM([
+      JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }),
+      JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }),
+      JSON.stringify({ summary: 'Adds code.' }), '%% overview\nflowchart TD\n  A-->B',
+      customResponse, orchestrator,
+    ]);
+
+    const result = await runReviewPipeline(
+      { diff: sampleDiff, context: sampleContext, modelId: 'heavy', lightModelId: 'light', maxFindings: 25, enabledAgents: allAgentsEnabled, customAgents: [repoAgent] },
+      { llm },
+    );
+
+    const f = result.findings.find((x) => x.title === 'House rule broken');
+    expect(f).toBeDefined();
+    expect(f!.verification).toBeUndefined();
+  });
+
   it('#385 — a custom-agent finding at a location already surfaced by a kept builtin finding is skipped', async () => {
     const todoAgent = { name: 'no-todo', prompt: 'Flag any new TODO comment', severityDefault: 'warning' as const, enabled: true };
     const securityFinding = validFindingsJson([{ file: 'foo.ts', line: 3, severity: 'warning', title: 'Builtin issue', confidence: 90 }]);

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -3340,13 +3340,84 @@ export async function runReviewPipeline(
       customFindings.length === 1 ? '' : 's',
     );
   }
+
+  // #510 — verify the custom findings that can BLOCK a merge.
+  //
+  // #385 routes custom findings around every model layer because they are
+  // user-legislated policy and a model should not overrule them. That holds.
+  // But the same bypass removes the only layer that asks whether the claim is
+  // TRUE of the code, and a blocking agent acts on that claim: a `no-todo`
+  // agent reported "a new TODO comment has been added" three times against
+  // files containing no TODO, FIXME, HACK or XXX. The quotes were real; the
+  // characterization was not. With `enforcement: blocking` those would have
+  // failed the check and requested changes on a diff containing no TODO.
+  //
+  // Scoped three ways so #385's guarantee survives:
+  //   • Only BLOCKING agents. An advisory finding that is wrong is noise; a
+  //     blocking one that is wrong stops a merge. Cost and risk both follow
+  //     the consequence.
+  //   • DEMOTE, never drop. A refuted finding still renders under "Unverified
+  //     concerns" and is excluded from the blocking count (FP-L / W7), so the
+  //     user's policy never silently disappears — which is what fixtures#515
+  //     was, and what #385 was written to prevent.
+  //   • Nothing else comes back. FP-A, the orchestrator's anti-pedantry pass
+  //     and the line-proximity geometry stay bypassed for every custom
+  //     finding, blocking or not.
+  const blockingAgentNames = new Set(
+    enabledCustomAgents.filter((a) => a.enforcement === 'blocking').map((a) => a.name),
+  );
+  let verifiedCustomFindings = customFindings;
+  if (blockingAgentNames.size > 0) {
+    const blocking = customFindings.filter((f) => blockingAgentNames.has(f.category));
+    const rest = customFindings.filter((f) => !blockingAgentNames.has(f.category));
+    if (blocking.length > 0) {
+      console.log(
+        '[org-agents] verifying %d finding%s from blocking agent%s (#510)',
+        blocking.length, blocking.length === 1 ? '' : 's', blockingAgentNames.size === 1 ? '' : 's',
+      );
+      // The shared grounding fetch above is keyed off the ORCHESTRATOR's
+      // findings, and custom findings bypass the orchestrator (#385). So none
+      // of their files are in that map, and verifyFindings skips a finding
+      // whose content it does not have — silently, by design, since a skip is
+      // not a refutation. Verification would have been a no-op on every
+      // blocking finding: the log would say "verifying 1", nothing would come
+      // back changed, and it would look like the verifier had agreed.
+      // Fetched separately, and only for blocking findings, so the read cost
+      // follows the same consequence rule as the verification itself.
+      const blockingFileContents = {
+        ...groundingFileContents,
+        ...(await fetchFindingFileContents(blocking, groundingContext)),
+      };
+      const verified = await verifyFindings(
+        blocking,
+        blockingFileContents,
+        lightModelId,
+        llm,
+        previousFindings,
+        trace,
+      );
+      // verifyFindings demotes rather than deletes (#459), but a custom
+      // finding must never be lost even if that changes: re-attach anything
+      // the verifier did not return, marked unverified.
+      const returnedKeys = new Set(verified.map((f) => outcomeKey(f)));
+      const missing = blocking
+        .filter((f) => !returnedKeys.has(outcomeKey(f)))
+        .map((f) => ({ ...f, verification: 'unverified' as const }));
+      for (const f of missing) {
+        trace.record(f, 'demoted', 'finding-verify', {
+          reason: 'the verifier did not return this blocking custom finding — kept as unverified rather than lost',
+        });
+      }
+      verifiedCustomFindings = [...verified, ...missing, ...rest];
+    }
+  }
   // #469 — attach cited code once, after builtin and custom findings are
   // combined, so a single call covers both paths rather than two that can
   // drift apart.
   const preTriageFindings = withEvidenceCode(
     [
       ...onChangedLines,
-      ...withTracedFingerprints(customFindings),
+      ...withTracedFingerprints(verifiedCustomFindings),
     ],
     groundingFileContents,
     convergence,

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -14,6 +14,16 @@ export interface CustomAgentDef {
   severityDefault: 'info' | 'warning' | 'critical';
   /** Whether this custom agent is enabled */
   enabled: boolean;
+  /**
+   * #510 — org agents only. `blocking` means a critical finding from this
+   * agent fails the check and requests changes regardless of merge score
+   * (#235), which is why those findings are W2-verified before they can act.
+   *
+   * Absent for repo-level `.mergewatch.yml` agents, which cannot block —
+   * so absent reads as advisory, and the pipeline's behaviour for them is
+   * unchanged.
+   */
+  enforcement?: 'advisory' | 'blocking';
 }
 
 export interface UXConfig {

--- a/packages/core/src/org-agents.ts
+++ b/packages/core/src/org-agents.ts
@@ -136,7 +136,18 @@ export function selectOrgAgentsForReview(
 
 /** Map an org agent onto the pipeline's per-repo `CustomAgentDef` shape. */
 export function toCustomAgentDef(a: OrgCustomAgent): CustomAgentDef {
-  return { name: a.name, prompt: a.prompt, severityDefault: a.severityDefault, enabled: true };
+  // #510 — enforcement travels with the agent. It used to be dropped here, so
+  // the pipeline could not tell a blocking agent from an advisory one and had
+  // to verify all custom findings or none. `blockingCriticalAgents` below
+  // still runs in the runtimes for the gate itself; this is the same fact,
+  // carried to where the findings are produced.
+  return {
+    name: a.name,
+    prompt: a.prompt,
+    severityDefault: a.severityDefault,
+    enabled: true,
+    enforcement: a.enforcement,
+  };
 }
 
 /**


### PR DESCRIPTION
Closes #510.

## The problem

Custom-agent findings bypass the entire post-orchestrator filter pipeline. That is `#385`, and it is deliberate — it exists so a user's own policy is never silently filtered away (fixtures#515).

The bypass is right for an **advisory** agent. It is wrong for a **blocking** one: a blocking agent's critical finding fails the check and requests changes, so an unverified finding stops a merge on a claim that nothing ever checked against the file.

## The change

W2 verification is restored for blocking agents only, scoped three ways so `#385`'s guarantee survives:

- **Only BLOCKING agents.** A wrong advisory finding is noise; a wrong blocking one halts a merge. Cost and risk both follow the consequence.
- **DEMOTE, never drop.** A refuted finding still renders under "Unverified concerns" and is excluded from the blocking count (FP-L / W7). Anything the verifier does not return is re-attached as `unverified` rather than lost.
- **Nothing else comes back.** FP-A's confidence floor, the anti-pedantry pass and the line-proximity geometry stay bypassed for every custom finding, blocking or not.

`enforcement` is carried onto `CustomAgentDef` so repo-level `.mergewatch.yml` agents and dashboard org agents resolve it the same way. Absent means advisory, so existing repo config is unchanged.

## The bug inside the fix

The first version of this passed its own test for the wrong reason.

The shared grounding fetch is keyed off the **orchestrator's** findings, and custom findings never reach the orchestrator — so none of their files were in that map. `verifyFindings` skips a finding whose content it does not have, silently and by design, because a skip is not a refutation and must not tag anything.

So the feature would have shipped as a no-op: the log would say `verifying 1 finding from blocking agent`, nothing would come back changed, and it would look exactly like the verifier had agreed. Blocking findings now get their own fetch, scoped the same way as the verification.

`expect(octokit.repos.getContent).toHaveBeenCalled()` pins it, because verification succeeding and verification never running are otherwise indistinguishable.

## Limits — please read these as part of the review

Two things this PR does **not** establish:

1. **A unit test cannot tell us whether this works.** The verifier is a model call. Mocked, it proves the plumbing — that blocking findings are routed to it, that a refusal demotes rather than drops, that advisory findings are untouched. It proves nothing about the judgement.
2. **No end-to-end coverage.** `68-org-custom-agents` is manual-only as of fixtures#1551 (the E2E gate job has no AWS credentials, so its seed step can never succeed there). This path will not be exercised by the gate.

## Tests

Three added to `reviewer.test.ts`: a blocking finding verified and demoted-not-dropped; an advisory agent's `#385` bypass unchanged; a repo-level agent with no `enforcement` treated as advisory.

Full forced gate green — build 12/12, typecheck 20/20, test 21/21, all `Cached: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp