### PR TITLE
fix(core): reject a wrong-shaped orchestrator response instead of crashing (#540)

### DIFF
--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -973,6 +973,50 @@ describe('runOrchestratorAgent', () => {
     expect(llm.calls).toHaveLength(2);
   });
 
+  // #540 — the guards above defend PARSEABILITY. `findings: parsed.findings ?? []`
+  // rejects only null/undefined, so a parseable response carrying the WRONG TYPE
+  // for `findings` passed the `as` cast and crashed five stages later inside
+  // recordDrops as `se.map is not a function` — losing the whole review: no
+  // comment, no findings, just a red check saying nothing useful.
+  const TAGGED = [{ category: 'bug' as const, findings: [{ file: 'x.ts', line: 1, severity: 'critical' as const, confidence: 90, title: 'Real bug', description: '', suggestion: '' }] }];
+  const GOOD = JSON.stringify({
+    findings: [{ file: 'x.ts', line: 1, severity: 'critical', confidence: 90, category: 'bug', title: 'Real bug', description: '', suggestion: '' }],
+    mergeScore: 2, mergeScoreReason: 'Real bug.',
+  });
+
+  it.each([
+    ['an object', '{"findings": {"0": {"file": "x.ts"}}, "mergeScore": 2}'],
+    ['a string',  '{"findings": "none found", "mergeScore": 5}'],
+    ['a number',  '{"findings": 0, "mergeScore": 5}'],
+    ['null',      '{"findings": null, "mergeScore": 5}'],
+  ])('#540 — `findings` as %s is treated as unparseable and retried, not passed through', async (_label, bad) => {
+    const llm = createMockLLM([bad, GOOD]);
+    const result = await runOrchestratorAgent(TAGGED, 'model-1', 25, llm);
+    expect(llm.calls).toHaveLength(2);
+    expect(Array.isArray(result.findings)).toBe(true);
+    expect(result.findings).toHaveLength(1);
+  });
+
+  it('#540 — a wrong-shaped response twice throws, and never yields a silent all-clear', async () => {
+    // The critical half. Coercing a bad shape to [] would produce "no findings
+    // → 5/5" on a PR the agents flagged as critical — the exact silent approval
+    // #382 and fixtures#465 exist to prevent. Failing loudly is the contract.
+    const bad = '{"findings": {"0": {"file": "x.ts"}}, "mergeScore": 5}';
+    const llm = createMockLLM([bad, bad]);
+    await expect(runOrchestratorAgent(TAGGED, 'model-1', 25, llm))
+      .rejects.toThrow(/could not be parsed after retry/);
+    expect(llm.calls).toHaveLength(2);
+  });
+
+  it('#540 — a non-numeric mergeScore does not become NaN', async () => {
+    // mergeScore rides the same cast; a string survives Math.max/Math.min as
+    // NaN and renders as a broken badge instead of failing.
+    const llm = createMockLLM([JSON.stringify({ findings: [], mergeScore: 'high', mergeScoreReason: '' })]);
+    const result = await runOrchestratorAgent(TAGGED, 'model-1', 25, llm);
+    expect(Number.isFinite(result.mergeScore)).toBe(true);
+    expect(result.mergeScore).toBe(3);
+  });
+
   it('injects previous findings into the prompt and still calls the LLM when there are no new agent findings', async () => {
     const orchestratorResponse = JSON.stringify({
       findings: [

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -1387,13 +1387,39 @@ export async function runOrchestratorAgent(
   // the invocation once; if the retry is also unparseable, throw so the
   // review fails loudly (failure check run) instead of approving blind.
   type OrchestratorRaw = { findings: OrchestratedFinding[]; mergeScore?: number; mergeScoreReason?: string };
+
+  // #540 — the guards below defend PARSEABILITY. They did not defend SHAPE, and
+  // `findings: parsed.findings ?? []` only rejects null/undefined: a response of
+  // `{"findings": {...}}` is present, parses, and satisfies the `as` cast, which
+  // asserts an array nobody checked. The TypeError then surfaced five stages
+  // later inside recordDrops as `se.map is not a function`, losing the entire
+  // review — no comment, no findings, just a red check.
+  //
+  // Returning null for a bad shape routes it into the SAME retry-then-throw
+  // ladder as an unparseable one, which is the already-correct behaviour. It
+  // must never coerce to `[]`: a silent empty finding set is the 7-findings-to-
+  // 5/5 silent approval that #382 and fixtures#465 exist to prevent. A crash is
+  // bad; a false all-clear is worse.
+  const asOrchestratorRaw = (value: unknown): OrchestratorRaw | null => {
+    if (!value || typeof value !== 'object') return null;
+    const findings = (value as { findings?: unknown }).findings;
+    if (!Array.isArray(findings)) {
+      console.warn(
+        '[orchestrator] `findings` is %s, not an array — treating as unparseable (#540)',
+        findings === undefined ? 'absent' : typeof findings,
+      );
+      return null;
+    }
+    return value as OrchestratorRaw;
+  };
+
   let parsed: OrchestratorRaw | null = null;
   // #390 — prefer schema-constrained output: the orchestrator is the single
   // point where a parse failure used to cost EVERY finding at once. Silent
   // fallback on unsupported providers; throttles rethrow (review parks).
   if (llm.invokeStructured) {
     try {
-      parsed = (await llm.invokeStructured(modelId, prompt, ORCHESTRATOR_SCHEMA)).object as OrchestratorRaw;
+      parsed = asOrchestratorRaw((await llm.invokeStructured(modelId, prompt, ORCHESTRATOR_SCHEMA)).object);
     } catch (err) {
       if (isThrottleError(err)) throw err;
       if (!(err instanceof StructuredOutputUnsupportedError)) {
@@ -1403,22 +1429,27 @@ export async function runOrchestratorAgent(
   }
   if (!parsed) {
     const raw = normalizeLLMResult(await llm.invoke(modelId, prompt)).text;
-    parsed = tryParseJson<OrchestratorRaw>(raw, 'findings');
+    parsed = asOrchestratorRaw(tryParseJson<unknown>(raw, 'findings'));
   }
   if (!parsed) {
-    console.warn('[orchestrator] unparseable response — retrying once');
+    console.warn('[orchestrator] unparseable or wrong-shaped response — retrying once');
     const retryRaw = normalizeLLMResult(await llm.invoke(modelId, prompt)).text;
-    parsed = tryParseJson<OrchestratorRaw>(retryRaw, 'findings');
+    parsed = asOrchestratorRaw(tryParseJson<unknown>(retryRaw, 'findings'));
     if (!parsed) {
-      console.error('[orchestrator] unparseable response after retry:', retryRaw.trim().slice(0, 200));
+      console.error('[orchestrator] unusable response after retry:', retryRaw.trim().slice(0, 200));
       throw new Error(
         'Orchestrator response could not be parsed after retry — failing the review instead of approving with all findings dropped (#382)',
       );
     }
   }
+  // `mergeScore` rides the same cast. A non-numeric value survives
+  // Math.max/Math.min as NaN, which renders as a broken badge rather than
+  // failing, so it is normalised here rather than clamped blind.
+  const rawScore = parsed.mergeScore;
+  const mergeScore = typeof rawScore === 'number' && Number.isFinite(rawScore) ? rawScore : 3;
   return {
-    findings: parsed.findings ?? [],
-    mergeScore: Math.max(1, Math.min(5, parsed.mergeScore ?? 3)),
+    findings: parsed.findings,
+    mergeScore: Math.max(1, Math.min(5, mergeScore)),
     mergeScoreReason: parsed.mergeScoreReason ?? '',
   };
 }


### PR DESCRIPTION
Closes #540. Found by the v0.6.1 release gate, which failed and correctly refused to cut the release.

## What broke

`32-cross-agent-dedup` (fixtures#1617) produced **no review at all**. The check run said:

```
Review failed
MergeWatch encountered an error: se.map is not a function
```

```
TypeError: se.map is not a function
    at recordDrops (packages/core/src/agents/reviewer.ts:3000:32)
    at <pipeline> (packages/core/src/agents/reviewer.ts:3057:3)
```

## Why

The parse path already retries once and then throws, so an unparseable response fails loudly instead of approving with every finding dropped (#382 / fixtures#465). That guard covers **parseability**. It does not cover **shape**:

```ts
findings: parsed.findings ?? [],
```

`??` rejects only null and undefined. A response of `{"findings": {…}}` is present, parses fine, and satisfies `as OrchestratorRaw` — a cast asserting an array nobody checked. The mismatch then surfaces five stages downstream in an unrelated helper.

## The fix

`asOrchestratorRaw()` returns null unless `findings` is genuinely an array, applied at all three points that assign `parsed` (structured, text, retry). A bad shape routes into the **existing** retry-then-throw ladder — no new failure path.

It deliberately does **not** coerce to `[]`. Silently emptying findings produces "no action items → 5/5" on a PR the agents flagged critical, which is the exact silent approval #382 exists to prevent. A crash is bad; a false all-clear is worse. (Note `{"findings": null}` previously took that coercion path — it now retries.)

`mergeScore` rides the same cast and is normalised too: a string survives `Math.max/Math.min` as `NaN`.

## Tests

Six added, all verified to **fail without the fix and pass with it** — I reverted the source and re-ran to confirm, rather than trusting green:

- `findings` as an object / string / number / null → retried, not passed through
- wrong shape twice → throws, never a silent all-clear
- non-numeric `mergeScore` → 3, not `NaN`

Full forced gate green — build 12/12, typecheck 20/20, test 21/21, all `Cached: 0`.

## Scope note

This is **latent and pre-existing**, not a regression from anything in v0.6.1 — I verified the org agent involved is `advisory`, so #510's new blocking path never executed. It is model nondeterminism: the same commit reviewed the same PR successfully in the other stage minutes earlier, and only 1 of 48 fixtures hit it. Expect it to have been failing rarely and at random across all reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp