### PR TITLE
docs: explain the Contents write permission before we ask for it (#545)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Pre-built images are published to GHCR on pushes to `main` that change relevant 
 
 ### Environment variables
 
-Create a [GitHub App](https://github.com/settings/apps/new) first (permissions: `pull_requests` rw, `contents` r, `checks` rw, `issues` rw; events: `pull_request`, `issue_comment`, `installation`).
+Create a [GitHub App](https://github.com/settings/apps/new) first (permissions: `pull_requests` rw, `contents` rw, `checks` rw, `issues` rw; events: `pull_request`, `issue_comment`, `pull_request_review_comment`, `installation`). See [docs/permissions.md](docs/permissions.md) for what each one is used for — `contents` needs **write** only to resolve review threads, which is a GitHub requirement rather than a design choice, and `pull_request_review_comment` is what makes threaded replies work.
 
 | Variable | Required | Notes |
 |----------|----------|-------|

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,0 +1,92 @@
+# What MergeWatch asks for, and why
+
+MergeWatch is a code review tool. It reads your pull requests and writes review
+comments. This page lists every permission the GitHub App requests, what each
+one is actually used for, and — because we are asking for one more than we used
+to — why.
+
+If you would rather not take our word for it, all of this is enforceable by
+reading the source: the entire GitHub client lives in
+[`packages/core/src/github/client.ts`](../packages/core/src/github/client.ts).
+
+## The change: Contents is now Read and write
+
+**Previously:** `Contents: Read-only`
+**Now:** `Contents: Read and write`
+
+Existing installations will see a prompt from GitHub asking an owner to accept
+this. Until someone accepts, your installation keeps the old permissions and
+MergeWatch keeps working exactly as it does today — minus the one feature
+described below.
+
+### Why
+
+MergeWatch resolves an inline review thread in two situations:
+
+1. You reply `resolved` (or `/resolve`) in a finding's thread.
+2. A finding is **withdrawn** on a later review — the code changed and the
+   problem is gone — so the thread asserting it should not stay open.
+
+Both call GitHub's `resolveReviewThread` GraphQL mutation. That mutation
+requires **Contents: Read and write**, and `Pull requests: Read and write` is
+not sufficient for it. This is unintuitive — the operation touches a comment
+thread, not repository contents — and it is GitHub's requirement, not a design
+choice of ours. It is documented by GitHub only in a community discussion:
+<https://github.com/orgs/community/discussions/44650>
+
+We found it the way you would expect: the feature silently did nothing in
+production, and the API returned `Resource not accessible by integration`.
+
+### What we do NOT do with it
+
+`Contents: Read and write` is a broad permission. GitHub does not offer a
+narrower one that covers thread resolution, so this is the smallest grant that
+makes the feature work — not the smallest grant we would like to ask for.
+
+MergeWatch does not, and will not without a further explicit change:
+
+- push commits to your repository
+- create, modify, or delete branches, files, or tags
+- open or merge pull requests
+- change repository settings
+
+The write half of `Contents` is used for exactly one thing: resolving and
+unresolving review threads that MergeWatch itself created.
+
+### If you would rather not grant it
+
+Decline the prompt. Everything else continues to work: reviews run, findings
+post, inline comments appear, check runs pass and fail as before.
+
+What you lose is thread tidying — a thread you have replied `resolved` to, or
+whose finding no longer applies, stays open instead of collapsing. The
+underlying signal is still recorded either way, so declining costs you
+presentation, not correctness.
+
+We would rather tell you that plainly than have you discover a permission you
+did not expect.
+
+## Every permission, and what uses it
+
+| Permission | Level | Used for |
+|---|---|---|
+| **Pull requests** | Read and write | Reading the diff and PR metadata; posting the review summary, inline comments and review state (approve / request changes) |
+| **Contents** | Read and write | **Read:** fetching file contents to ground and verify findings against the real code, and reading `.mergewatch.yml` and convention files. **Write:** resolving review threads (see above) |
+| **Checks** | Read and write | Creating and updating the `MergeWatch Review` check run |
+| **Issues** | Read and write | Pull request comments — GitHub delivers PR-level comments through the Issues API |
+| **Metadata** | Read-only | Mandatory for every GitHub App |
+
+### Events
+
+`pull_request`, `issue_comment`, `pull_request_review_comment`, `installation`
+
+`pull_request_review_comment` is what makes replying inside a finding thread
+work. If you are configuring a self-hosted App and omit it, reviews will post
+normally but threaded replies — including `resolved` and `/mergewatch reject` —
+will be silently ignored.
+
+## Self-hosted
+
+If you self-host, you create and own the GitHub App, so you decide what it may
+do. Grant `Contents: Read-only` and skip thread resolution if that suits your
+policy better; nothing else changes.


### PR DESCRIPTION
Part of #545.

## Why

We are escalating the App from `Contents: Read-only` to `Contents: Read and write`, because `resolveReviewThread` requires it and `Pull requests: Read and write` is not sufficient — [GitHub community discussion #44650](https://github.com/orgs/community/discussions/44650). That is unintuitive, undocumented outside a discussion thread, and it is why FP-F inline resolve errored out and #526 silently did nothing.

Escalating permissions on existing installations is not quiet: GitHub prompts an owner to accept, and `Contents: write` is a broad grant on customer source code. For a product that argues for being open and auditable, asking for that without explaining it is the wrong way round.

## What this adds

`docs/permissions.md` — a user-facing note that says:

- **What changed and why**, naming GitHub's requirement rather than implying we need it
- **What the write half is used for**: resolving and unresolving threads MergeWatch created. Nothing else.
- **What we explicitly do not do**: no commits, branches, files, tags, PRs, or repo settings
- **What declining costs**: thread tidying, not correctness — reviews, findings, inline comments and check runs all continue. The signal is recorded either way.
- **Every permission** in a table with its actual use, so the ask is legible as a whole
- **Self-hosted**: you own the App; keep `Contents: Read-only` and skip thread resolution if you prefer

It says plainly that `Contents: write` is broader than we want, and that GitHub offers no narrower grant — because that is true, and a reader evaluating this will work it out anyway.

## README correction

The setup line was wrong in two ways, and both would bite a self-hoster:

- documented `contents` as **r** — an App built from it cannot resolve threads
- omitted **`pull_request_review_comment`** from the events — an App built from it posts reviews normally but **silently ignores every threaded reply**, including `resolved` and `/mergewatch reject`

The second explains a whole class of "inline replies don't work" that would be invisible to whoever hit it. Found while verifying the actual App behaviour against what the README claims (#544 is the sibling bug on the code side).

## Scope

Docs only — no code, no permission change. Flipping the App setting and rolling out the re-authorisation is a separate manual step, and this is written so it can land first and be linked from that prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp