### PR TITLE
fix(core): pass the deployment stage to the inline-reply handler (#544)

### DIFF
--- a/packages/core/src/agents/inline-reply.test.ts
+++ b/packages/core/src/agents/inline-reply.test.ts
@@ -471,6 +471,83 @@ describe('handleInlineReply', () => {
     expect(llm.calls).toHaveLength(0);
   });
 
+  // #544 — the marker check resolves via `inlineMarker(ctx.stage)`, and an
+  // ABSENT stage is prod (stage.ts:51). The Lambda and self-hosted handlers both
+  // omitted `stage`, so a dev App looked for the prod marker, failed to
+  // recognise a thread it had written itself, and silently discarded the reply.
+  // Verified in production: with the permission granted and everything else
+  // working, a dev-stage reply still returned `skipped`.
+  describe('#544 — stage-scoped thread ownership', () => {
+    const devThread = [
+      { id: 100, body: '<!-- mergewatch-inline:dev -->\nMissing try/catch around this call.', user: { login: 'mergewatch-ai-dev[bot]', type: 'Bot' as const }, created_at: '2026-04-01T00:00:00Z' },
+      { id: 101, body: 'resolved', user: { login: 'santthosh', type: 'User' as const }, in_reply_to_id: 100, created_at: '2026-04-01T01:00:00Z' },
+    ];
+
+    it('a dev-stage handler recognises a dev-stage thread root', async () => {
+      const { octokit } = makeOctokitMock(devThread);
+      const llm = makeLLM('unused');
+      const result = await handleInlineReply(
+        { owner: 'o', repo: 'r', prNumber: 1, replyCommentId: 101, stage: 'dev' },
+        { octokit, llm, lightModelId: 'light' },
+      );
+      expect(result.action).not.toBe('skipped');
+    });
+
+    it('a PROD-stage handler does NOT claim a dev-stage thread', async () => {
+      // The other half of the guarantee. Passing a stage must not become "any
+      // MergeWatch marker will do" — the two Apps run on the same PRs and must
+      // never answer in each other's threads (cf. #418).
+      const { octokit } = makeOctokitMock(devThread);
+      const llm = makeLLM('unused');
+      const result = await handleInlineReply(
+        { owner: 'o', repo: 'r', prNumber: 1, replyCommentId: 101, stage: 'prod' },
+        { octokit, llm, lightModelId: 'light' },
+      );
+      expect(result.action).toBe('skipped');
+      expect(result.reason).toMatch(/not a MergeWatch comment/);
+      expect(llm.calls).toHaveLength(0);
+    });
+
+    it('a dev-stage handler does NOT claim a prod-stage thread', async () => {
+      const { octokit } = makeOctokitMock(baseComments);
+      const llm = makeLLM('unused');
+      const result = await handleInlineReply(
+        { owner: 'o', repo: 'r', prNumber: 1, replyCommentId: 101, stage: 'dev' },
+        { octokit, llm, lightModelId: 'light' },
+      );
+      expect(result.action).toBe('skipped');
+      expect(llm.calls).toHaveLength(0);
+    });
+
+    it('an absent stage still means prod, so existing callers are unaffected', async () => {
+      // The documented contract of the field. This is what made the omission
+      // look harmless: absent is a VALID configuration for prod and self-hosted,
+      // so nothing about the call site read as wrong.
+      const { octokit } = makeOctokitMock(baseComments);
+      const llm = makeLLM('unused');
+      const result = await handleInlineReply(
+        { owner: 'o', repo: 'r', prNumber: 1, replyCommentId: 101 },
+        { octokit, llm, lightModelId: 'light' },
+      );
+      expect(result.action).not.toBe('skipped');
+    });
+
+    it('every skip carries a reason for the caller to log (#544)', async () => {
+      // The reason was always computed and always discarded by both runtimes.
+      // Asserting it exists here keeps the log fix honest at the source.
+      const { octokit } = makeOctokitMock([
+        { id: 100, body: 'human top comment', user: { login: 'alice', type: 'User' as const } },
+        { id: 101, body: 'reply', user: { login: 'bob', type: 'User' as const }, in_reply_to_id: 100 },
+      ]);
+      const result = await handleInlineReply(
+        { owner: 'o', repo: 'r', prNumber: 1, replyCommentId: 101 },
+        { octokit, llm: makeLLM('unused'), lightModelId: 'light' },
+      );
+      expect(result.action).toBe('skipped');
+      expect(result.reason).toBeTruthy();
+    });
+  });
+
   it('skips when the thread root is a third-party bot (CopilotAI, dependabot, etc.)', async () => {
     // Root is bot-authored but lacks the MergeWatch inline marker — exactly
     // the CopilotAI-thread scenario we want to ignore so MergeWatch doesn't

--- a/packages/lambda/src/handlers/inline-reply-stage.test.ts
+++ b/packages/lambda/src/handlers/inline-reply-stage.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * #544 — the inline-reply call site must pass the deployment stage.
+ *
+ * This is a source assertion, and it is deliberate. The bug was NOT in
+ * `handleInlineReply`: that function has accepted a `stage` since #416 and
+ * behaves correctly for every value of it, which is why the core unit tests
+ * passed throughout the entire period the feature was broken. The bug was that
+ * the Lambda handler never passed one.
+ *
+ * An absent stage IS prod (`stage.ts:51`), so the omission had no type error,
+ * no runtime error, and no failing test — a non-prod App simply looked for the
+ * prod marker, failed to recognise a thread it had written itself, and
+ * discarded the user's reply. It took driving a fixture by hand against a
+ * deployed stage to notice.
+ *
+ * Testing the call site is the only level at which that class of bug is
+ * visible. #416 wired STAGE through four other call sites in this file and
+ * missed this one; nothing could have told us.
+ */
+describe('#544 — the inline-reply call site passes the stage', () => {
+  const src = readFileSync(join(__dirname, 'review-agent.ts'), 'utf-8');
+
+  /** The `handleInlineReply({...})` context argument, as written in source. */
+  function inlineReplyContext(): string {
+    const at = src.indexOf('handleInlineReply(');
+    expect(at, 'handleInlineReply is no longer called from review-agent.ts').toBeGreaterThan(-1);
+    // The context object is the first argument: from the first `{` to its match.
+    const open = src.indexOf('{', at);
+    let depth = 0;
+    for (let i = open; i < src.length; i++) {
+      if (src[i] === '{') depth++;
+      else if (src[i] === '}' && --depth === 0) return src.slice(open, i + 1);
+    }
+    throw new Error('could not find the end of the inline-reply context object');
+  }
+
+  it('passes `stage` into the context', () => {
+    expect(inlineReplyContext()).toMatch(/\bstage:/);
+  });
+
+  it('passes the module STAGE constant, not a literal', () => {
+    // `stage: 'prod'` or `stage: undefined` would satisfy the check above while
+    // reintroducing exactly this bug.
+    expect(inlineReplyContext()).toMatch(/\bstage:\s*STAGE\b/);
+  });
+
+  it('STAGE is read from the environment', () => {
+    expect(src).toMatch(/const STAGE = process\.env\.STAGE/);
+  });
+
+  it('logs the skip reason alongside the action', () => {
+    // The reason was computed on every skip and thrown away, so the log could
+    // not distinguish "not our thread" from "already answered". That is why
+    // this cost a hand-driven investigation rather than a log read.
+    expect(src).toMatch(/result\.reason/);
+  });
+});

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -264,6 +264,12 @@ async function handleInlineReplyMode(
         prNumber,
         replyCommentId: inlineReplyCommentId,
         conventions: conventionsResult?.content,
+        // #544 — WITHOUT this the marker check falls back to prod (an absent
+        // stage IS prod, by stage.ts:51), so a non-prod App looks for the prod
+        // marker, fails to recognise a thread it wrote itself, and silently
+        // discards the reply. Every other STAGE-scoped call site in this file
+        // was wired by #416; this one was missed.
+        stage: STAGE,
       },
       {
         octokit,
@@ -358,8 +364,12 @@ async function handleInlineReplyMode(
     }
 
     console.log(
-      'Inline reply %s for %s#%d (reply=%d, cost=$%s)',
+      // #544 — `reason` was computed on every skip and then thrown away, so
+      // the log could not distinguish "not our thread" from "already answered".
+      // That is the whole reason this took a hand-driven fixture to find.
+      'Inline reply %s%s for %s#%d (reply=%d, cost=$%s)',
       result.action,
+      result.reason ? ` (${result.reason})` : '',
       repoFullName,
       prNumber,
       inlineReplyCommentId,

--- a/packages/server/src/inline-reply-stage.test.ts
+++ b/packages/server/src/inline-reply-stage.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * #544 — the inline-reply call site must pass the deployment stage.
+ *
+ * This is a source assertion, and it is deliberate. The bug was NOT in
+ * `handleInlineReply`: that function has accepted a `stage` since #416 and
+ * behaves correctly for every value of it, which is why the core unit tests
+ * passed throughout the entire period the feature was broken. The bug was that
+ * the self-hosted handler never passed one.
+ *
+ * An absent stage IS prod (`stage.ts:51`), so the omission had no type error,
+ * no runtime error, and no failing test — a non-prod App simply looked for the
+ * prod marker, failed to recognise a thread it had written itself, and
+ * discarded the user's reply. It took driving a fixture by hand against a
+ * deployed stage to notice.
+ *
+ * Testing the call site is the only level at which that class of bug is
+ * visible. #416 wired STAGE through the check-run call sites in this file and
+ * missed this one; nothing could have told us.
+ */
+describe('#544 — the inline-reply call site passes the stage', () => {
+  const src = readFileSync(join(__dirname, 'review-processor.ts'), 'utf-8');
+
+  /** The `handleInlineReply({...})` context argument, as written in source. */
+  function inlineReplyContext(): string {
+    const at = src.indexOf('handleInlineReply(');
+    expect(at, 'handleInlineReply is no longer called from review-processor.ts').toBeGreaterThan(-1);
+    // The context object is the first argument: from the first `{` to its match.
+    const open = src.indexOf('{', at);
+    let depth = 0;
+    for (let i = open; i < src.length; i++) {
+      if (src[i] === '{') depth++;
+      else if (src[i] === '}' && --depth === 0) return src.slice(open, i + 1);
+    }
+    throw new Error('could not find the end of the inline-reply context object');
+  }
+
+  it('passes `stage` into the context', () => {
+    expect(inlineReplyContext()).toMatch(/\bstage:/);
+  });
+
+  it('passes the module STAGE constant, not a literal', () => {
+    // `stage: 'prod'` or `stage: undefined` would satisfy the check above while
+    // reintroducing exactly this bug.
+    expect(inlineReplyContext()).toMatch(/\bstage:\s*STAGE\b/);
+  });
+
+  it('STAGE is read from the environment', () => {
+    expect(src).toMatch(/const STAGE = process\.env\.STAGE/);
+  });
+
+  it('logs the skip reason alongside the action', () => {
+    // The reason was computed on every skip and thrown away, so the log could
+    // not distinguish "not our thread" from "already answered". That is why
+    // this cost a hand-driven investigation rather than a log read.
+    expect(src).toMatch(/result\.reason/);
+  });
+});

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -187,6 +187,10 @@ async function handleInlineReplyJob(
         prNumber,
         replyCommentId: inlineReplyCommentId,
         conventions: conventionsResult?.content,
+        // #544 — see the Lambda handler. A self-hosted deployment that sets
+        // STAGE to anything other than prod would otherwise ignore every
+        // threaded reply its users write.
+        stage: STAGE,
       },
       {
         octokit,
@@ -284,8 +288,9 @@ async function handleInlineReplyJob(
     }
 
     console.log(
-      'Inline reply %s for %s#%d (reply=%d, cost=$%s)',
+      'Inline reply %s%s for %s#%d (reply=%d, cost=$%s)',
       result.action,
+      result.reason ? ` (${result.reason})` : '',
       repoFullName,
       prNumber,
       inlineReplyCommentId,


### PR DESCRIPTION
Closes #544.

## The bug

On any non-prod stage, replying in a MergeWatch inline thread does nothing. `/mergewatch reject`, `resolved`, and ordinary threaded conversation are all discarded. The log says only:

```
Inline reply skipped for <repo>#1712 (reply=3930393921, cost=$0.0000)
```

`handleInlineReply` decides whether a thread is ours via `inlineMarker(ctx.stage)`, and an **absent stage is prod** (`stage.ts:51`). Neither runtime passed one, so a dev App looked for `<!-- mergewatch-inline -->` while its own thread root carried `<!-- mergewatch-inline:dev -->` — not a substring match — concluded "not a MergeWatch comment", and dropped the user's reply.

`InlineReplyContext.stage` has existed since #416. That PR wired `STAGE` through four other call sites in the Lambda handler and the check-run sites in the server, and missed these two.

## Why nothing caught it

- **No type error** — `stage` is optional, and absent is a *valid* configuration for prod and self-hosted. The call site does not read as wrong.
- **No runtime error** — the skip is a normal return.
- **The unit tests passed the whole time**, because `handleInlineReply` was never the broken part. It has always handled every value of `stage` correctly.

Same shape as #510 and #526: the code runs, logs a result, and achieves nothing.

## Evidence

Driven by hand against both deployed stages. The identical `/mergewatch reject` posted in each stage's thread on one PR, a minute apart:

| Thread | Result |
|---|---|
| dev | `Inline reply skipped` — nothing recorded |
| prod | `Inline reply rejected` · `[fb-d] recorded 2 /mergewatch rejects` · finding comment footer added |

Re-tested after granting the dev App the #545 permission — **still `skipped`, not FORBIDDEN**, which isolates this from access entirely.

## The fix

- Pass `STAGE` into the context in both the Lambda handler and the self-hosted server.
- Log `result.reason` next to `result.action`. Every skip already computed one and both runtimes discarded it, so "not our thread" and "already answered" were indistinguishable — that is why this needed a hand-driven fixture instead of a log read.

## Tests

**The core tests here would not have caught this, and I verified that** — I reverted the fix and they all still passed, because the core was never broken. So the new assertions target the **call sites**:

- `stage` is present in the context
- it is the module `STAGE` constant, not a literal (`stage: 'prod'` would satisfy a naive check while reintroducing the bug)
- the skip reason is logged

**3 of 4 fail in each package without this change** (the 4th asserts `STAGE` exists at all — a precondition true either way).

Core tests are added too, covering the behaviour contract: a dev handler claims a dev thread; a prod handler does **not** claim a dev thread and vice versa (the two Apps share PRs and must never answer in each other's threads, cf. #418); and an absent stage still means prod, so existing callers are unaffected.

Full forced gate green — build 12/12, typecheck 20/20, test 21/21, all `Cached: 0`.

## Out of scope

Changing `isProd(undefined)`'s prod default is deliberately **not** here. It is load-bearing for *writers* — an unconfigured deployment must write prod markers — and changing it would ripple through every marker call site. That readers should arguably fail loudly instead is worth its own issue.

## Follow-on effect worth knowing

`resolveWithdrawnFindingThreads` refuses to touch a thread containing any non-App comment ("ours, and ours alone", `client.ts:1299`) so it never resolves a conversation out from under a human. Correct — but combined with this bug, a user's ignored `resolved` reply stays in the thread and **permanently** disqualifies it from withdrawn-thread cleanup. The action does nothing *and* blocks the tidy-up that would have closed it. Fixing this removes that trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp