### PR TITLE
fix(release): grant actions:write so the gate can dispatch docker-publish

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -53,6 +53,12 @@ on:
 
 permissions:
   contents: write
+  # `actions: write` is what lets the release job DISPATCH docker-publish.
+  # Without it the dispatch fails 403 "Resource not accessible by integration"
+  # and the release exists with no images — which is exactly what v0.6.1 did.
+  # It is not covered by `contents: write`: dispatching a workflow is an Actions
+  # API write, and GITHUB_TOKEN grants only what is declared here.
+  actions: write
 
 jobs:
   suite:

--- a/packages/lambda/src/docker-publish.test.ts
+++ b/packages/lambda/src/docker-publish.test.ts
@@ -63,6 +63,27 @@ describe('docker-publish — only a release ships images', () => {
 });
 
 describe('release gate — the release actually ships images', () => {
+  // v0.6.1: the gate tagged, created the release, then failed dispatching
+  // docker-publish with
+  //   HTTP 403: Resource not accessible by integration
+  //     .../actions/workflows/<id>/dispatches
+  // because the workflow declared only `contents: write`. Dispatching a
+  // workflow is an ACTIONS API write, and GITHUB_TOKEN grants exactly what the
+  // permissions block lists — so the release shipped with no images and a human
+  // had to publish them by hand.
+  //
+  // Asserted here rather than in the dispatch step because the failure is a
+  // property of the workflow's declared permissions, which nothing else checks.
+  it('grants actions: write, without which the dispatch 403s', () => {
+    const perms = gate.permissions ?? {};
+    expect(perms['actions']).toBe('write');
+  });
+
+  it('still grants contents: write for tagging and the release', () => {
+    // Guard against "fixing" the above by replacing rather than adding.
+    expect((gate.permissions ?? {})['contents']).toBe('write');
+  });
+
   const publish = () =>
     gate.jobs.release.steps.find((s: any) => s.name === 'Publish the images');
 


### PR DESCRIPTION
Found by cutting v0.6.1.

## What happened

The release gate tagged `v0.6.1`, created the GitHub release, and then failed:

```
could not create workflow dispatch event: HTTP 403: Resource not accessible by integration
https://api.github.com/repos/mergewatch/mergewatch.ai/actions/workflows/244437205/dispatches
```

**The release exists; the images did not.** They were published manually afterwards.

## Cause

```yaml
permissions:
  contents: write
```

Dispatching a workflow is an **Actions API write**, not a contents write, and `GITHUB_TOKEN` grants exactly what the permissions block lists. So `gh workflow run docker-publish.yml` was forbidden.

## The guard worked

This is the failure #513/#514 anticipated. Rather than reporting a green release with no images, the step failed with:

```
::error::docker-publish never started for $VERSION — the release exists without images
```

That is the whole point of that guard, and it is why this was caught in the run rather than discovered later by someone pulling a missing tag.

## Tests

Two assertions on the workflow's declared permissions — the only level at which this failure is visible, since nothing about the dispatch step's code is wrong:

- `actions: write` is granted (**fails without this change** — verified by reverting)
- `contents: write` is still granted, so a future fix cannot replace it rather than add to it

Full forced gate green — build 12/12, typecheck 20/20, test 21/21, all `Cached: 0`.

## Fourth of a kind this week

| | Code | Missing | Symptom |
|---|---|---|---|
| #544 | correct | `stage` not passed | replies silently ignored |
| #545 | correct | `Contents: write` | resolve silently forbidden |
| #558 | correct | `check_suite` handler | Re-run button inert |
| this | correct | `actions: write` | release ships without images |

Every one: implementation right, an out-of-band grant or wiring missing, and unit tests green because the missing piece is not in the code under test. This one was caught only because someone had already written a guard that refused to call it a success. That argues for #548's capability check covering **declared workflow permissions** too, not just App permissions and webhook subscriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp