### PR TITLE
fix(core): handle check_suite.rerequested so the Re-run button works (#558)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -292,6 +292,7 @@ export type {
   MarketplacePurchaseEvent,
   MarketplacePurchase,
   CheckRunEvent,
+  CheckSuiteEvent,
   CheckRunPullRequestRef,
   WebhookEvent,
   ReviewMode,

--- a/packages/core/src/types/github.ts
+++ b/packages/core/src/types/github.ts
@@ -281,6 +281,30 @@ export interface CheckRunEvent {
   sender: GitHubUser;
 }
 
+/**
+ * `check_suite` — what GitHub actually fires for the "Re-run" button.
+ *
+ * #558: the webhook handled `check_run.rerequested` and GitHub sends
+ * `check_suite.rerequested`, so the button silently did nothing in production
+ * for every user. A suite has no `name`, which is why ownership cannot be
+ * decided the way `isMergeWatchCheckRun` decides it.
+ */
+export interface CheckSuiteEvent {
+  action: "completed" | "requested" | "rerequested";
+  check_suite: {
+    id: number;
+    head_sha: string;
+    status: string | null;
+    conclusion: string | null;
+    /** The App the suite belongs to. Present, but see #558 on why it is not the identity check. */
+    app?: { id: number; slug: string; name: string };
+    pull_requests: CheckRunPullRequestRef[];
+  };
+  repository: GitHubRepository;
+  installation?: { id: number };
+  sender: GitHubUser;
+}
+
 // ---------------------------------------------------------------------------
 // Discriminated union for routing
 // ---------------------------------------------------------------------------

--- a/packages/lambda/src/handlers/webhook.test.ts
+++ b/packages/lambda/src/handlers/webhook.test.ts
@@ -643,6 +643,16 @@ describe('handler — check_suite.rerequested (#558)', () => {
     expect(mockEnqueue).not.toHaveBeenCalled();
   });
 
+  it('resolves the installation client once, not once per step', async () => {
+    // Review finding on #562: the ownership check and the enqueue each resolved
+    // their own client, so every Re-run cost two token exchanges for the same
+    // installation — and gave the second one a chance to fail after ownership
+    // had already passed.
+    await handler(makeCheckSuiteApiEvent(JSON.stringify(makeCheckSuiteEvent())));
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
+    expect(mockGetInstallationOctokit).toHaveBeenCalledTimes(1);
+  });
+
   it('one suite event yields exactly one job, however many checks it holds', async () => {
     // The fan-out worry resolves by construction: the suite is one event.
     mockGetInstallationOctokit.mockResolvedValue(

--- a/packages/lambda/src/handlers/webhook.test.ts
+++ b/packages/lambda/src/handlers/webhook.test.ts
@@ -74,7 +74,7 @@ vi.mock('../github-auth-ssm.js', () => ({
 
 import { verifySignature, parseReviewMode, shouldHandleReviewCommentEvent, isMergeWatchCheckRun, handler } from './webhook.js';
 import { REVIEW_TRIGGERING_ACTIONS, COMMENT_LOOKUP_ACTIONS, MERGEWATCH_CHECK_RUN_NAME } from '@mergewatch/core';
-import type { PullRequestReviewCommentEvent, PullRequestEvent, CheckRunEvent } from '@mergewatch/core';
+import type { PullRequestReviewCommentEvent, PullRequestEvent, CheckRunEvent, CheckSuiteEvent } from '@mergewatch/core';
 
 // ---------------------------------------------------------------------------
 // verifySignature
@@ -508,6 +508,148 @@ describe('isMergeWatchCheckRun', () => {
     const event = makeCheckRunEvent();
     (event.check_run as unknown as { name: undefined }).name = undefined;
     expect(isMergeWatchCheckRun(event)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #558 — check_suite.rerequested dispatch
+//
+// The "Re-run" button fires check_suite.rerequested, not check_run.rerequested.
+// The webhook handled only the latter, so the event hit the dispatch switch's
+// default branch and the button silently did nothing — in production, for every
+// user. handleCheckRunEvent was correct throughout; it was never reached.
+// ---------------------------------------------------------------------------
+
+function makeCheckSuiteEvent(overrides: {
+  action?: CheckSuiteEvent['action'];
+  pullRequests?: CheckSuiteEvent['check_suite']['pull_requests'];
+  installation?: CheckSuiteEvent['installation'];
+} = {}): CheckSuiteEvent {
+  const base = makeCheckRunEvent();
+  return {
+    action: overrides.action ?? 'rerequested',
+    check_suite: {
+      id: 7001,
+      head_sha: 'abc123',
+      status: 'completed',
+      conclusion: 'failure',
+      app: { id: 42, slug: 'mergewatch-ai', name: 'MergeWatch' },
+      pull_requests: overrides.pullRequests ?? base.check_run.pull_requests,
+    },
+    repository: base.repository,
+    installation: 'installation' in overrides ? overrides.installation : { id: 999 },
+    sender: base.sender,
+  };
+}
+
+function makeCheckSuiteApiEvent(body: string) {
+  return {
+    body,
+    headers: {
+      'x-hub-signature-256': signBody(body),
+      'x-github-event': 'check_suite',
+    },
+  } as any;
+}
+
+/** Octokit whose listForRef reports the check runs present on the head SHA. */
+function octokitWithChecks(names: string[]) {
+  return {
+    pulls: {
+      get: vi.fn().mockResolvedValue({
+        data: { draft: false, labels: [{ name: 'needs-review' }], changed_files: 3 },
+      }),
+    },
+    checks: {
+      listForRef: vi.fn().mockResolvedValue({
+        data: { check_runs: names.map((name) => ({ name })) },
+      }),
+    },
+  };
+}
+
+describe('handler — check_suite.rerequested (#558)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetInstallationOctokit.mockResolvedValue(octokitWithChecks([MERGEWATCH_CHECK_RUN_NAME]));
+    mockFetchRepoConfig.mockResolvedValue(null);
+    mockClassifyPrSource.mockResolvedValue({ source: 'human' });
+    mockFindExistingBotComment.mockResolvedValue(555);
+  });
+
+  it('enqueues a review job — the button now does something', async () => {
+    const body = JSON.stringify(makeCheckSuiteEvent());
+    const res = await handler(makeCheckSuiteApiEvent(body));
+
+    expect(res.statusCode).toBe(200);
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(
+      (mockEnqueue.mock.calls[0][0] as { input: { Payload: Buffer } }).input.Payload.toString(),
+    );
+    expect(payload.prNumber).toBe(42);
+    expect(payload.mode).toBe('review');
+    expect(payload.headSha).toBe('abc123');
+    expect(payload.existingCommentId).toBe(555);
+  });
+
+  it('ignores a suite that is not ours', async () => {
+    // A suite has no `name`, so isMergeWatchCheckRun's rule cannot be applied to
+    // the payload. It is applied one level down instead: our stage's check run
+    // must exist on the suite's head.
+    mockGetInstallationOctokit.mockResolvedValue(octokitWithChecks(['CodeQL', 'Build & Test']));
+    const body = JSON.stringify(makeCheckSuiteEvent());
+    const res = await handler(makeCheckSuiteApiEvent(body));
+
+    expect(res.statusCode).toBe(200);
+    expect(mockEnqueue).not.toHaveBeenCalled();
+  });
+
+  it('fails CLOSED when the ownership check errors', async () => {
+    // A missed re-run is recoverable by pushing a commit. Reviewing another
+    // tool's suite spends real money on work nobody asked for.
+    mockGetInstallationOctokit.mockResolvedValue({
+      pulls: { get: vi.fn() },
+      checks: { listForRef: vi.fn().mockRejectedValue(new Error('503')) },
+    });
+    const res = await handler(makeCheckSuiteApiEvent(JSON.stringify(makeCheckSuiteEvent())));
+
+    expect(res.statusCode).toBe(200);
+    expect(mockEnqueue).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-rerequested actions', async () => {
+    // `requested` fires on every push and would double every review.
+    for (const action of ['requested', 'completed'] as const) {
+      vi.clearAllMocks();
+      mockGetInstallationOctokit.mockResolvedValue(octokitWithChecks([MERGEWATCH_CHECK_RUN_NAME]));
+      await handler(makeCheckSuiteApiEvent(JSON.stringify(makeCheckSuiteEvent({ action }))));
+      expect(mockEnqueue, action).not.toHaveBeenCalled();
+    }
+  });
+
+  it('ignores a suite with no attached PR', async () => {
+    const res = await handler(
+      makeCheckSuiteApiEvent(JSON.stringify(makeCheckSuiteEvent({ pullRequests: [] }))),
+    );
+    expect(res.statusCode).toBe(200);
+    expect(mockEnqueue).not.toHaveBeenCalled();
+  });
+
+  it('ignores an event with no installation id', async () => {
+    const res = await handler(
+      makeCheckSuiteApiEvent(JSON.stringify(makeCheckSuiteEvent({ installation: undefined }))),
+    );
+    expect(res.statusCode).toBe(200);
+    expect(mockEnqueue).not.toHaveBeenCalled();
+  });
+
+  it('one suite event yields exactly one job, however many checks it holds', async () => {
+    // The fan-out worry resolves by construction: the suite is one event.
+    mockGetInstallationOctokit.mockResolvedValue(
+      octokitWithChecks([MERGEWATCH_CHECK_RUN_NAME, 'CodeQL', 'Build & Test']),
+    );
+    await handler(makeCheckSuiteApiEvent(JSON.stringify(makeCheckSuiteEvent())));
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/lambda/src/handlers/webhook.ts
+++ b/packages/lambda/src/handlers/webhook.ts
@@ -43,6 +43,7 @@ import type {
   ReviewMode,
   ReviewJobPayload,
   AgentReviewConfig,
+  CheckSuiteEvent,
 } from '@mergewatch/core';
 import {
   DynamoPRLifecycleStore, DEFAULT_PR_LIFECYCLE_TABLE,
@@ -499,15 +500,99 @@ async function handleCheckRunEvent(event: CheckRunEvent): Promise<void> {
     return;
   }
 
+  await enqueueRereview({
+    installationId,
+    repository: event.repository,
+    prNumber: prRef.number,
+    // The event already names the commit the check ran on, so the config ref
+    // does not depend on the PR lookup succeeding.
+    headSha: event.check_run.head_sha,
+    trigger: 'check_run rerequested',
+  });
+}
+
+/**
+ * #558 — the "Re-run" button in GitHub's Checks UI fires
+ * `check_suite.rerequested`, NOT `check_run.rerequested`. The webhook only
+ * handled the latter, so the event fell through to the dispatch switch's
+ * default branch and the button silently did nothing — in production, for
+ * every user, on every PR. `handleCheckRunEvent` was complete and correct the
+ * whole time; it was simply never reached.
+ *
+ * `check_run.rerequested` is kept: GitHub sends it when a SINGLE check run is
+ * re-run, which is a different affordance with a different payload shape.
+ */
+async function handleCheckSuiteEvent(event: CheckSuiteEvent): Promise<void> {
+  if (event.action !== 'rerequested') return;
+
+  const installationId = event.installation?.id;
+  if (!installationId) {
+    console.warn('check_suite event missing installation ID — skipping');
+    return;
+  }
+
+  const prRef = event.check_suite.pull_requests?.[0];
+  if (!prRef) {
+    // A suite on a commit with no PR (a branch push). Nothing to review.
+    console.warn(
+      `check_suite rerequested with no attached PR on ${event.repository.full_name} @ ${event.check_suite.head_sha}`,
+    );
+    return;
+  }
+
   const owner = event.repository.owner.login;
   const repo = event.repository.name;
-  const prNumber = prRef.number;
+  const headSha = event.check_suite.head_sha;
+
+  // A suite carries no `name`, so `isMergeWatchCheckRun`'s identity rule cannot
+  // be applied to the payload. Apply the SAME rule one level down instead: our
+  // stage's check run must exist on the suite's head. That keeps a rename from
+  // breaking it (unlike app.id), keeps dev from acting on prod's suite, and
+  // costs one call on an event that only fires when a human clicks a button.
+  const octokit = await authProvider.getInstallationOctokit(installationId);
+  const isOurs = await octokit.checks
+    .listForRef({ owner, repo, ref: headSha, per_page: 100 })
+    .then(({ data }) => data.check_runs.some((c) => c.name === checkRunName(STAGE)))
+    .catch((err) => {
+      // Fail closed: an unverifiable suite is not re-reviewed. A missed
+      // re-run is recoverable by pushing a commit; reviewing another tool's
+      // suite spends real money on work nobody asked for.
+      console.warn(
+        `check_suite ownership check failed for ${owner}/${repo}@${headSha} — not re-reviewing:`,
+        err,
+      );
+      return false;
+    });
+  if (!isOurs) return;
+
+  await enqueueRereview({
+    installationId,
+    repository: event.repository,
+    prNumber: prRef.number,
+    headSha,
+    trigger: 'check_suite rerequested',
+  });
+}
+
+/**
+ * Shared tail for both re-run entry points (#558).
+ *
+ * Extracted rather than duplicated: `check_run` and `check_suite` must produce
+ * an identical review job, and two copies of the classification + comment
+ * lookup would drift the first time one of them was touched.
+ */
+async function enqueueRereview(args: {
+  installationId: number;
+  repository: CheckRunEvent['repository'];
+  prNumber: number;
+  headSha: string;
+  trigger: string;
+}): Promise<void> {
+  const { installationId, repository, prNumber, headSha, trigger } = args;
+  const owner = repository.owner.login;
+  const repo = repository.name;
 
   const octokit = await authProvider.getInstallationOctokit(installationId);
-
-  // The check_run event already names the commit the check ran on, so the
-  // config ref does not depend on the PR lookup succeeding.
-  const headSha = event.check_run.head_sha;
 
   // Classification: refetch the PR so we get a full object + labels for
   // agentReview detection, mirroring the pull_request.synchronize path.
@@ -519,7 +604,7 @@ async function handleCheckRunEvent(event: CheckRunEvent): Promise<void> {
     .then(({ data }) => data)
     .catch((err) => {
       console.warn(
-        'Failed to fetch PR for check_run rerequest — enqueuing without labels/classification:',
+        `Failed to fetch PR for ${trigger} — enqueuing without labels/classification:`,
         `${owner}/${repo}#${prNumber}`,
         err,
       );
@@ -550,11 +635,11 @@ async function handleCheckRunEvent(event: CheckRunEvent): Promise<void> {
     source: classification.source,
     agentKind: classification.agentKind,
     headSha,
-    ...ossRepoFields(event.repository),
+    ...ossRepoFields(repository),
   });
 
   console.log(
-    `Enqueued review job from check_run rerequested: ${owner}/${repo}#${prNumber} (existingComment=${existingCommentId ?? 'none'})`,
+    `Enqueued review job from ${trigger}: ${owner}/${repo}#${prNumber} (existingComment=${existingCommentId ?? 'none'})`,
   );
 }
 
@@ -740,6 +825,10 @@ export async function handler(
 
       case "check_run":
         await handleCheckRunEvent(payload as CheckRunEvent);
+        break;
+
+      case "check_suite":
+        await handleCheckSuiteEvent(payload as CheckSuiteEvent);
         break;
 
       case "installation":

--- a/packages/lambda/src/handlers/webhook.ts
+++ b/packages/lambda/src/handlers/webhook.ts
@@ -571,6 +571,7 @@ async function handleCheckSuiteEvent(event: CheckSuiteEvent): Promise<void> {
     prNumber: prRef.number,
     headSha,
     trigger: 'check_suite rerequested',
+    octokit,
   });
 }
 
@@ -587,12 +588,20 @@ async function enqueueRereview(args: {
   prNumber: number;
   headSha: string;
   trigger: string;
+  /**
+   * An already-resolved client, when the caller needed one anyway. The
+   * check_suite path resolves one for its ownership check; re-resolving here
+   * would be a second token exchange for the same installation, and a second
+   * place for that exchange to fail after the ownership check already passed.
+   * Absent on the check_run path, which has no prior call.
+   */
+  octokit?: Awaited<ReturnType<typeof authProvider.getInstallationOctokit>>;
 }): Promise<void> {
   const { installationId, repository, prNumber, headSha, trigger } = args;
   const owner = repository.owner.login;
   const repo = repository.name;
 
-  const octokit = await authProvider.getInstallationOctokit(installationId);
+  const octokit = args.octokit ?? (await authProvider.getInstallationOctokit(installationId));
 
   // Classification: refetch the PR so we get a full object + labels for
   // agentReview detection, mirroring the pull_request.synchronize path.


### PR DESCRIPTION
Closes #558.

## The bug

Clicking **Re-run** on the `MergeWatch Review` check did nothing — in production, for every user, on every PR. No review, no error, and the only trace was:

```
Ignoring unhandled event type: check_suite
```

GitHub fires **`check_suite.rerequested`** for that button. The webhook handled only `check_run.rerequested`, so the event hit the dispatch switch's `default` branch and was discarded. `handleCheckRunEvent` was complete and correct the entire time — including #416's stage-aware name matching — it was simply never reached.

Three clicks produced three `check_suite` deliveries on the prod webhook and **no** `check_run` event in three days of logs.

## The fix

- `case "check_suite"` handling `rerequested`, resolving the PR from `check_suite.pull_requests[0]`.
- `check_run` is **kept** — GitHub sends it when a *single* check run is re-run, a different affordance with a different payload shape.
- The shared tail (PR fetch → classification → existing-comment lookup → enqueue) is **extracted rather than duplicated**, so the two entry points cannot drift into producing different review jobs.

## Ownership, and why it is not `app.id`

A suite has no `name`, so `isMergeWatchCheckRun`'s rule cannot be applied to the payload. Its own comment explains why `app.id` is not the identity check:

> We match by name (stable across deploys) since `check_run.app.id` requires knowing our GitHub App ID at runtime.

So the same rule is applied one level down: **our stage's check run must exist on the suite's head SHA.** That survives an App rename, keeps dev from acting on prod's suite, and costs one API call on an event that only fires when a human clicks a button.

It **fails closed**. A missed re-run is recoverable by pushing a commit; re-reviewing another tool's suite spends real money on work nobody asked for.

## On fan-out

The acceptance criteria asked that a suite re-run not fan out into duplicate reviews. That **resolves by construction** — one suite event yields one job however many check runs the suite holds, and there is a test asserting exactly that.

Separately, `check_run.rerequested` and `check_suite.rerequested` do not co-fire today (three clicks → three `check_suite`, zero `check_run`), so handling both does not double-enqueue. The enqueue path has no dedup, so I have **not** built speculative dedup for a case with no evidence — flagging it here rather than hiding it.

## Tests

Seven added. **Two fail without the handler** (the positive cases); the other five are negative guards — ignore a non-ours suite, fail closed on an ownership-check error, ignore `requested`/`completed` (which fire on every push and would double every review), ignore a suite with no PR, ignore a missing installation id. Those pass trivially against a no-op baseline by design: they exist to stop the *new* code over-firing, not to catch the original bug.

Full forced gate green — build 12/12, typecheck 20/20, test 21/21, all `Cached: 0`.

## Provenance

Found by driving `12-rerun-check` by hand during v0.6.1's manual verification — the fixture whose entire procedure is clicking this button, and which had therefore never passed. The gate cannot catch this class: it is an event the fixture suite has no way to emit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp