### PR TITLE
feat(core): prompts become ordered segments with stability labels (#489)

### DIFF
--- a/packages/core/src/agents/prompt-golden.test.ts
+++ b/packages/core/src/agents/prompt-golden.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { buildPrompt } from './reviewer.js';
+import { renderPrompt, findVolatilityInversion } from '../llm/prompt-segment.js';
+import { applyConfidenceFloor } from './prompts.js';
+
+/**
+ * #489 — the guarantee that makes this refactor safe.
+ *
+ * `buildPrompt` went from returning a string to returning segments, and the
+ * provider interface widened to accept either. The claim is that rendered
+ * output is byte-identical to before, EXCEPT the deliberately deleted
+ * `Current date:` line (#488 open question 3).
+ *
+ * There were no prompt snapshot tests before this. Without them the claim
+ * would be an assertion rather than a fact, which is exactly the kind of
+ * unverifiable "no behaviour change" this repo has been bitten by.
+ *
+ * Reordering is NOT in this phase — see #564. That change deliberately breaks
+ * byte-equality and is verified by a graded fixture run instead.
+ */
+const CONTEXT = {
+  owner: 'octo',
+  repo: 'demo',
+  prNumber: 7,
+  prTitle: 'Add retry policy',
+  prBody: 'Adds a shared retry helper.',
+} as const;
+
+const TEMPLATE = [
+  'AGENT TEMPLATE',
+  'TONE_PLACEHOLDER',
+  'CONVENTIONS_PLACEHOLDER',
+  'AGENT_MODE_PLACEHOLDER',
+  'FILE_REQUEST_PLACEHOLDER',
+].join('\n');
+
+const build = (over: Partial<{ agentic: boolean; conventions: string; agentAuthored: boolean }> = {}) =>
+  buildPrompt(
+    TEMPLATE, 'DIFF BODY', CONTEXT as never,
+    over.agentic ?? false, undefined, over.conventions, over.agentAuthored ?? false,
+  );
+
+describe('#489 — buildPrompt returns segments', () => {
+  it('renders to the exact shape the flat string produced', () => {
+    const rendered = renderPrompt(build());
+    // The assembled order is unchanged: template, intent-claims, PR context, diff.
+    expect(rendered).toContain('AGENT TEMPLATE');
+    expect(rendered.indexOf('--- PR Context ---')).toBeGreaterThan(rendered.indexOf('AGENT TEMPLATE'));
+    expect(rendered.indexOf('--- Diff ---')).toBeGreaterThan(rendered.indexOf('--- PR Context ---'));
+    expect(rendered.endsWith('DIFF BODY')).toBe(true);
+  });
+
+  it('has NO date line — the one deliberate difference from before', () => {
+    // It invalidated any prompt cache daily and would invalidate a cassette
+    // corpus every midnight, for context the review does not use.
+    expect(renderPrompt(build())).not.toMatch(/Current date:/);
+  });
+
+  it('still carries the PR context the date line used to sit above', () => {
+    // Guard against deleting more than intended.
+    const r = renderPrompt(build());
+    expect(r).toContain('Repository: octo/demo');
+    expect(r).toContain('PR #7');
+    expect(r).toContain('Title: Add retry policy');
+  });
+
+  it('emits segments in non-decreasing volatility', () => {
+    expect(findVolatilityInversion(build())).toBeNull();
+  });
+
+  it('labels merged segments honestly', () => {
+    // `head` holds a static template AND a per-PR agent-mode block, so it is
+    // per-pr. Claiming `static` would promise a stability the text lacks and
+    // produce a cache prefix that never hits.
+    const head = build().find((s) => s.id === 'head');
+    expect(head?.stability).toBe('per-pr');
+  });
+
+  it('segment ids are stable and unique — cassette keys depend on them', () => {
+    const ids = build().map((s) => s.id);
+    expect(ids).toEqual(['head', 'pr-context', 'diff']);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('#489 — applyConfidenceFloor is a segment transform', () => {
+  const DIRECTIVE = 'If you are less than 75% confident';
+
+  it('rewrites only the segment holding the directive', () => {
+    const segments = [
+      { id: 'head', stability: 'per-pr' as const, text: `x ${DIRECTIVE} y` },
+      { id: 'diff', stability: 'per-pr' as const, text: 'UNTOUCHED DIFF' },
+    ];
+    const out = applyConfidenceFloor(segments, 90) as typeof segments;
+    expect(out[0].text).toContain('less than 90% confident');
+    // The trap this guards: as a regex over the assembled string, a non-default
+    // minConfidence could rewrite anywhere, breaking prefix stability for every
+    // repo that sets one — a cache AND cassette miss with no visible cause.
+    expect(out[1]).toBe(segments[1]);
+    expect(out[1].text).toBe('UNTOUCHED DIFF');
+  });
+
+  it('returns the input unchanged at the default floor', () => {
+    const segments = [{ id: 'head', stability: 'per-pr' as const, text: DIRECTIVE }];
+    expect(applyConfidenceFloor(segments, 75)).toBe(segments);
+  });
+
+  it('still works on a plain string, for unmigrated callers', () => {
+    expect(applyConfidenceFloor(`a ${DIRECTIVE} b`, 60)).toContain('less than 60% confident');
+  });
+});

--- a/packages/core/src/agents/prompts.ts
+++ b/packages/core/src/agents/prompts.ts
@@ -1,3 +1,4 @@
+import type { PromptInput } from '../llm/prompt-segment.js';
 /**
  * System prompts for each review agent.
  *
@@ -606,11 +607,31 @@ export const PREVIOUS_FINDINGS_PLACEHOLDER = '{{PREVIOUS_FINDINGS}}';
  * them pass through untouched. reviewer.test.ts asserts both source
  * sentences still exist so a prompt rewording breaks loudly, not silently.
  */
-export function applyConfidenceFloor(prompt: string, floor: number): string {
-  if (floor === 75) return prompt;
-  return prompt
+function rewriteFloor(text: string, floor: number): string {
+  return text
     .replace('If you are less than 75% confident', `If you are less than ${floor}% confident`)
     .replace('Drop any finding with confidence below 75.', `Drop any finding with confidence below ${floor}.`);
+}
+
+/**
+ * #489 — segment-aware, and that matters more than it looks.
+ *
+ * This used to be a regex over the whole assembled prompt string. Left that
+ * way, any repo setting a non-default `minConfidence` would rewrite text
+ * anywhere in the prompt — including the parts a cache breakpoint or a
+ * cassette key depends on being stable. The result is a cache miss AND a
+ * cassette miss, for every such repo, with nothing to indicate why.
+ *
+ * Rewriting per segment confines the edit to the segment that actually holds
+ * the directive; every other segment stays byte-identical.
+ */
+export function applyConfidenceFloor(prompt: PromptInput, floor: number): PromptInput {
+  if (floor === 75) return prompt;
+  if (typeof prompt === 'string') return rewriteFloor(prompt, floor);
+  return prompt.map((seg) => {
+    const text = rewriteFloor(seg.text, floor);
+    return text === seg.text ? seg : { ...seg, text };
+  });
 }
 
 export const ORCHESTRATOR_PROMPT = `${SHARED_PREAMBLE}

--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -1,3 +1,4 @@
+import { renderPrompt, type PromptInput } from '../llm/prompt-segment.js';
 import { describe, it, expect, vi } from 'vitest';
 import type { ILLMProvider } from '../llm/types.js';
 import type { CustomAgentDef } from '../config/defaults.js';
@@ -45,8 +46,10 @@ function createMockLLM(responses: string[]): ILLMProvider & { calls: { modelId: 
   const calls: { modelId: string; prompt: string }[] = [];
   return {
     calls,
-    async invoke(modelId: string, prompt: string, _maxTokens?: number) {
-      calls.push({ modelId, prompt });
+    async invoke(modelId: string, prompt: PromptInput, _maxTokens?: number) {
+      // #489 — record what reaches the wire, so the many string assertions
+      // downstream keep testing the rendered prompt rather than a shape.
+      calls.push({ modelId, prompt: renderPrompt(prompt) });
       return responses[idx++] ?? responses[responses.length - 1];
     },
   };
@@ -237,7 +240,8 @@ describe('runSecurityAgent', () => {
     let call = 0;
     const inner: ILLMProvider = {
       async invoke(_m, prompt, maxTokens) {
-        calls.push({ prompt, maxTokens });
+        // #489 — prompts are segments now; record what actually goes on the wire.
+        calls.push({ prompt: renderPrompt(prompt), maxTokens });
         call++;
         // Call 1: security agent, truncated at the cap. Call 2: its retry
         // (identical prompt), full response. Call 3: the orchestrator.
@@ -3892,7 +3896,7 @@ function createStructuredMockLLM(opts: {
     structuredCalls,
     textCalls,
     async invoke(_m: string, prompt: string) {
-      textCalls.push(prompt);
+      textCalls.push(renderPrompt(prompt));
       return (opts.textResponses ?? [])[ti++] ?? JSON.stringify({ findings: [] });
     },
     async invokeStructured(_m: string, prompt: string, schema: object) {

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -13,6 +13,7 @@
 import type { ILLMProvider } from '../llm/types.js';
 import { normalizeLLMResult, StructuredOutputUnsupportedError } from '../llm/types.js';
 import { TokenAccumulator, TrackingLLMProvider } from '../llm/token-accumulator.js';
+import type { PromptSegment, PromptInput } from '../llm/prompt-segment.js';
 import { isThrottleError } from '../llm/throttle.js';
 import { AGENT_FINDINGS_SCHEMA, ORCHESTRATOR_SCHEMA, VERIFIER_VERDICT_SCHEMA } from './schemas.js';
 import {
@@ -191,7 +192,7 @@ function buildAgentModeBlock(agentAuthored: boolean | undefined): string {
  * and optional PR context. When agentic file fetching is enabled, injects
  * the FILE_REQUEST_INSTRUCTION via the FILE_REQUEST_PLACEHOLDER in prompts.
  */
-function buildPrompt(
+export function buildPrompt(
   systemPrompt: string,
   diff: string,
   context: ReviewContext,
@@ -199,7 +200,7 @@ function buildPrompt(
   tone?: UXConfig['tone'],
   conventions?: string,
   agentAuthored?: boolean,
-): string {
+): PromptSegment[] {
   // Inject tone directive or strip placeholder
   const toneDirective = tone ? (TONE_DIRECTIVES[tone] ?? '') : '';
   const tonedPrompt = systemPrompt.replace(TONE_PLACEHOLDER, toneDirective);
@@ -215,8 +216,12 @@ function buildPrompt(
     ? withAgentMode.replace('FILE_REQUEST_PLACEHOLDER', FILE_REQUEST_INSTRUCTION)
     : withAgentMode.replace('FILE_REQUEST_PLACEHOLDER', '');
 
+  // #489 — the `Current date:` line that used to head this block is gone.
+  // It invalidated any prompt cache once a day and would have invalidated an
+  // entire cassette corpus every midnight, for temporal context the review
+  // does not use: the diff and the PR context carry what the model reasons
+  // about. (#488 open question 3, decided: delete.)
   const contextBlock = [
-    `Current date: ${new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}`,
     `Repository: ${context.owner}/${context.repo}`,
     `PR #${context.prNumber}`,
     context.prTitle ? `Title: ${context.prTitle}` : '',
@@ -228,7 +233,26 @@ function buildPrompt(
   // #372 — every agent gets the intent-claims directive: in-code claims of
   // intentionality never suppress a finding; only sanctioned channels
   // (conventions, exclude patterns, /resolve memory) carry that authority.
-  return `${resolvedPrompt}\n\n${INTENT_CLAIMS_DIRECTIVE}\n\n--- PR Context ---\n${contextBlock}\n\n--- Diff ---\n${diff}`;
+  //
+  // #489 — returned as segments rather than one string. The split is
+  // deliberately COARSE and the labels conservative: `head` is `per-pr`
+  // because the agent-mode block it contains varies per PR, even though the
+  // template and the intent-claims directive inside it are static.
+  //
+  // Splitting them apart would put a `static` segment after a `per-pr` one —
+  // the volatility inversion the lint rejects, and the very thing #564 exists
+  // to fix by reordering. Until that lands, merging them and labelling the
+  // result honestly is correct: claiming a segment is stable when the text
+  // around it is not would produce a cache prefix that never hits, with
+  // nothing to say why.
+  //
+  // Segments carry their own leading whitespace so rendering is pure
+  // concatenation — byte-identical to the string this replaced.
+  return [
+    { id: 'head', stability: 'per-pr', text: `${resolvedPrompt}\n\n${INTENT_CLAIMS_DIRECTIVE}` },
+    { id: 'pr-context', stability: 'per-pr', text: `\n\n--- PR Context ---\n${contextBlock}` },
+    { id: 'diff', stability: 'per-pr', text: `\n\n--- Diff ---\n${diff}` },
+  ];
 }
 
 /**
@@ -478,7 +502,7 @@ export function parseAgentFindings(raw: string, diag?: AgentDiagnostics): AgentF
 async function invokeAgentText(
   llm: ILLMProvider,
   modelId: string,
-  prompt: string,
+  prompt: PromptInput,
   fileFetchOptions?: FileFetchOptions,
 ): Promise<string> {
   if (fileFetchOptions) {
@@ -522,7 +546,7 @@ function structuredAsText(llm: ILLMProvider, schema: object): ILLMProvider {
 async function invokeAgent(
   llm: ILLMProvider,
   modelId: string,
-  prompt: string,
+  prompt: PromptInput,
   fileFetchOptions?: FileFetchOptions,
   schema?: object,
 ): Promise<string> {

--- a/packages/core/src/context/agentic-fetcher.ts
+++ b/packages/core/src/context/agentic-fetcher.ts
@@ -1,3 +1,4 @@
+import type { PromptInput } from '../llm/prompt-segment.js';
 /**
  * Agentic file fetching — lets LLM agents request files they need.
  *
@@ -112,12 +113,12 @@ function parseFileRequest(response: string): string[] | null {
 export async function invokeWithFileFetching(
   llm: ILLMProvider,
   modelId: string,
-  basePrompt: string,
+  basePrompt: PromptInput,
   fetchOptions: FileFetchOptions,
   maxTokens?: number,
 ): Promise<AgenticInvokeResult> {
   const allFetchedFiles: Record<string, string> = {};
-  let currentPrompt = basePrompt;
+  let currentPrompt: PromptInput = basePrompt;
   let roundsUsed = 0;
 
   for (let round = 0; round < fetchOptions.maxRounds; round++) {
@@ -196,9 +197,17 @@ export async function invokeWithFileFetching(
       .map(([path, content]) => `### ${path}\n\`\`\`\n${content}\n\`\`\``)
       .join('\n\n');
 
-    currentPrompt = basePrompt
-      + `\n\n--- Related Files ---\nThe following files were fetched at your request. Use them for context:\n\n${filesSection}`
+    // #489 — fetched files are the textbook `per-call` segment: they differ
+    // every round and every finding. Appending them as their own segment
+    // rather than concatenating onto the base keeps everything before them
+    // byte-stable, which is what a cache breakpoint needs. Rendering is pure
+    // concatenation, so the wire format is unchanged.
+    const fetchedText =
+      `\n\n--- Related Files ---\nThe following files were fetched at your request. Use them for context:\n\n${filesSection}`
       + '\n\nNow proceed with your analysis. Do NOT request more files.';
+    currentPrompt = typeof basePrompt === 'string'
+      ? basePrompt + fetchedText
+      : [...basePrompt, { id: 'fetched-files', stability: 'per-call' as const, text: fetchedText }];
   }
 
   // Max rounds reached — do a final invoke forcing analysis

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,7 @@
 // ─── Interfaces ─────────────────────────────────────────────────────────────
 export type { ILLMProvider, TokenUsage, LLMInvokeResult, LLMSamplingConfig, LLMStructuredResult } from './llm/types.js';
+export type { PromptSegment, PromptStability, PromptInput } from './llm/prompt-segment.js';
+export { renderPrompt, findVolatilityInversion, assertNonDecreasingVolatility, mostVolatile } from './llm/prompt-segment.js';
 export { normalizeLLMResult, StructuredOutputUnsupportedError } from './llm/types.js';
 export { TokenAccumulator, TrackingLLMProvider } from './llm/token-accumulator.js';
 export { estimateCost, DEFAULT_PRICING, parseEnvModelPricing } from './llm/pricing.js';

--- a/packages/core/src/llm/prompt-segment.test.ts
+++ b/packages/core/src/llm/prompt-segment.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import {
+  renderPrompt,
+  findVolatilityInversion,
+  assertNonDecreasingVolatility,
+  mostVolatile,
+  type PromptSegment,
+} from './prompt-segment.js';
+
+const seg = (id: string, stability: PromptSegment['stability'], text = id): PromptSegment =>
+  ({ id, stability, text });
+
+describe('renderPrompt', () => {
+  it('joins with NO separator, so rendering is pure concatenation', () => {
+    // Segments carry their own leading whitespace. A separator here would
+    // silently reflow every prompt in the product.
+    expect(renderPrompt([seg('a', 'static', 'A'), seg('b', 'per-pr', '\n\nB')])).toBe('A\n\nB');
+  });
+
+  it('passes a string through untouched, so unmigrated callers are unaffected', () => {
+    expect(renderPrompt('already assembled')).toBe('already assembled');
+  });
+
+  it('renders an empty segment list to an empty string', () => {
+    expect(renderPrompt([])).toBe('');
+  });
+});
+
+describe('volatility ordering', () => {
+  it('accepts a non-decreasing sequence', () => {
+    expect(findVolatilityInversion([
+      seg('directives', 'static'), seg('conventions', 'per-repo'),
+      seg('diff', 'per-pr'), seg('files', 'per-call'),
+    ])).toBeNull();
+  });
+
+  it('accepts equal neighbours', () => {
+    expect(findVolatilityInversion([seg('a', 'per-pr'), seg('b', 'per-pr')])).toBeNull();
+  });
+
+  it('rejects a static segment sitting after a volatile one', () => {
+    // The failure that matters: one static segment after a per-pr one makes
+    // the WHOLE prefix unstable, so the cache never hits and nothing says why.
+    const bad = findVolatilityInversion([seg('diff', 'per-pr'), seg('directives', 'static')]);
+    expect(bad).not.toBeNull();
+    expect(bad!.offending.id).toBe('directives');
+    expect(bad!.previous.id).toBe('diff');
+  });
+
+  it('throws with both segment ids and stabilities named', () => {
+    // A build failure is only useful if it says which pair is wrong.
+    expect(() => assertNonDecreasingVolatility(
+      [seg('diff', 'per-pr'), seg('directives', 'static')], 'review prompt',
+    )).toThrow(/review prompt.*directives.*static.*diff.*per-pr/s);
+  });
+
+  it('does not throw on a sound order', () => {
+    expect(() => assertNonDecreasingVolatility([seg('a', 'static'), seg('b', 'per-call')], 'x'))
+      .not.toThrow();
+  });
+});
+
+describe('mostVolatile', () => {
+  it('is what a merged segment must be labelled', () => {
+    // Merging a static template with a per-pr block yields per-pr. Labelling
+    // the result `static` would claim a stability the text does not have.
+    expect(mostVolatile('static', 'per-pr', 'per-repo')).toBe('per-pr');
+    expect(mostVolatile('static')).toBe('static');
+    expect(mostVolatile()).toBe('static');
+  });
+});

--- a/packages/core/src/llm/prompt-segment.ts
+++ b/packages/core/src/llm/prompt-segment.ts
@@ -1,0 +1,112 @@
+/**
+ * #489 (Phase 1a of #488) — a prompt as ordered segments rather than a string.
+ *
+ * `buildPrompt` returned a flat `string`, and a flat string cannot express
+ * which of its parts are stable. Three separate problems need exactly that
+ * distinction:
+ *
+ *   - prompt caching needs it to place a `cache_control` breakpoint at each
+ *     stability boundary;
+ *   - cassette keys need it to stay valid across unrelated edits, excluding
+ *     volatile parts by declaration rather than by hoping;
+ *   - blast-radius detection needs it to scope re-recording.
+ *
+ * One ordering discipline, three payoffs. That is the argument for doing it as
+ * one change rather than three.
+ */
+
+/**
+ * How often a segment's text changes. Ordered least- to most-volatile; the
+ * lint below depends on this order.
+ */
+export type PromptStability =
+  /** Frozen in source: directives, agent templates. */
+  | 'static'
+  /** Conventions, tone, custom rules — changes when a repo changes. */
+  | 'per-repo'
+  /** PR context, diff — changes per pull request. */
+  | 'per-pr'
+  /** Fetched files, the finding under verification, previous findings. */
+  | 'per-call';
+
+export interface PromptSegment {
+  /** Stable identifier, used for cassette keys and cache-boundary reporting. */
+  id: string;
+  text: string;
+  stability: PromptStability;
+}
+
+/** Volatility rank. Higher = changes more often. */
+const RANK: Record<PromptStability, number> = {
+  static: 0,
+  'per-repo': 1,
+  'per-pr': 2,
+  'per-call': 3,
+};
+
+/** The most volatile of the given stabilities — a merged segment's honest label. */
+export function mostVolatile(...s: PromptStability[]): PromptStability {
+  return s.reduce((a, b) => (RANK[b] > RANK[a] ? b : a), 'static' as PromptStability);
+}
+
+/**
+ * Segments must be non-decreasing in volatility.
+ *
+ * A cache breakpoint can only be placed where everything before it is at least
+ * as stable as the breakpoint itself. One `static` segment sitting after a
+ * `per-pr` one makes the whole prefix unstable, so the cache never hits and
+ * nothing says why. Catching that here turns a silent cost regression into a
+ * build failure.
+ *
+ * Returns the offending index pair, or null when the order is sound.
+ */
+export function findVolatilityInversion(
+  segments: readonly PromptSegment[],
+): { at: number; previous: PromptSegment; offending: PromptSegment } | null {
+  for (let i = 1; i < segments.length; i++) {
+    if (RANK[segments[i].stability] < RANK[segments[i - 1].stability]) {
+      return { at: i, previous: segments[i - 1], offending: segments[i] };
+    }
+  }
+  return null;
+}
+
+/**
+ * Throwing form, for use at the point a prompt is assembled.
+ *
+ * Deliberately throws rather than warns: a warning here would be read by
+ * nobody and the cost would show up as an unexplained bill.
+ */
+export function assertNonDecreasingVolatility(
+  segments: readonly PromptSegment[],
+  label: string,
+): void {
+  const bad = findVolatilityInversion(segments);
+  if (!bad) return;
+  throw new Error(
+    `[prompt] ${label}: segment '${bad.offending.id}' (${bad.offending.stability}) follows `
+      + `'${bad.previous.id}' (${bad.previous.stability}) — segments must be `
+      + `non-decreasing in volatility, or no cache prefix is stable (#489)`,
+  );
+}
+
+/**
+ * A prompt, either already-assembled or segmented.
+ *
+ * The union exists so this phase does not have to convert all 26 call sites at
+ * once. A provider renders whichever it is given; a caller that has not been
+ * migrated keeps passing a string and behaves exactly as before.
+ */
+export type PromptInput = string | readonly PromptSegment[];
+
+/**
+ * Render segments to the wire format.
+ *
+ * Segments are joined with NO separator: each segment carries whatever
+ * whitespace preceded it in the original flat string, so rendering is
+ * byte-identical to the concatenation it replaced. Adding a separator here
+ * would silently reflow every prompt.
+ */
+export function renderPrompt(prompt: PromptInput): string {
+  return typeof prompt === 'string' ? prompt : prompt.map((s) => s.text).join('');
+}

--- a/packages/core/src/llm/token-accumulator.ts
+++ b/packages/core/src/llm/token-accumulator.ts
@@ -1,3 +1,4 @@
+import type { PromptInput } from './prompt-segment.js';
 /**
  * Token usage accumulator and tracking LLM provider wrapper.
  *
@@ -89,7 +90,7 @@ export class TrackingLLMProvider implements ILLMProvider {
   // default instead.
   async invoke(
     modelId: string,
-    prompt: string,
+    prompt: PromptInput,
     maxTokens?: number,
     sampling?: LLMSamplingConfig,
   ): Promise<LLMInvokeResult> {
@@ -108,7 +109,7 @@ export class TrackingLLMProvider implements ILLMProvider {
   // fallback costs nothing) when the inner provider has no invokeStructured.
   async invokeStructured(
     modelId: string,
-    prompt: string,
+    prompt: PromptInput,
     schema: object,
     maxTokens?: number,
     sampling?: LLMSamplingConfig,

--- a/packages/core/src/llm/types.ts
+++ b/packages/core/src/llm/types.ts
@@ -1,3 +1,4 @@
+import type { PromptInput } from './prompt-segment.js';
 /**
  * Provider-agnostic LLM interface.
  *
@@ -74,7 +75,14 @@ export class StructuredOutputUnsupportedError extends Error {
 export interface ILLMProvider {
   invoke(
     modelId: string,
-    prompt: string,
+    /**
+     * #489 — a string, or ordered segments carrying stability labels. The
+     * union lets this phase migrate the three prompt builders without
+     * converting all 26 call sites at once: an unmigrated caller keeps passing
+     * a string and behaves exactly as before. Providers render with
+     * `renderPrompt`.
+     */
+    prompt: PromptInput,
     maxTokens?: number,
     sampling?: LLMSamplingConfig,
   ): Promise<string | LLMInvokeResult>;
@@ -88,7 +96,7 @@ export interface ILLMProvider {
    */
   invokeStructured?(
     modelId: string,
-    prompt: string,
+    prompt: PromptInput,
     schema: object,
     maxTokens?: number,
     sampling?: LLMSamplingConfig,

--- a/packages/core/src/triage.test.ts
+++ b/packages/core/src/triage.test.ts
@@ -1,3 +1,4 @@
+import { renderPrompt } from './llm/prompt-segment.js';
 import { describe, it, expect } from 'vitest';
 import type { ILLMProvider } from './llm/types.js';
 import {
@@ -17,7 +18,7 @@ function recordingLLM(response: string) {
   const prompts: string[] = [];
   const llm: ILLMProvider = {
     async invoke(_modelId, prompt) {
-      prompts.push(prompt);
+      prompts.push(renderPrompt(prompt));
       return response;
     },
   };

--- a/packages/llm-anthropic/src/anthropic-provider.ts
+++ b/packages/llm-anthropic/src/anthropic-provider.ts
@@ -1,5 +1,6 @@
+import { renderPrompt } from '@mergewatch/core';
 import Anthropic from '@anthropic-ai/sdk';
-import type { ILLMProvider, LLMInvokeResult, LLMSamplingConfig, LLMStructuredResult } from '@mergewatch/core';
+import type { ILLMProvider, LLMInvokeResult, LLMSamplingConfig, LLMStructuredResult, PromptInput} from '@mergewatch/core';
 
 export class AnthropicLLMProvider implements ILLMProvider {
   private client: Anthropic;
@@ -10,7 +11,7 @@ export class AnthropicLLMProvider implements ILLMProvider {
 
   async invoke(
     modelId: string,
-    prompt: string,
+    prompt: PromptInput,
     maxTokens = 4096,
     sampling: LLMSamplingConfig = {},
   ): Promise<LLMInvokeResult> {
@@ -20,7 +21,10 @@ export class AnthropicLLMProvider implements ILLMProvider {
       temperature: sampling.temperature ?? 0,
       ...(sampling.topP !== undefined ? { top_p: sampling.topP } : {}),
       ...(sampling.topK !== undefined ? { top_k: sampling.topK } : {}),
-      messages: [{ role: 'user', content: prompt }],
+      // #489 — rendered here rather than upstream. This provider does not yet
+      // place cache breakpoints, so segments collapse to exactly the string
+      // it built before.
+      messages: [{ role: 'user', content: renderPrompt(prompt) }],
     });
     const block = response.content[0];
     if (block.type !== 'text') {
@@ -41,7 +45,7 @@ export class AnthropicLLMProvider implements ILLMProvider {
   // the JSON Schema — no free-text JSON to parse.
   async invokeStructured(
     modelId: string,
-    prompt: string,
+    prompt: PromptInput,
     schema: object,
     maxTokens = 4096,
     sampling: LLMSamplingConfig = {},
@@ -58,7 +62,10 @@ export class AnthropicLLMProvider implements ILLMProvider {
         input_schema: schema as Anthropic.Messages.Tool['input_schema'],
       }],
       tool_choice: { type: 'tool', name: 'emit_result' },
-      messages: [{ role: 'user', content: prompt }],
+      // #489 — rendered here rather than upstream. This provider does not yet
+      // place cache breakpoints, so segments collapse to exactly the string
+      // it built before.
+      messages: [{ role: 'user', content: renderPrompt(prompt) }],
     });
     const block = response.content.find((b) => b.type === 'tool_use');
     if (!block || block.type !== 'tool_use') {

--- a/packages/llm-bedrock/src/bedrock-provider.ts
+++ b/packages/llm-bedrock/src/bedrock-provider.ts
@@ -16,8 +16,8 @@ import {
   BedrockRuntimeClient,
   InvokeModelCommand,
 } from '@aws-sdk/client-bedrock-runtime';
-import type { ILLMProvider, LLMInvokeResult, LLMSamplingConfig, LLMStructuredResult, TokenUsage } from '@mergewatch/core';
-import { StructuredOutputUnsupportedError } from '@mergewatch/core';
+import type { ILLMProvider, LLMInvokeResult, LLMSamplingConfig, LLMStructuredResult, TokenUsage, PromptInput} from '@mergewatch/core';
+import { StructuredOutputUnsupportedError, renderPrompt} from '@mergewatch/core';
 
 // ─── Supported model IDs ───────────────────────────────────────────────────
 export const SUPPORTED_MODELS = {
@@ -76,7 +76,7 @@ export function acceptsSamplingParams(modelId: string): boolean {
 }
 
 function buildAnthropicBody(
-  prompt: string,
+  prompt: PromptInput,
   maxTokens: number,
   sampling: LLMSamplingConfig,
   modelId: string,
@@ -84,7 +84,7 @@ function buildAnthropicBody(
   const body: Record<string, unknown> = {
     anthropic_version: 'bedrock-2023-05-31',
     max_tokens: maxTokens,
-    messages: [{ role: 'user', content: prompt }],
+    messages: [{ role: 'user', content: renderPrompt(prompt) }],
   };
   if (acceptsSamplingParams(modelId)) {
     body.temperature = sampling.temperature ?? 0;
@@ -103,7 +103,7 @@ function buildAnthropicBody(
  * `emit_result` and the API constrains its input against the JSON Schema.
  */
 function buildAnthropicStructuredBody(
-  prompt: string,
+  prompt: PromptInput,
   schema: object,
   maxTokens: number,
   sampling: LLMSamplingConfig,
@@ -112,7 +112,7 @@ function buildAnthropicStructuredBody(
   const body: Record<string, unknown> = {
     anthropic_version: 'bedrock-2023-05-31',
     max_tokens: maxTokens,
-    messages: [{ role: 'user', content: prompt }],
+    messages: [{ role: 'user', content: renderPrompt(prompt) }],
     tools: [{
       name: 'emit_result',
       description: 'Emit the structured result of your analysis.',
@@ -133,13 +133,13 @@ function buildAnthropicStructuredBody(
 }
 
 function buildTitanBody(
-  prompt: string,
+  prompt: PromptInput,
   maxTokens: number,
   sampling: LLMSamplingConfig,
 ): ModelRequestBody {
   return {
     body: JSON.stringify({
-      inputText: prompt,
+      inputText: renderPrompt(prompt),
       textGenerationConfig: {
         maxTokenCount: maxTokens,
         temperature: sampling.temperature ?? 0,
@@ -161,7 +161,7 @@ function isTitanModel(modelId: string): boolean {
 
 function buildRequestBody(
   modelId: string,
-  prompt: string,
+  prompt: PromptInput,
   maxTokens: number,
   sampling: LLMSamplingConfig,
 ): ModelRequestBody {
@@ -231,7 +231,7 @@ export class BedrockLLMProvider implements ILLMProvider {
 
   async invoke(
     modelId: string,
-    prompt: string,
+    prompt: PromptInput,
     maxTokens = 4096,
     sampling: LLMSamplingConfig = {},
   ): Promise<LLMInvokeResult> {
@@ -256,7 +256,7 @@ export class BedrockLLMProvider implements ILLMProvider {
   // text fallback costs nothing.
   async invokeStructured(
     modelId: string,
-    prompt: string,
+    prompt: PromptInput,
     schema: object,
     maxTokens = 4096,
     sampling: LLMSamplingConfig = {},

--- a/packages/llm-litellm/src/litellm-provider.ts
+++ b/packages/llm-litellm/src/litellm-provider.ts
@@ -1,4 +1,5 @@
-import type { ILLMProvider, LLMInvokeResult, LLMSamplingConfig, LLMStructuredResult } from '@mergewatch/core';
+import { renderPrompt } from '@mergewatch/core';
+import type { ILLMProvider, LLMInvokeResult, LLMSamplingConfig, LLMStructuredResult, PromptInput} from '@mergewatch/core';
 
 export class LiteLLMProvider implements ILLMProvider {
   constructor(
@@ -8,7 +9,7 @@ export class LiteLLMProvider implements ILLMProvider {
 
   async invoke(
     modelId: string,
-    prompt: string,
+    prompt: PromptInput,
     maxTokens = 4096,
     sampling: LLMSamplingConfig = {},
   ): Promise<LLMInvokeResult> {
@@ -32,7 +33,7 @@ export class LiteLLMProvider implements ILLMProvider {
         temperature: sampling.temperature ?? 0,
         ...(sampling.topP !== undefined ? { top_p: sampling.topP } : {}),
         ...(sampling.topK !== undefined ? { top_k: sampling.topK } : {}),
-        messages: [{ role: 'user', content: prompt }],
+        messages: [{ role: 'user', content: renderPrompt(prompt) }],
       }),
     });
 
@@ -63,7 +64,7 @@ export class LiteLLMProvider implements ILLMProvider {
   // throws here — the caller falls back to the hardened text path.
   async invokeStructured(
     modelId: string,
-    prompt: string,
+    prompt: PromptInput,
     schema: object,
     maxTokens = 4096,
     sampling: LLMSamplingConfig = {},
@@ -81,7 +82,7 @@ export class LiteLLMProvider implements ILLMProvider {
         ...(sampling.topP !== undefined ? { top_p: sampling.topP } : {}),
         ...(sampling.topK !== undefined ? { top_k: sampling.topK } : {}),
         response_format: { type: 'json_schema', json_schema: { name: 'result', schema, strict: false } },
-        messages: [{ role: 'user', content: prompt }],
+        messages: [{ role: 'user', content: renderPrompt(prompt) }],
       }),
     });
     if (!response.ok) {

--- a/packages/llm-ollama/src/ollama-provider.test.ts
+++ b/packages/llm-ollama/src/ollama-provider.test.ts
@@ -153,3 +153,40 @@ describe('OllamaLLMProvider', () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// #489 — segments must reach the wire as a STRING
+//
+// This is the bug the refactor nearly shipped. `invoke` widened to accept
+// `PromptInput`, and this provider passed `prompt` straight into
+// `content:` in an untyped JSON body. TypeScript had nothing to check, so a
+// PromptSegment[] would have been serialised as a JSON ARRAY into every
+// request — breaking every review, and compiling perfectly cleanly.
+// ---------------------------------------------------------------------------
+describe('#489 — segment rendering', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('sends segments as a concatenated string, never as an array', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ message: { content: 'ok' } }));
+    const provider = new OllamaLLMProvider('http://myhost:11434');
+    await provider.invoke('m', [
+      { id: 'head', stability: 'static', text: 'A' },
+      { id: 'diff', stability: 'per-pr', text: '\n\nB' },
+    ] as never);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    const content = body.messages[0].content;
+    expect(typeof content).toBe('string');
+    expect(Array.isArray(content)).toBe(false);
+    expect(content).toBe('A\n\nB');
+  });
+
+  it('leaves a plain-string prompt byte-identical', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ message: { content: 'ok' } }));
+    const provider = new OllamaLLMProvider('http://myhost:11434');
+    await provider.invoke('m', 'plain prompt');
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.messages[0].content).toBe('plain prompt');
+  });
+});

--- a/packages/llm-ollama/src/ollama-provider.ts
+++ b/packages/llm-ollama/src/ollama-provider.ts
@@ -1,11 +1,12 @@
-import type { ILLMProvider, LLMInvokeResult, LLMSamplingConfig, LLMStructuredResult } from '@mergewatch/core';
+import { renderPrompt } from '@mergewatch/core';
+import type { ILLMProvider, LLMInvokeResult, LLMSamplingConfig, LLMStructuredResult, PromptInput} from '@mergewatch/core';
 
 export class OllamaLLMProvider implements ILLMProvider {
   constructor(private baseUrl: string = 'http://localhost:11434') {}
 
   async invoke(
     modelId: string,
-    prompt: string,
+    prompt: PromptInput,
     maxTokens = 4096,
     sampling: LLMSamplingConfig = {},
   ): Promise<LLMInvokeResult> {
@@ -23,7 +24,7 @@ export class OllamaLLMProvider implements ILLMProvider {
         model: modelId,
         stream: false,
         options,
-        messages: [{ role: 'user', content: prompt }],
+        messages: [{ role: 'user', content: renderPrompt(prompt) }],
       }),
     });
 
@@ -48,7 +49,7 @@ export class OllamaLLMProvider implements ILLMProvider {
   // caller falls back to the hardened text path.
   async invokeStructured(
     modelId: string,
-    prompt: string,
+    prompt: PromptInput,
     schema: object,
     maxTokens = 4096,
     sampling: LLMSamplingConfig = {},
@@ -68,7 +69,7 @@ export class OllamaLLMProvider implements ILLMProvider {
         stream: false,
         options,
         format: schema,
-        messages: [{ role: 'user', content: prompt }],
+        messages: [{ role: 'user', content: renderPrompt(prompt) }],
       }),
     });
     if (!response.ok) {


### PR DESCRIPTION
Phase 1a of #488. Closes #489.

## Why

`buildPrompt` returned a flat `string`. A flat string cannot express which of its parts are stable — which is what prompt caching needs to place breakpoints, what cassette keys need to survive unrelated edits, and what blast-radius detection needs to scope re-recording. One missing distinction, three blocked payoffs.

**Nothing else in #488 can start until this lands** — cassette keys derive from segment structure.

## What changed

- `buildPrompt`, the agentic fetcher and `applyConfidenceFloor` speak `PromptSegment[]`
- `ILLMProvider` accepts `string | PromptSegment[]`, so the three migrated builders convert **without touching all 26 call sites** — an unmigrated caller keeps passing a string and behaves exactly as before
- All four providers render via `renderPrompt`
- New ordering lint: segments must be non-decreasing in volatility
- `Current date:` deleted (#488 open question 3, decided)

## Segments are deliberately coarse — and that is the honest choice

`head` is labelled `per-pr` because the agent-mode block inside it varies per PR, even though the template and intent-claims directive are static.

Splitting them apart would put a `static` segment after a `per-pr` one — the exact volatility inversion the new lint rejects, and what **#564** fixes by reordering. Until that lands, merging and labelling honestly is right: claiming a stability the text does not have produces a cache prefix that never hits, with nothing to say why.

So this phase delivers the *type and the plumbing*, not the caching win. That arrives with #564 + #490.

## The trap the issue predicted, confirmed

`applyConfidenceFloor` was a regex over the whole assembled prompt. Left that way, any repo setting a non-default `minConfidence` rewrites text anywhere in the prompt — a cache **and** cassette miss for that repo, with no visible cause. It now rewrites per segment; a test asserts every other segment is byte-identical and object-identical.

## A bug this nearly shipped

`bedrock`, `litellm` and `ollama` passed `prompt` straight into `content:` in an **untyped JSON body**. Widening the parameter gave TypeScript nothing to check — so `PromptSegment[]` would have been serialised as a JSON **array** into every request, breaking every review, and compiling perfectly cleanly.

Every render site is now explicit, and `ollama-provider.test.ts` asserts the wire carries a string. **Verified it catches the bug** by reverting the render and re-running: the test fails.

Same shape as the four configuration failures this week — it compiles, it looks right, and it is silently wrong.

## Tests

- `prompt-segment.test.ts` — 9: rendering is pure concatenation (a separator would reflow every prompt), inversion detection both ways, error names both segments, `mostVolatile` for honest merged labels
- `prompt-golden.test.ts` — 9: **there were no prompt snapshot tests before this.** Asserts the rendered shape, that the date line is gone, that the PR context it sat above survives, non-decreasing volatility, honest labels, and stable segment ids
- `ollama-provider.test.ts` — 2 wire-format tests

Full forced gate: build 12/12, typecheck 20/20, test 21/21, all `Cached: 0`.

## Scope

No changes in `packages/lambda` or `packages/server`. **No reordering** — that is #564, which deliberately breaks byte-equality and is verified by a graded fixture run rather than by assertion.

## Limit

The golden tests pin the rendered *shape* and the date deletion, not a byte-for-byte capture of every agent's real prompt. A full corpus snapshot would be stronger; this covers the structural claims the refactor actually makes. The E2E gate is the backstop — every fixture exercises real prompts end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp