### PR TITLE
feat(core): cache-aware token accounting and pricing (#490, phase A)

### DIFF
--- a/packages/core/src/llm/cache-accounting.test.ts
+++ b/packages/core/src/llm/cache-accounting.test.ts
@@ -31,7 +31,8 @@ describe('estimateCost with cache traffic', () => {
 
   it('a cached review costs MORE than counting uncached input alone', () => {
     // The under-billing failure stated directly: if cache traffic were ignored,
-    // this review would be billed 0.30 when it actually cost 0.63.
+    // this review would be billed 0.30 when it actually cost 0.60 —
+    // 100k uncached at $3/1M = $0.30, plus 1M cache-read at $3/1M x 0.1 = $0.30.
     const ignored = estimateCost(MODEL, 100_000, 0, PRICING)!;
     const actual = estimateCost(MODEL, 100_000, 0, PRICING, { readTokens: 1_000_000, writeTokens: 0 })!;
     expect(ignored).toBeCloseTo(0.3, 10);

--- a/packages/core/src/llm/cache-accounting.test.ts
+++ b/packages/core/src/llm/cache-accounting.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { estimateCost, CACHE_READ_MULTIPLIER, CACHE_WRITE_MULTIPLIER } from './pricing.js';
+import { TokenAccumulator } from './token-accumulator.js';
+
+/**
+ * #490 Phase A — cache-aware accounting.
+ *
+ * `estimatedCostUsd` is metered spend, not a label: it drives Stripe charges,
+ * OSS grant drawdown and auto-reload. The API reports `input_tokens` as
+ * UNCACHED input only, with cache traffic in separate fields. Reading none of
+ * them means cached tokens vanish from the bill — reported cost falls FURTHER
+ * than true cost, which is under-billing arriving through a door the
+ * `REVENUE LEAK` alarm does not watch.
+ *
+ * This lands BEFORE any breakpoints are placed, so the meter is correct before
+ * anything starts using the cache.
+ */
+const MODEL = 'test-model';
+const PRICING = { [MODEL]: { inputPer1M: 3, outputPer1M: 15 } };
+
+describe('estimateCost with cache traffic', () => {
+  it('prices reads and writes at their own rates, not at zero', () => {
+    const cost = estimateCost(MODEL, 1_000_000, 0, PRICING, {
+      readTokens: 1_000_000,
+      writeTokens: 1_000_000,
+    });
+    // uncached 3.00 + read 0.30 + write 3.75
+    expect(cost).toBeCloseTo(3 + 3 * CACHE_READ_MULTIPLIER + 3 * CACHE_WRITE_MULTIPLIER, 10);
+    expect(cost).toBeCloseTo(7.05, 10);
+  });
+
+  it('a cached review costs MORE than counting uncached input alone', () => {
+    // The under-billing failure stated directly: if cache traffic were ignored,
+    // this review would be billed 0.30 when it actually cost 0.63.
+    const ignored = estimateCost(MODEL, 100_000, 0, PRICING)!;
+    const actual = estimateCost(MODEL, 100_000, 0, PRICING, { readTokens: 1_000_000, writeTokens: 0 })!;
+    expect(ignored).toBeCloseTo(0.3, 10);
+    expect(actual).toBeCloseTo(0.6, 10);
+    expect(actual).toBeGreaterThan(ignored);
+  });
+
+  it('is unchanged when there is no cache traffic', () => {
+    // Every existing call site keeps its exact meaning; a provider with no
+    // cache API reports nothing and the arithmetic is what it always was.
+    expect(estimateCost(MODEL, 1000, 500, PRICING))
+      .toBe(estimateCost(MODEL, 1000, 500, PRICING, { readTokens: 0, writeTokens: 0 }));
+    expect(estimateCost(MODEL, 1000, 500, PRICING))
+      .toBe(estimateCost(MODEL, 1000, 500, PRICING, {}));
+  });
+
+  it('an existing TWO-KEY customPricing override still prices cache traffic', () => {
+    // The reason rates are multipliers rather than pricing fields. A
+    // self-hosted `.mergewatch.yml` pricing block carries inputPer1M and
+    // outputPer1M today. Adding cacheReadPer1M/cacheWritePer1M would leave
+    // every un-updated override silently pricing cache traffic at ZERO.
+    const twoKeyOverride = { [MODEL]: { inputPer1M: 10, outputPer1M: 40 } };
+    const cost = estimateCost(MODEL, 0, 0, twoKeyOverride, { readTokens: 1_000_000, writeTokens: 0 })!;
+    expect(cost).toBeCloseTo(10 * CACHE_READ_MULTIPLIER, 10);
+    expect(cost).toBeGreaterThan(0);
+  });
+
+  it('still returns null for an unknown model', () => {
+    expect(estimateCost('nope', 1, 1, PRICING, { readTokens: 100 })).toBeNull();
+  });
+});
+
+describe('TokenAccumulator with cache traffic', () => {
+  it('tracks cached and uncached input separately', () => {
+    const acc = new TokenAccumulator();
+    acc.add(MODEL, { inputTokens: 100, outputTokens: 10, cacheReadInputTokens: 900, cacheWriteInputTokens: 50 });
+    acc.add(MODEL, { inputTokens: 100, outputTokens: 10, cacheReadInputTokens: 900, cacheWriteInputTokens: 0 });
+    expect(acc.totalInputTokens).toBe(200);
+    expect(acc.totalCacheReadInputTokens).toBe(1800);
+    expect(acc.totalCacheWriteInputTokens).toBe(50);
+  });
+
+  it('treats a provider without a cache API as zero, not as missing', () => {
+    // litellm and ollama omit these fields entirely.
+    const acc = new TokenAccumulator();
+    acc.add(MODEL, { inputTokens: 100, outputTokens: 10 });
+    expect(acc.totalCacheReadInputTokens).toBe(0);
+    expect(acc.estimateTotalCost(PRICING)).toBeCloseTo(estimateCost(MODEL, 100, 10, PRICING)!, 12);
+  });
+
+  it('feeds cache traffic into the total cost', () => {
+    const acc = new TokenAccumulator();
+    acc.add(MODEL, { inputTokens: 0, outputTokens: 0, cacheReadInputTokens: 1_000_000, cacheWriteInputTokens: 0 });
+    expect(acc.estimateTotalCost(PRICING)).toBeCloseTo(3 * CACHE_READ_MULTIPLIER, 10);
+  });
+});

--- a/packages/core/src/llm/pricing.ts
+++ b/packages/core/src/llm/pricing.ts
@@ -84,16 +84,40 @@ export const DEFAULT_PRICING: Record<string, ModelPricing> = {
  * Estimate cost in USD for a given model and token counts.
  * Returns null if the model is not in the pricing table (and no custom pricing provided).
  */
+/**
+ * #490 — cache rates as MULTIPLIERS of the input rate, not as pricing fields.
+ *
+ * Adding `cacheReadPer1M` / `cacheWritePer1M` would mean editing ~40 rows AND
+ * breaking every `customPricing` override: a self-hosted `.mergewatch.yml`
+ * `pricing:` block carries two keys today, so any override not updated would
+ * silently price cache traffic at ZERO. Deriving keeps every existing
+ * two-key override correct by construction.
+ *
+ * Anthropic's published ratios; they hold across the Claude family, so a
+ * single pair covers every model in DEFAULT_PRICING and any custom entry.
+ */
+export const CACHE_READ_MULTIPLIER = 0.1;
+export const CACHE_WRITE_MULTIPLIER = 1.25;
+
 export function estimateCost(
   modelId: string,
   inputTokens: number,
   outputTokens: number,
   customPricing?: Record<string, ModelPricing>,
+  /**
+   * Cache traffic. Optional so every existing call site keeps its meaning:
+   * absent means "no cache involved", which is what a provider without a
+   * cache API reports.
+   */
+  cache?: { readTokens?: number; writeTokens?: number },
 ): number | null {
   const pricing = customPricing?.[modelId] ?? DEFAULT_PRICING[modelId];
   if (!pricing) return null;
+  const cacheRead = (cache?.readTokens ?? 0) / 1_000_000 * pricing.inputPer1M * CACHE_READ_MULTIPLIER;
+  const cacheWrite = (cache?.writeTokens ?? 0) / 1_000_000 * pricing.inputPer1M * CACHE_WRITE_MULTIPLIER;
   return (inputTokens / 1_000_000) * pricing.inputPer1M
-       + (outputTokens / 1_000_000) * pricing.outputPer1M;
+       + (outputTokens / 1_000_000) * pricing.outputPer1M
+       + cacheRead + cacheWrite;
 }
 
 /**

--- a/packages/core/src/llm/token-accumulator.ts
+++ b/packages/core/src/llm/token-accumulator.ts
@@ -15,6 +15,9 @@ import { estimateCost } from './pricing.js';
 interface ModelUsage {
   inputTokens: number;
   outputTokens: number;
+  /** #490 — tracked separately because they are billed at different rates. */
+  cacheReadInputTokens: number;
+  cacheWriteInputTokens: number;
   invocations: number;
 }
 
@@ -25,9 +28,14 @@ export class TokenAccumulator {
   /** Record token usage for a model invocation. */
   add(modelId: string, tokenUsage?: TokenUsage): void {
     if (!tokenUsage) return;
-    const existing = this.usage.get(modelId) ?? { inputTokens: 0, outputTokens: 0, invocations: 0 };
+    const existing = this.usage.get(modelId)
+      ?? { inputTokens: 0, outputTokens: 0, cacheReadInputTokens: 0, cacheWriteInputTokens: 0, invocations: 0 };
     existing.inputTokens += tokenUsage.inputTokens;
     existing.outputTokens += tokenUsage.outputTokens;
+    // #490 — a provider without a cache API omits these; absent means zero,
+    // which is the same arithmetic as before caching existed.
+    existing.cacheReadInputTokens += tokenUsage.cacheReadInputTokens ?? 0;
+    existing.cacheWriteInputTokens += tokenUsage.cacheWriteInputTokens ?? 0;
     existing.invocations += 1;
     this.usage.set(modelId, existing);
   }
@@ -36,6 +44,23 @@ export class TokenAccumulator {
   get totalInputTokens(): number {
     let total = 0;
     for (const u of this.usage.values()) total += u.inputTokens;
+    return total;
+  }
+
+  /**
+   * #490 — cache traffic across all models, reported separately from
+   * `totalInputTokens` because the API reports uncached input there and these
+   * are billed at different rates.
+   */
+  get totalCacheReadInputTokens(): number {
+    let total = 0;
+    for (const u of this.usage.values()) total += u.cacheReadInputTokens;
+    return total;
+  }
+
+  get totalCacheWriteInputTokens(): number {
+    let total = 0;
+    for (const u of this.usage.values()) total += u.cacheWriteInputTokens;
     return total;
   }
 
@@ -50,7 +75,10 @@ export class TokenAccumulator {
   estimateTotalCost(customPricing?: Record<string, { inputPer1M: number; outputPer1M: number }>): number | null {
     let total = 0;
     for (const [modelId, u] of this.usage.entries()) {
-      const cost = estimateCost(modelId, u.inputTokens, u.outputTokens, customPricing);
+      const cost = estimateCost(modelId, u.inputTokens, u.outputTokens, customPricing, {
+        readTokens: u.cacheReadInputTokens,
+        writeTokens: u.cacheWriteInputTokens,
+      });
       if (cost === null) return null;
       total += cost;
     }

--- a/packages/core/src/llm/types.ts
+++ b/packages/core/src/llm/types.ts
@@ -11,8 +11,30 @@ import type { PromptInput } from './prompt-segment.js';
 
 /** Token usage from a single LLM invocation. */
 export interface TokenUsage {
+  /**
+   * UNCACHED input only. The Anthropic/Bedrock APIs report cached input in
+   * separate fields, so this is not the total the request was billed for —
+   * see the two below (#490).
+   */
   inputTokens: number;
   outputTokens: number;
+  /**
+   * #490 — input served from cache, billed at roughly 0.1× the input rate.
+   *
+   * Reading this matters for BILLING, not display: `estimatedCostUsd` drives
+   * Stripe charges, OSS grant drawdown and auto-reload. Left unread, cached
+   * tokens vanish from the count entirely and reported cost falls further
+   * than true cost — under-billing through a door `REVENUE LEAK` does not
+   * watch.
+   *
+   * Absent on providers with no cache API (litellm, ollama).
+   */
+  cacheReadInputTokens?: number;
+  /**
+   * #490 — input written to cache, billed at roughly 1.25× the input rate.
+   * Paid once by whichever agent writes the shared prefix first.
+   */
+  cacheWriteInputTokens?: number;
 }
 
 /** Result from an LLM invocation, optionally including token usage. */

--- a/packages/llm-anthropic/src/anthropic-provider.test.ts
+++ b/packages/llm-anthropic/src/anthropic-provider.test.ts
@@ -83,6 +83,29 @@ describe('AnthropicLLMProvider', () => {
     expect(result.text).toBe('The answer is 42');
   });
 
+  it('#490 — extracts cache read/write tokens the API reports separately', async () => {
+    // input_tokens is UNCACHED input only. Reading only that field means cached
+    // tokens vanish from the bill entirely, and reported cost falls further
+    // than true cost — under-billing, through a door REVENUE LEAK does not watch.
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: 'text', text: 'ok' }],
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 9000,
+        cache_creation_input_tokens: 400,
+      },
+    });
+
+    const provider = new AnthropicLLMProvider('key');
+    const result = await provider.invoke('claude-sonnet-4-20250514', 'prompt');
+    expect(result.usage).toEqual({
+      // Uncached input stays uncached input — not a total.
+      inputTokens: 100, outputTokens: 50,
+      cacheReadInputTokens: 9000, cacheWriteInputTokens: 400,
+    });
+  });
+
   it('returns usage with inputTokens and outputTokens', async () => {
     mockCreate.mockResolvedValueOnce({
       content: [{ type: 'text', text: 'ok' }],
@@ -92,7 +115,12 @@ describe('AnthropicLLMProvider', () => {
     const provider = new AnthropicLLMProvider('key');
     const result = await provider.invoke('claude-sonnet-4-20250514', 'prompt');
 
-    expect(result.usage).toEqual({ inputTokens: 100, outputTokens: 50 });
+    // #490 — cache fields are reported even when the response carries none,
+    // so an absent cache is an explicit zero rather than a missing number.
+    expect(result.usage).toEqual({
+      inputTokens: 100, outputTokens: 50,
+      cacheReadInputTokens: 0, cacheWriteInputTokens: 0,
+    });
   });
 
   it('uses default maxTokens of 4096', async () => {

--- a/packages/llm-anthropic/src/anthropic-provider.ts
+++ b/packages/llm-anthropic/src/anthropic-provider.ts
@@ -35,6 +35,9 @@ export class AnthropicLLMProvider implements ILLMProvider {
       usage: {
         inputTokens: response.usage.input_tokens,
         outputTokens: response.usage.output_tokens,
+        // #490 — separate fields; input_tokens is uncached input only.
+        cacheReadInputTokens: response.usage.cache_read_input_tokens ?? 0,
+        cacheWriteInputTokens: response.usage.cache_creation_input_tokens ?? 0,
       },
       stopReason: response.stop_reason ?? undefined,
     };
@@ -76,6 +79,9 @@ export class AnthropicLLMProvider implements ILLMProvider {
       usage: {
         inputTokens: response.usage.input_tokens,
         outputTokens: response.usage.output_tokens,
+        // #490 — separate fields; input_tokens is uncached input only.
+        cacheReadInputTokens: response.usage.cache_read_input_tokens ?? 0,
+        cacheWriteInputTokens: response.usage.cache_creation_input_tokens ?? 0,
       },
       stopReason: response.stop_reason ?? undefined,
     };

--- a/packages/llm-bedrock/src/bedrock-provider.test.ts
+++ b/packages/llm-bedrock/src/bedrock-provider.test.ts
@@ -92,7 +92,12 @@ describe('BedrockLLMProvider', () => {
     const result = await provider.invoke('us.anthropic.claude-opus-4-6-v1', 'prompt');
 
     expect(result.text).toBe('Review result');
-    expect(result.usage).toEqual({ inputTokens: 100, outputTokens: 50 });
+    // #490 — cache fields are reported even when the response carries none,
+    // so an absent cache is an explicit zero rather than a missing number.
+    expect(result.usage).toEqual({
+      inputTokens: 100, outputTokens: 50,
+      cacheReadInputTokens: 0, cacheWriteInputTokens: 0,
+    });
   });
 
   it('parses Titan response correctly (no usage)', async () => {

--- a/packages/llm-bedrock/src/bedrock-provider.ts
+++ b/packages/llm-bedrock/src/bedrock-provider.ts
@@ -186,7 +186,15 @@ function parseAnthropicResponse(raw: string): ParsedResponse {
   const parsed = JSON.parse(raw);
   const text = parsed.content?.[0]?.text ?? '';
   const usage: TokenUsage | undefined = parsed.usage
-    ? { inputTokens: parsed.usage.input_tokens ?? 0, outputTokens: parsed.usage.output_tokens ?? 0 }
+    ? {
+        inputTokens: parsed.usage.input_tokens ?? 0,
+        outputTokens: parsed.usage.output_tokens ?? 0,
+        // #490 — the API reports these SEPARATELY from input_tokens, which
+        // counts uncached input only. Unread, cached tokens vanish from the
+        // bill entirely and reported cost falls further than true cost.
+        cacheReadInputTokens: parsed.usage.cache_read_input_tokens ?? 0,
+        cacheWriteInputTokens: parsed.usage.cache_creation_input_tokens ?? 0,
+      }
     : undefined;
   return { text, usage, stopReason: parsed.stop_reason ?? undefined };
 }
@@ -282,7 +290,15 @@ export class BedrockLLMProvider implements ILLMProvider {
     return {
       object: block.input,
       usage: parsed.usage
-        ? { inputTokens: parsed.usage.input_tokens ?? 0, outputTokens: parsed.usage.output_tokens ?? 0 }
+        ? {
+        inputTokens: parsed.usage.input_tokens ?? 0,
+        outputTokens: parsed.usage.output_tokens ?? 0,
+        // #490 — the API reports these SEPARATELY from input_tokens, which
+        // counts uncached input only. Unread, cached tokens vanish from the
+        // bill entirely and reported cost falls further than true cost.
+        cacheReadInputTokens: parsed.usage.cache_read_input_tokens ?? 0,
+        cacheWriteInputTokens: parsed.usage.cache_creation_input_tokens ?? 0,
+      }
         : undefined,
       stopReason: parsed.stop_reason ?? undefined,
     };


### PR DESCRIPTION
Phase A of #490. Part of #488.

## Why this lands before any breakpoints

`estimatedCostUsd` is **metered spend**, not a label — it drives Stripe charges, OSS grant drawdown and auto-reload. The Anthropic/Bedrock APIs report `input_tokens` as **uncached input only**, with `cache_read_input_tokens` and `cache_creation_input_tokens` as separate fields that no provider read:

```ts
{ inputTokens: parsed.usage.input_tokens ?? 0, outputTokens: parsed.usage.output_tokens ?? 0 }
```

Place breakpoints first and cached tokens vanish from the count entirely. True cost drops with caching; **reported cost would drop further**, charging zero for tokens billed at 0.1× and 1.25×. That is under-billing, arriving through a door the `REVENUE LEAK` alarm does not watch.

So the meter is fixed first, while nothing is using the cache.

## What changed

- `TokenUsage` gains `cacheReadInputTokens` / `cacheWriteInputTokens`
- Bedrock and Anthropic populate them at **all four** extraction sites
- `TokenAccumulator` tracks them per model, reported separately from uncached input
- `estimateCost` prices them

## Rates are multipliers, not pricing fields

```ts
export const CACHE_READ_MULTIPLIER = 0.1;
export const CACHE_WRITE_MULTIPLIER = 1.25;
```

Adding `cacheReadPer1M` / `cacheWritePer1M` would mean editing ~40 rows **and breaking every `customPricing` override**: a self-hosted `.mergewatch.yml` `pricing:` block carries two keys today, so any override not updated would silently price cache traffic at **zero**. Deriving from `inputPer1M` keeps existing two-key overrides correct by construction — and there is a test that pins exactly that.

## No behaviour change

Nothing caches yet, so every new count is zero and cost is arithmetically identical. litellm and ollama have no cache API and omit the fields, which reads as zero — asserted.

## Tests

11 added. The ones that matter are the billing ones:

- reads and writes priced at their own rates, not zero
- **a cached review costs more than counting uncached input alone** — the under-billing failure stated directly (0.30 vs 0.60 on the same review)
- an existing **two-key** `customPricing` override still prices cache traffic
- absent cache fields are arithmetically identical to before
- the Anthropic provider **extracts** the fields — verified to fail without the change by reverting the provider

Full forced gate: build 12/12, typecheck 20/20, test 21/21, all `Cached: 0`.

**Worth noting:** vitest passed 9/9 on the provider tests while `typecheck` failed on an invalid cast in one of them. Vitest does not typecheck; the two are run separately for exactly this reason.

## Not in this PR

Breakpoints and the verifier reorder are Phase B. Also **not merging either until #566's E2E gate is green** — Phase B caches the prefix that PR created, and if the reorder regressed review quality it needs reverting rather than caching.

## Acceptance criterion I cannot honestly meet

> a test asserts `cache_read_input_tokens > 0` on agents 2..6

A unit test cannot establish this — mocked, it proves only that I wrote the number into the mock. It needs a real API round-trip. What is provable is that the request carries `cache_control` (Phase B) and that whatever comes back is priced correctly (this PR). Whether Bedrock honours it is measurable from the gate's `Suite cost` line across runs, and I will report it that way rather than claim the criterion met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp