### PR TITLE
feat(core): cache_control breakpoints and verifier reorder (#490, phase B)

### DIFF
--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -2334,18 +2334,30 @@ export async function verifyFindings(
         return { keep: false };
       }
 
-      const prompt = `${verifierPromptHead}
-
---- Finding ---
-File: ${f.file}
-Line: ${f.line}
-Severity: ${f.severity}
-Title: ${f.title}
-Description: ${f.description}
-Suggestion: ${f.suggestion}
-
---- Complete current file: ${f.file} ---
-${content}`;
+      // #490 — the FILE goes ABOVE the finding, and that ordering is the
+      // single biggest saving in the pipeline. This used to send
+      // `head + finding + file`, so ten findings in one file re-sent that
+      // whole file ten times at full price. With the file above, the prefix
+      // `head + file` is identical for every finding in that file and is
+      // served from cache after the first.
+      //
+      // Labels: the file content is `per-pr` because it is fixed at the PR
+      // head for the whole review; only the finding differs per call. That
+      // gives static → per-pr → per-call, which is where the breakpoint goes.
+      const prompt: PromptSegment[] = [
+        { id: 'verifier-head', stability: 'static', text: verifierPromptHead },
+        {
+          id: 'verifier-file',
+          stability: 'per-pr',
+          text: `\n\n--- Complete current file: ${f.file} ---\n${content}`,
+        },
+        {
+          id: 'verifier-finding',
+          stability: 'per-call',
+          text: `\n\n--- Finding ---\nFile: ${f.file}\nLine: ${f.line}\nSeverity: ${f.severity}\n`
+            + `Title: ${f.title}\nDescription: ${f.description}\nSuggestion: ${f.suggestion}`,
+        },
+      ];
 
       try {
         // #390 — prefer schema-constrained verdicts; unsupported providers

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,8 @@
 export type { ILLMProvider, TokenUsage, LLMInvokeResult, LLMSamplingConfig, LLMStructuredResult } from './llm/types.js';
 export type { PromptSegment, PromptStability, PromptInput } from './llm/prompt-segment.js';
 export { renderPrompt, findVolatilityInversion, assertNonDecreasingVolatility, mostVolatile } from './llm/prompt-segment.js';
+export { toCacheableBlocks, hasCacheableBoundary, MAX_CACHE_BREAKPOINTS } from './llm/cache-blocks.js';
+export type { AnthropicContentBlock } from './llm/cache-blocks.js';
 export { normalizeLLMResult, StructuredOutputUnsupportedError } from './llm/types.js';
 export { TokenAccumulator, TrackingLLMProvider } from './llm/token-accumulator.js';
 export { estimateCost, DEFAULT_PRICING, parseEnvModelPricing } from './llm/pricing.js';

--- a/packages/core/src/llm/cache-blocks.test.ts
+++ b/packages/core/src/llm/cache-blocks.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { toCacheableBlocks, hasCacheableBoundary, MAX_CACHE_BREAKPOINTS } from './cache-blocks.js';
+import { renderPrompt, type PromptSegment } from './prompt-segment.js';
+
+const seg = (id: string, stability: PromptSegment['stability'], text: string): PromptSegment =>
+  ({ id, stability, text });
+
+const REVIEW = [
+  seg('shared', 'static', 'DIRECTIVES'),
+  seg('conv', 'per-repo', '\n\nCONVENTIONS'),
+  seg('ctx', 'per-pr', '\n\nCONTEXT'),
+  seg('diff', 'per-pr', '\n\nDIFF'),
+  seg('agent', 'per-call', '\n\nAGENT'),
+];
+
+describe('toCacheableBlocks', () => {
+  it('never loses or reorders text — the wire content is the rendered prompt', () => {
+    // The property that matters most: caching must not change what the model
+    // reads. If this ever fails, cost is the least of the problems.
+    expect(toCacheableBlocks(REVIEW).map((b) => b.text).join('')).toBe(renderPrompt(REVIEW));
+  });
+
+  it('collapses consecutive same-stability segments into one block', () => {
+    // ctx and diff are both per-pr; a breakpoint between them would buy
+    // nothing and spend one of the four.
+    const blocks = toCacheableBlocks(REVIEW);
+    expect(blocks).toHaveLength(4);
+    expect(blocks[2].text).toBe('\n\nCONTEXT\n\nDIFF');
+  });
+
+  it('marks every boundary except the last', () => {
+    const blocks = toCacheableBlocks(REVIEW);
+    expect(blocks.slice(0, -1).every((b) => b.cache_control?.type === 'ephemeral')).toBe(true);
+    // Caching a prefix that includes the MOST volatile segment writes an entry
+    // nothing can ever read — paying the 1.25x write premium for no read.
+    expect(blocks[blocks.length - 1].cache_control).toBeUndefined();
+  });
+
+  it('never exceeds the 4-breakpoint API limit', () => {
+    const many = (['static', 'per-repo', 'per-pr', 'per-call'] as const)
+      .flatMap((s, i) => [seg(`a${i}`, s, `A${i}`)]);
+    // Six distinct groups would want five marks; the API allows four.
+    const wide = [...many, seg('x', 'per-call', 'X'), seg('y', 'per-call', 'Y')];
+    const marked = toCacheableBlocks(wide).filter((b) => b.cache_control).length;
+    expect(marked).toBeLessThanOrEqual(MAX_CACHE_BREAKPOINTS);
+  });
+
+  it('passes a plain string through as a single unmarked block', () => {
+    // Unmigrated callers must be byte-identical and must not pay a write premium.
+    const blocks = toCacheableBlocks('just a string');
+    expect(blocks).toEqual([{ type: 'text', text: 'just a string' }]);
+  });
+
+  it('handles an empty segment list without emitting a broken body', () => {
+    expect(toCacheableBlocks([])).toEqual([{ type: 'text', text: '' }]);
+  });
+});
+
+describe('hasCacheableBoundary', () => {
+  it('is false for a string, and for segments that are all one stability', () => {
+    // No boundary means no reason to switch to block form — so the request
+    // stays exactly the shape it was before #490.
+    expect(hasCacheableBoundary('x')).toBe(false);
+    expect(hasCacheableBoundary([seg('a', 'per-pr', 'A'), seg('b', 'per-pr', 'B')])).toBe(false);
+  });
+
+  it('is true once stabilities differ', () => {
+    expect(hasCacheableBoundary(REVIEW)).toBe(true);
+  });
+});
+
+describe('the verifier shape (#490)', () => {
+  it('caches head+file so every finding in one file reuses the prefix', () => {
+    // The biggest single saving: this used to send head + finding + FILE, so
+    // ten findings in one file re-sent that file ten times at full price.
+    const forFinding = (title: string) => [
+      seg('verifier-head', 'static', 'HEAD'),
+      seg('verifier-file', 'per-pr', '\n\nFILE CONTENT'),
+      seg('verifier-finding', 'per-call', `\n\n${title}`),
+    ];
+    const a = toCacheableBlocks(forFinding('FINDING A'));
+    const b = toCacheableBlocks(forFinding('FINDING B'));
+    // The cached prefix is identical across findings...
+    const prefix = (bs: typeof a) => bs.filter((x) => x.cache_control).map((x) => x.text).join('');
+    expect(prefix(a)).toBe(prefix(b));
+    expect(prefix(a)).toContain('FILE CONTENT');
+    // ...and the part that differs is not inside it.
+    expect(prefix(a)).not.toContain('FINDING A');
+  });
+});

--- a/packages/core/src/llm/cache-blocks.ts
+++ b/packages/core/src/llm/cache-blocks.ts
@@ -1,0 +1,69 @@
+import type { PromptInput, PromptSegment, PromptStability } from './prompt-segment.js';
+import { renderPrompt } from './prompt-segment.js';
+
+/**
+ * #490 — turn segments into Anthropic content blocks with `cache_control` at
+ * stability boundaries.
+ *
+ * Lives in core because both Bedrock and Anthropic need identical behaviour,
+ * but it emits only the shape; neither the decision to cache nor the wire call
+ * belongs here. A provider without a cache API ignores this entirely and keeps
+ * calling `renderPrompt`.
+ */
+
+/** Anthropic allows at most 4 cache breakpoints per request. */
+export const MAX_CACHE_BREAKPOINTS = 4;
+
+export interface AnthropicContentBlock {
+  type: 'text';
+  text: string;
+  cache_control?: { type: 'ephemeral' };
+}
+
+/**
+ * Group consecutive segments by stability, then mark the END of each group as
+ * a cache breakpoint.
+ *
+ * Why group rather than mark every segment: a breakpoint mid-way through a run
+ * of equally-stable text buys nothing and spends one of the four. Why the END
+ * of a group: `cache_control` marks a prefix boundary — everything up to and
+ * including that block is the cached prefix.
+ *
+ * The LAST group is never marked. Caching a prefix that includes the most
+ * volatile segment would write a cache entry nothing can ever read, paying the
+ * 1.25x write premium for no read.
+ */
+export function toCacheableBlocks(prompt: PromptInput): AnthropicContentBlock[] {
+  if (typeof prompt === 'string') return [{ type: 'text', text: prompt }];
+  const segments = prompt as readonly PromptSegment[];
+  if (segments.length === 0) return [{ type: 'text', text: '' }];
+
+  // Collapse consecutive same-stability segments into one block.
+  const groups: Array<{ stability: PromptStability; text: string }> = [];
+  for (const seg of segments) {
+    const last = groups[groups.length - 1];
+    if (last && last.stability === seg.stability) last.text += seg.text;
+    else groups.push({ stability: seg.stability, text: seg.text });
+  }
+
+  // Breakpoints go on the earliest boundaries: the most stable prefixes are
+  // the ones most worth caching, and they are also the ones most likely to be
+  // shared with another request.
+  const markable = Math.max(0, groups.length - 1);
+  const marks = Math.min(markable, MAX_CACHE_BREAKPOINTS);
+
+  return groups.map((g, i) => (
+    i < marks
+      ? { type: 'text' as const, text: g.text, cache_control: { type: 'ephemeral' as const } }
+      : { type: 'text' as const, text: g.text }
+  ));
+}
+
+/** True when this prompt has any boundary worth marking. */
+export function hasCacheableBoundary(prompt: PromptInput): boolean {
+  return typeof prompt !== 'string'
+    && new Set((prompt as readonly PromptSegment[]).map((s) => s.stability)).size > 1;
+}
+
+/** Rendered text, for providers with no cache API. */
+export { renderPrompt };

--- a/packages/llm-anthropic/src/anthropic-provider.ts
+++ b/packages/llm-anthropic/src/anthropic-provider.ts
@@ -1,4 +1,4 @@
-import { renderPrompt } from '@mergewatch/core';
+import { renderPrompt, toCacheableBlocks, hasCacheableBoundary } from '@mergewatch/core';
 import Anthropic from '@anthropic-ai/sdk';
 import type { ILLMProvider, LLMInvokeResult, LLMSamplingConfig, LLMStructuredResult, PromptInput} from '@mergewatch/core';
 
@@ -24,7 +24,10 @@ export class AnthropicLLMProvider implements ILLMProvider {
       // #489 — rendered here rather than upstream. This provider does not yet
       // place cache breakpoints, so segments collapse to exactly the string
       // it built before.
-      messages: [{ role: 'user', content: renderPrompt(prompt) }],
+      messages: [{
+        role: 'user',
+        content: hasCacheableBoundary(prompt) ? toCacheableBlocks(prompt) : renderPrompt(prompt),
+      }] as never,
     });
     const block = response.content[0];
     if (block.type !== 'text') {
@@ -68,7 +71,10 @@ export class AnthropicLLMProvider implements ILLMProvider {
       // #489 — rendered here rather than upstream. This provider does not yet
       // place cache breakpoints, so segments collapse to exactly the string
       // it built before.
-      messages: [{ role: 'user', content: renderPrompt(prompt) }],
+      messages: [{
+        role: 'user',
+        content: hasCacheableBoundary(prompt) ? toCacheableBlocks(prompt) : renderPrompt(prompt),
+      }] as never,
     });
     const block = response.content.find((b) => b.type === 'tool_use');
     if (!block || block.type !== 'tool_use') {

--- a/packages/llm-bedrock/src/bedrock-provider.ts
+++ b/packages/llm-bedrock/src/bedrock-provider.ts
@@ -17,7 +17,7 @@ import {
   InvokeModelCommand,
 } from '@aws-sdk/client-bedrock-runtime';
 import type { ILLMProvider, LLMInvokeResult, LLMSamplingConfig, LLMStructuredResult, TokenUsage, PromptInput} from '@mergewatch/core';
-import { StructuredOutputUnsupportedError, renderPrompt} from '@mergewatch/core';
+import { StructuredOutputUnsupportedError, renderPrompt, toCacheableBlocks, hasCacheableBoundary } from '@mergewatch/core';
 
 // ─── Supported model IDs ───────────────────────────────────────────────────
 export const SUPPORTED_MODELS = {
@@ -81,10 +81,16 @@ function buildAnthropicBody(
   sampling: LLMSamplingConfig,
   modelId: string,
 ): ModelRequestBody {
+  // #490 — segments with more than one stability level become content blocks
+  // with cache_control at the boundaries; anything else stays the plain string
+  // it was, so a caller passing a string sees byte-identical behaviour.
   const body: Record<string, unknown> = {
     anthropic_version: 'bedrock-2023-05-31',
     max_tokens: maxTokens,
-    messages: [{ role: 'user', content: renderPrompt(prompt) }],
+    messages: [{
+      role: 'user',
+      content: hasCacheableBoundary(prompt) ? toCacheableBlocks(prompt) : renderPrompt(prompt),
+    }],
   };
   if (acceptsSamplingParams(modelId)) {
     body.temperature = sampling.temperature ?? 0;


### PR DESCRIPTION
Phase B of #490. Closes #490. Builds on #567 (accounting) and #566 (shared prefix).

## The verifier reorder — the biggest single win

`verifyFindings` built `head + finding + FILE`, with the file **last**. Ten findings in one file re-sent that whole file **ten times at full price**.

The file now sits above the finding, so `head + file` is an identical prefix for every finding in that file and is served from cache after the first. Its segment is `per-pr` — the file is fixed at the PR head for the whole review — while only the finding is `per-call`. That gives `static → per-pr → per-call`, and the breakpoint falls exactly where it should.

## Breakpoints

`toCacheableBlocks` emits Anthropic content blocks with `cache_control` at stability boundaries. Two decisions worth stating:

**It groups consecutive same-stability segments first.** A breakpoint inside a run of equally-stable text buys nothing and spends one of the four the API allows.

**It never marks the last group.** Caching a prefix that includes the most volatile segment writes an entry nothing can ever read — paying the 1.25× write premium for zero reads. That is a way to make caching cost *more*, so it is prevented by construction and asserted by a test.

Providers switch to block form **only** when a prompt genuinely has more than one stability level. A string, or segments that are all one stability, takes the old path and is byte-identical on the wire — so unmigrated callers cannot start paying a write premium by accident.

## Unaffected

litellm and ollama have no cache API. Their prefix caching is automatic, which #564's stable-first ordering already earns.

## Tests

9 added. The first is the one that matters most:

- **the wire content equals the rendered prompt** — caching must not change what the model reads; if that ever fails, cost is the least of the problems
- consecutive same-stability segments collapse into one block
- every boundary marked except the last
- the 4-breakpoint API limit is never exceeded
- a plain string passes through as a single **unmarked** block
- the verifier shape: the cached prefix is identical across findings, contains the file, and does **not** contain the finding

Full forced gate: build 12/12, typecheck 20/20, test 21/21, all `Cached: 0`.

## What this does not prove — and how it will be judged

**That Bedrock actually honours the breakpoints.** #490 asks for a test asserting `cache_read_input_tokens > 0` on agents 2..6; mocked, that proves only that I wrote the number into the mock. It needs a real round-trip.

What is provable here is that the **request** carries `cache_control` at the right boundaries, and (from #567) that whatever comes back is **priced correctly** — including cache reads at 0.1× and writes at 1.25×, so a working cache cannot silently under-bill.

The real evidence is the gate's `Suite cost` line across runs. Three baselines: **$4.45 → $4.48 → $4.55**, all with 47/48 graded clean. If caching works, this run should fall below them; if it does not, cost stays flat and I will say so rather than claim the win.

This also **deliberately changes the verifier prompt**, so review quality is again only judgeable by the graded suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp