### PR TITLE
fix(core): enforce maxFindings in code, not just in the prompt (#569)

### DIFF
--- a/packages/core/src/agents/cap-findings.test.ts
+++ b/packages/core/src/agents/cap-findings.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { capFindings } from './reviewer.js';
+
+/**
+ * #569 — `maxFindings` was only ever substituted into the orchestrator prompt
+ * as `MAX_FINDINGS_PLACEHOLDER`. It was a REQUEST to the model, never a cap, so
+ * a repo configured `maxFindings: 3` could receive four findings with no signal
+ * that anything had been ignored. `minSeverity`, in the same config block and
+ * documented alike, has always been a real code filter.
+ */
+const f = (title: string, category?: string) => ({ title, category, file: 'a.ts', line: 1 });
+const NO_CUSTOM = new Set<string>();
+
+describe('capFindings', () => {
+  it('caps the model set at maxFindings, keeping the highest-ranked', () => {
+    // Order is the orchestrator's ranking, preserved through the filters, so
+    // taking the first N keeps the strongest rather than an arbitrary slice.
+    const { kept, dropped } = capFindings([f('1'), f('2'), f('3'), f('4')], 3, NO_CUSTOM);
+    expect(kept.map((x) => x.title)).toEqual(['1', '2', '3']);
+    expect(dropped.map((x) => x.title)).toEqual(['4']);
+  });
+
+  it('passes through unchanged when under the cap', () => {
+    const input = [f('1'), f('2')];
+    const { kept, dropped } = capFindings(input, 5, NO_CUSTOM);
+    expect(kept).toEqual(input);
+    expect(dropped).toEqual([]);
+  });
+
+  it('NEVER drops a custom-agent finding', () => {
+    // The important one. Custom findings bypass model filtering by design
+    // (#385) because they are user-legislated policy, and a blocking agent's
+    // finding failing the check is the entire point. Dropping one to satisfy a
+    // noise cap would silently discard exactly what #385 protects.
+    const custom = new Set(['no-todo']);
+    const { kept, dropped } = capFindings(
+      [f('m1'), f('m2'), f('c1', 'no-todo'), f('m3'), f('c2', 'no-todo')],
+      1,
+      custom,
+    );
+    expect(kept.map((x) => x.title)).toEqual(['m1', 'c1', 'c2']);
+    expect(dropped.map((x) => x.title)).toEqual(['m2', 'm3']);
+  });
+
+  it('custom findings do not consume the model budget', () => {
+    // A repo with custom agents still gets its full model allowance.
+    const custom = new Set(['policy']);
+    const { kept } = capFindings([f('c', 'policy'), f('m1'), f('m2')], 2, custom);
+    expect(kept.map((x) => x.title)).toEqual(['c', 'm1', 'm2']);
+  });
+
+  it('a builtin category is not mistaken for a custom agent', () => {
+    // Builtin findings carry categories too (security, bug, style…). Only a
+    // name in the enabled custom-agent set is exempt.
+    const { kept, dropped } = capFindings([f('a', 'security'), f('b', 'bug')], 1, new Set(['no-todo']));
+    expect(kept.map((x) => x.title)).toEqual(['a']);
+    expect(dropped.map((x) => x.title)).toEqual(['b']);
+  });
+
+  it('treats a non-positive or non-finite cap as no cap', () => {
+    // Absent config must not silently suppress every finding.
+    const input = [f('1'), f('2')];
+    for (const bad of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(capFindings(input, bad, NO_CUSTOM).kept).toEqual(input);
+      expect(capFindings(input, bad, NO_CUSTOM).dropped).toEqual([]);
+    }
+  });
+
+  it('handles an empty finding set', () => {
+    expect(capFindings([], 3, NO_CUSTOM)).toEqual({ kept: [], dropped: [] });
+  });
+
+  it('a cap of 1 with only custom findings keeps them all', () => {
+    const custom = new Set(['policy']);
+    const { kept, dropped } = capFindings([f('c1', 'policy'), f('c2', 'policy')], 1, custom);
+    expect(kept).toHaveLength(2);
+    expect(dropped).toEqual([]);
+  });
+});

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -295,6 +295,53 @@ export function buildPrompt(
 }
 
 /**
+ * #569 — enforce `maxFindings` in code.
+ *
+ * It was only ever substituted into the orchestrator prompt as
+ * `MAX_FINDINGS_PLACEHOLDER`: a REQUEST to the model, never a cap. A repo
+ * setting `maxFindings: 3` could receive four findings with no signal that
+ * anything had been ignored — which is what `78a-output-shaping` caught.
+ * `minSeverity`, in the same config block and documented alike, has always
+ * been a real code filter.
+ *
+ * Applied AFTER the filter chain, not before: the user asked for at most N
+ * findings POSTED. Capping first would spend the budget on findings the
+ * filters then remove, leaving fewer than N for no reason.
+ *
+ * Custom-agent findings are EXEMPT. They bypass model filtering by design
+ * (#385) because they are user-legislated policy, not model taste — and a
+ * blocking agent's finding failing the check is the entire point. Dropping
+ * one to satisfy a noise cap would silently discard the thing #385 exists to
+ * protect. The cap governs what the MODEL produced.
+ */
+export function capFindings<T extends { category?: string; title: string; file: string; line: number }>(
+  findings: T[],
+  maxFindings: number,
+  customAgentNames: ReadonlySet<string>,
+): { kept: T[]; dropped: T[] } {
+  if (!Number.isFinite(maxFindings) || maxFindings <= 0) return { kept: findings, dropped: [] };
+
+  const kept: T[] = [];
+  const dropped: T[] = [];
+  let modelBudget = maxFindings;
+  for (const f of findings) {
+    if (f.category && customAgentNames.has(f.category)) {
+      kept.push(f);
+      continue;
+    }
+    // Order is the orchestrator's ranking, preserved through the filters, so
+    // taking the first N keeps the strongest rather than an arbitrary slice.
+    if (modelBudget > 0) {
+      kept.push(f);
+      modelBudget--;
+    } else {
+      dropped.push(f);
+    }
+  }
+  return { kept, dropped };
+}
+
+/**
  * Scan text for top-level balanced JSON objects, respecting string literals
  * and escapes. Returns each candidate's exact source slice, in order. This is
  * what lets a response like `{"requestFiles": []}` + prose + `{"findings":
@@ -3538,13 +3585,32 @@ export async function runReviewPipeline(
     );
   }
 
+  // #569 — the cap, enforced. Last filter before finalize so it governs what
+  // is actually posted.
+  const { kept: cappedFindings, dropped: overCap } = capFindings(
+    filteredFindings,
+    maxFindings,
+    new Set(enabledCustomAgents.map((a) => a.name)),
+  );
+  for (const f of overCap) {
+    trace.record(f, 'dropped', 'max-findings', {
+      reason: `over the repo's maxFindings cap of ${maxFindings}`,
+    });
+  }
+  if (overCap.length > 0) {
+    console.warn(
+      '[max-findings] dropped %d finding%s over the cap of %d',
+      overCap.length, overCap.length === 1 ? '' : 's', maxFindings,
+    );
+  }
+
   // Delta caption — only on re-reviews where something actually changed
   // commit-to-commit. Uses lightModel to match the other prose agents.
   // #470 — everything still un-adjudicated survived to the reader.
-  trace.finalize(filteredFindings);
+  trace.finalize(cappedFindings);
   const filterOutcomes = trace.outcomes();
 
-  const delta = computeReviewDelta(filteredFindings, previousFindings);
+  const delta = computeReviewDelta(cappedFindings, previousFindings);
   const deltaCaption = delta
     ? await runDeltaCaptionAgent(delta, lightModelId, llm)
     : null;
@@ -3564,7 +3630,9 @@ export async function runReviewPipeline(
 
   // Reconcile the orchestrator's verdict with the post-filter findings.
   const { mergeScore, mergeScoreReason, disputeDisclosure } = reconcileMergeScore({
-    filteredFindings,
+    // #569 — the verdict must describe what was POSTED. Scoring the uncapped
+    // set would justify a score against findings the reader never sees.
+    filteredFindings: cappedFindings,
     previousFindings,
     orchestratorScore: orchestratorResult.mergeScore,
     orchestratorReason: orchestratorResult.mergeScoreReason,
@@ -3598,7 +3666,7 @@ export async function runReviewPipeline(
 
   return {
     summary,
-    findings: filteredFindings,
+    findings: cappedFindings,
     changedLines,
     diagram: diagramResult.diagram,
     diagramCaption: diagramResult.caption,

--- a/packages/core/src/filter-trace.ts
+++ b/packages/core/src/filter-trace.ts
@@ -36,7 +36,9 @@ export type FilterStage =
   | 'finding-verify'        // W2 / FP-E verifier verdict
   | 'line-proximity'        // ±3 changed-line filter
   | 'custom-agent-dedup'    // #385 re-entry
-  | 'triage-suppressed';    // W3
+  | 'triage-suppressed'
+  /** #569 — over the repo's `maxFindings` cap. */
+  | 'max-findings';    // W3
 
 /**
  * What happened to one finding in one review.


### PR DESCRIPTION
Closes #569.

## The bug

`maxFindings` is documented as a cap. It was never enforced:

```
packages/core/src/agents/reviewer.ts:1442
  .replace('MAX_FINDINGS_PLACEHOLDER', String(maxFindings))
```

That was the **only** thing done with the value — no slice, no truncation, no filter. A repo setting `maxFindings: 3` got a model *asked* for 3 that usually complied, with no signal when it did not.

`minSeverity` sits in the same config block, is documented the same way, and **is** a real code filter. Two options, same surface, different enforcement.

Found when `78a-output-shaping` failed the gate with `4 inline comments, above max 3` on a repo configured for 3.

## Two decisions worth stating

**The cap runs AFTER the filter chain.** The user asked for at most N findings *posted*. Capping before would spend the budget on findings the filters then remove, leaving fewer than N for no reason.

**Custom-agent findings are exempt.** They bypass model filtering by design (#385) because they are user-legislated policy, not model taste — and a blocking agent's finding failing the check is the entire point. Dropping one to satisfy a noise cap would silently discard exactly what #385 protects. The cap governs what the *model* produced; a repo with custom agents still gets its full model allowance.

That does mean `maxFindings` is not an absolute ceiling when custom agents fire. That is the right trade, but it is a real semantic and it is documented in the helper rather than left to be discovered.

## Also

The verdict and the returned set both read the capped findings — scoring the uncapped set would justify a score against findings the reader never sees. Dropped findings are recorded in the decision trail under a new `max-findings` stage rather than vanishing.

## Tests

8, covering the cap, the exemption, and the edges:

- caps at N keeping the highest-ranked (order is the orchestrator's ranking, preserved through the filters)
- **never drops a custom-agent finding**, even at `maxFindings: 1`
- custom findings do not consume the model budget
- a builtin category (`security`, `bug`) is not mistaken for a custom agent
- a non-positive or non-finite cap means no cap — absent config must not silently suppress everything
- empty set, and under-cap pass-through

Full forced gate: build 12/12, typecheck 20/20, test 21/21, all `Cached: 0`.

## Knock-on

This makes `78a-output-shaping`'s `inlineComments: {max: 3}` assertion genuinely deterministic — it was asserting a hard cap against a soft instruction (fixtures#2049, tracked in #570). That fixture should stop failing at random once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp