### PR TITLE
fix(bedrock): send cache breakpoints on the structured path too (#490)

### DIFF
--- a/packages/llm-bedrock/src/bedrock-provider.test.ts
+++ b/packages/llm-bedrock/src/bedrock-provider.test.ts
@@ -301,3 +301,71 @@ describe('BedrockLLMProvider', () => {
     expect(result.usage).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// #490 — BOTH request paths must carry cache breakpoints
+//
+// The bug this locks down: `buildAnthropicBody` was patched and
+// `buildAnthropicStructuredBody` was not. Since #390 the six finding agents
+// PREFER invokeStructured, so every agent call shipped with no cache_control
+// at all. The first gate run after breakpoints landed showed cost unchanged at
+// $4.53 and zero cache tokens — precisely what a half-wired provider looks
+// like, and indistinguishable from "Bedrock ignored our breakpoints".
+//
+// Testing only the text path would have passed while the product cached
+// nothing, which is why both are asserted here.
+// ---------------------------------------------------------------------------
+describe('#490 — cache breakpoints on every path', () => {
+  const MODEL = 'us.anthropic.claude-sonnet-4-20250514-v1:0';
+  const SEGMENTS = [
+    { id: 'shared', stability: 'static', text: 'DIRECTIVES' },
+    { id: 'diff', stability: 'per-pr', text: '\n\nDIFF' },
+    { id: 'agent', stability: 'per-call', text: '\n\nAGENT' },
+  ] as never;
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it('the TEXT path sends content blocks with cache_control', async () => {
+    mockSend.mockResolvedValueOnce(makeResponse({
+      content: [{ type: 'text', text: 'ok' }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    }));
+    const provider = new BedrockLLMProvider('us-east-1');
+    await provider.invoke(MODEL, SEGMENTS, 100);
+
+    const content = getLastCommandBody().messages[0].content;
+    expect(Array.isArray(content)).toBe(true);
+    expect(content.filter((b: { cache_control?: unknown }) => b.cache_control).length).toBeGreaterThan(0);
+  });
+
+  it('the STRUCTURED path sends them too — the path the agents actually use', async () => {
+    mockSend.mockResolvedValueOnce(makeResponse({
+      content: [{ type: 'tool_use', name: 'emit_result', input: { ok: true } }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    }));
+    const provider = new BedrockLLMProvider('us-east-1');
+    await provider.invokeStructured!(MODEL, SEGMENTS, { type: 'object' }, 100);
+
+    const body = getLastCommandBody();
+    expect(Array.isArray(body.messages[0].content)).toBe(true);
+    expect(body.messages[0].content.filter((b: { cache_control?: unknown }) => b.cache_control).length)
+      .toBeGreaterThan(0);
+    // …and the forced tool is still there; caching must not disturb #390.
+    expect(body.tools[0].name).toBe('emit_result');
+  });
+
+  it('both paths leave a plain string as a plain string', async () => {
+    // An unmigrated caller must not start paying the 1.25x write premium.
+    for (const structured of [false, true]) {
+      vi.clearAllMocks();
+      mockSend.mockResolvedValueOnce(makeResponse({
+        content: [structured ? { type: 'tool_use', name: 'emit_result', input: {} } : { type: 'text', text: 'ok' }],
+        usage: { input_tokens: 1, output_tokens: 1 },
+      }));
+      const provider = new BedrockLLMProvider('us-east-1');
+      if (structured) await provider.invokeStructured!(MODEL, 'plain', { type: 'object' }, 100);
+      else await provider.invoke(MODEL, 'plain', 100);
+      expect(getLastCommandBody().messages[0].content).toBe('plain');
+    }
+  });
+});

--- a/packages/llm-bedrock/src/bedrock-provider.ts
+++ b/packages/llm-bedrock/src/bedrock-provider.ts
@@ -118,7 +118,16 @@ function buildAnthropicStructuredBody(
   const body: Record<string, unknown> = {
     anthropic_version: 'bedrock-2023-05-31',
     max_tokens: maxTokens,
-    messages: [{ role: 'user', content: renderPrompt(prompt) }],
+    // #490 — the STRUCTURED path needs the breakpoints too, and this is the
+    // path that matters: since #390 the six finding agents PREFER
+    // invokeStructured, so patching only buildAnthropicBody left every agent
+    // call sending no cache_control at all. The first gate run after
+    // breakpoints shipped showed cost unchanged and zero cache tokens, which
+    // is exactly what a half-wired provider looks like.
+    messages: [{
+      role: 'user',
+      content: hasCacheableBoundary(prompt) ? toCacheableBlocks(prompt) : renderPrompt(prompt),
+    }],
     tools: [{
       name: 'emit_result',
       description: 'Emit the structured result of your analysis.',


### PR DESCRIPTION
Follow-up to #568. Part of #490.

## The prediction failed, and this is why

#568 shipped `cache_control` breakpoints. The prediction was that suite cost would fall below the $4.45–$4.55 band. It did not move:

| Run | Cost | Input tokens |
|---|---|---|
| baseline | $4.45 | — |
| baseline | $4.48 | 1,281,285 |
| #566 reorder | $4.55 | 1,290,580 |
| #571 | $4.53 | 1,283,220 |
| **#568 breakpoints** | **$4.53** | 1,269,370 |

Zero cache tokens reported anywhere.

## Cause: I patched one of two request builders

`buildAnthropicBody` got the breakpoints. `buildAnthropicStructuredBody` kept `content: renderPrompt(prompt)`.

Since #390 the six finding agents **prefer** `invokeStructured` — so every agent call went through the unpatched builder and sent no `cache_control` at all. The caching landed on the path the pipeline barely uses.

## Why this was hard to see

A half-wired provider and a provider whose breakpoints Bedrock ignores produce **identical** evidence: flat cost, zero cache tokens. Without Phase A's accounting (#567) there would have been no way to tell them apart, and the obvious conclusion would have been "Bedrock does not honour this" — wrong, and it would have closed off the real fix.

That is the sixth instance this week of code that compiles, reads correctly, and does nothing: #544 (stage not passed), #545 (permission), #558 (wrong event), #559 (`actions: write`), #565 (providers accepting a widened type without rendering), and this.

## Tests

Three added. The important property: **the structured test fails without this change while the text test passes either way** — verified by reverting. Testing one path would have stayed green while the product cached nothing.

- text path sends blocks with `cache_control`
- **structured path sends them too** — and the forced `emit_result` tool is still intact, so caching does not disturb #390
- both paths leave a plain string as a plain string, so an unmigrated caller cannot start paying the 1.25× write premium

Full forced gate: build 12/12, typecheck 20/20, test 21/21, all `Cached: 0`.

## The prediction, restated

Next gate run should fall **below $4.53** and report non-zero `cache_read_input_tokens`. If it stays flat with cache tokens still zero, then Bedrock genuinely is not honouring the breakpoints — a different problem, most likely a missing `anthropic_beta` opt-in — and I will say so rather than keep guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp