### PR TITLE
feat(core): emit a machine-readable cost payload (#561, phase 2)

### DIFF
--- a/packages/core/src/comment-formatter.test.ts
+++ b/packages/core/src/comment-formatter.test.ts
@@ -188,6 +188,46 @@ describe('formatReviewComment', () => {
     expect(result).not.toContain('```mermaid');
   });
 
+  // #561 — the payload and the prose must describe the SAME review.
+  //
+  // Two representations of one number will drift the first time someone edits
+  // one of them. The grader will prefer the payload, so a payload that
+  // disagreed with the visible table would silently bill against numbers
+  // nobody could see.
+  it('#561 — the machine-readable payload agrees with the rendered table', async () => {
+    const { parseCostPayload } = await import('./comment-formatter.js');
+    const result = formatReviewComment(baseOptions({
+      inputTokens: 115256,
+      outputTokens: 2551,
+      estimatedCostUsd: 0.2424,
+    }));
+
+    const payload = parseCostPayload(result);
+    expect(payload).not.toBeNull();
+    expect(payload!.estimatedCostUsd).toBe(0.2424);
+    expect(payload!.inputTokens).toBe(115256);
+    expect(payload!.outputTokens).toBe(2551);
+
+    // …and those exact figures are what the human table shows.
+    expect(result).toContain('$0.2424');
+    expect(result).toContain('115,256 in');
+    expect(result).toContain('2,551 out');
+  });
+
+  it('#561 — a re-review payload carries both figures the prose splits', async () => {
+    const { parseCostPayload } = await import('./comment-formatter.js');
+    const result = formatReviewComment(baseOptions({
+      inputTokens: 10, outputTokens: 5,
+      estimatedCostUsd: 0.1, cumulativeCostUsd: 0.75,
+    }));
+    const payload = parseCostPayload(result);
+    expect(payload!.estimatedCostUsd).toBe(0.1);
+    expect(payload!.cumulativeCostUsd).toBe(0.75);
+    // The prose form the regex has to special-case; the payload does not.
+    expect(result).toContain('this run');
+    expect(result).toContain('total for PR');
+  });
+
   // Review details section
   it('shows review details with tokens, cost, duration, and model', () => {
     const result = formatReviewComment(baseOptions({

--- a/packages/core/src/comment-formatter.ts
+++ b/packages/core/src/comment-formatter.ts
@@ -558,6 +558,55 @@ function fitSections(sections: Section[], budget: number, reviewDetailUrl?: stri
  *
  * @returns A markdown string ready to be posted as a GitHub PR comment.
  */
+/**
+ * #561 — marker for the machine-readable cost payload.
+ *
+ * Exported so a consumer parses against the same constant the formatter
+ * writes, rather than a copied literal.
+ */
+export const COST_PAYLOAD_MARKER = 'mw-cost';
+
+export interface CostPayload {
+  inputTokens?: number | null;
+  outputTokens?: number | null;
+  estimatedCostUsd?: number | null;
+  cumulativeCostUsd?: number | null;
+}
+
+/**
+ * Render the cost payload as an HTML comment.
+ *
+ * Emitted even when every field is absent: a payload of `{}` still tells a
+ * reader "this deployment emits payloads and this review genuinely had no
+ * cost", which is different from "no payload, so I could not tell". That
+ * distinction is the whole point — a silent zero is what #561 is about.
+ */
+export function renderCostPayload(p: CostPayload): string {
+  const body: Record<string, number> = {};
+  if (p.inputTokens != null) body.inputTokens = p.inputTokens;
+  if (p.outputTokens != null) body.outputTokens = p.outputTokens;
+  if (p.estimatedCostUsd != null) body.estimatedCostUsd = p.estimatedCostUsd;
+  if (p.cumulativeCostUsd != null) body.cumulativeCostUsd = p.cumulativeCostUsd;
+  return `<!-- ${COST_PAYLOAD_MARKER}:${JSON.stringify(body)} -->`;
+}
+
+/**
+ * Read a cost payload back. Returns null when absent or unparseable — the
+ * caller then falls back to the prose table, which is what keeps a review
+ * from an older deployment readable.
+ */
+export function parseCostPayload(body: string): CostPayload | null {
+  const m = new RegExp(`<!-- ${COST_PAYLOAD_MARKER}:(\\{.*?\\}) -->`).exec(body ?? '');
+  if (!m) return null;
+  try {
+    const parsed: unknown = JSON.parse(m[1]);
+    if (!parsed || typeof parsed !== 'object') return null;
+    return parsed as CostPayload;
+  } catch {
+    return null;
+  }
+}
+
 export function formatReviewComment(options: FormatOptions): string {
   const {
     summary,
@@ -917,6 +966,17 @@ export function formatReviewComment(options: FormatOptions): string {
     }
     details.push('');
     details.push('</details>');
+    // #561 — a machine-readable copy of the numbers rendered above.
+    //
+    // The E2E grader parses cost out of the PROSE table with a regex, across a
+    // repo boundary. A formatter change stops it matching and the suite total
+    // silently collapses to $0.00 — which reads as good news. Nothing pins the
+    // two ends together, and nothing can: the parser is in another repo, so a
+    // test here would have to copy the regexes and could drift the same way.
+    //
+    // An HTML comment removes the coupling rather than testing it. Invisible
+    // when rendered, same pattern as the `mw-fp` inline fingerprint.
+    details.push(renderCostPayload({ inputTokens, outputTokens, estimatedCostUsd, cumulativeCostUsd }));
     details.push('');
   }
 

--- a/packages/core/src/cost-payload.test.ts
+++ b/packages/core/src/cost-payload.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { renderCostPayload, parseCostPayload, COST_PAYLOAD_MARKER } from './comment-formatter.js';
+
+/**
+ * #561 — the E2E grader parses cost out of the review comment's PROSE table
+ * with a regex, across a repo boundary. A formatter change stops it matching
+ * and the suite total silently collapses to $0.00 — which reads as good news,
+ * in the direction that makes the cost work look finished.
+ *
+ * Nothing pins the two ends together, and nothing can: the parser lives in
+ * another repo, so a test here would have to COPY the regexes and could drift
+ * exactly the same way. A machine-readable payload removes the coupling rather
+ * than testing it.
+ */
+describe('renderCostPayload', () => {
+  it('round-trips through parse', () => {
+    const p = { inputTokens: 115256, outputTokens: 2551, estimatedCostUsd: 0.2424 };
+    expect(parseCostPayload(renderCostPayload(p))).toEqual(p);
+  });
+
+  it('is an HTML comment — invisible when rendered', () => {
+    const s = renderCostPayload({ estimatedCostUsd: 1 });
+    expect(s.startsWith('<!--')).toBe(true);
+    expect(s.endsWith('-->')).toBe(true);
+  });
+
+  it('omits absent fields rather than writing null', () => {
+    // A null would be indistinguishable from a real zero once parsed.
+    expect(renderCostPayload({ estimatedCostUsd: 0.5 })).toBe(
+      `<!-- ${COST_PAYLOAD_MARKER}:{"estimatedCostUsd":0.5} -->`,
+    );
+  });
+
+  it('emits an empty payload rather than nothing when no numbers exist', () => {
+    // `{}` says "this deployment emits payloads and this review had no cost".
+    // No payload at all says "I could not tell" — a different thing, and the
+    // exact ambiguity #561 is about.
+    expect(renderCostPayload({})).toBe(`<!-- ${COST_PAYLOAD_MARKER}:{} -->`);
+    expect(parseCostPayload(renderCostPayload({}))).toEqual({});
+  });
+
+  it('carries the cumulative figure on a re-review', () => {
+    // The prose table switches format once a PR is reviewed twice; the payload
+    // keeps both numbers as separate fields, so a consumer never has to know
+    // which sentence form it is looking at.
+    const p = { estimatedCostUsd: 0.1, cumulativeCostUsd: 0.75 };
+    expect(parseCostPayload(renderCostPayload(p))).toEqual(p);
+  });
+});
+
+describe('parseCostPayload', () => {
+  it('returns null when absent, so a caller can fall back to the prose', () => {
+    // This is what keeps a review from an OLDER deployment readable while the
+    // payload rolls out across stages.
+    expect(parseCostPayload('a comment with no payload')).toBeNull();
+    expect(parseCostPayload('')).toBeNull();
+  });
+
+  it('returns null on malformed JSON rather than throwing', () => {
+    // Throwing here would take down the whole grading step, not just the note.
+    expect(parseCostPayload(`<!-- ${COST_PAYLOAD_MARKER}:{not json} -->`)).toBeNull();
+  });
+
+  it('finds the payload among surrounding comment text', () => {
+    const body = `## Review\n\nsome prose\n\n${renderCostPayload({ estimatedCostUsd: 2 })}\n\nmore prose`;
+    expect(parseCostPayload(body)).toEqual({ estimatedCostUsd: 2 });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -151,6 +151,8 @@ export type { ReviewThreadComment } from './github/client.js';
 // ─── Comment formatter ──────────────────────────────────────────────────────
 export { formatReviewComment,
   mergeScoreMeta, buildReviewDetailUrl, buildWorkDoneSection, countBlockingCriticals, buildCheckTitle, escapeUserContent } from './comment-formatter.js';
+export { renderCostPayload, parseCostPayload, COST_PAYLOAD_MARKER } from './comment-formatter.js';
+export type { CostPayload } from './comment-formatter.js';
 export type { Finding, WorkDoneSection } from './comment-formatter.js';
 
 // ─── Review delta ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Phase 2 of 3 for #561. Phase 1 is fixtures#2241; Phase 3 is the grader change that reads this.

## Why a payload rather than a test

#561 offered three options. **Option 1 — assert the pairing in a test here — has the flaw the issue is about.** The parser lives in a *different repo*, so a test in this one cannot import it; it would have to copy the regexes, and a copied regex drifts from the real parser silently. That is exactly the failure mode being fixed.

Compare `review-findings.test.ts`, the existing drift test: it works because it imports the *real* core function. Not available across a repo boundary.

**Option 2 removes the coupling instead of testing it.**

```
<!-- mw-cost:{"inputTokens":115256,"outputTokens":2551,"estimatedCostUsd":0.2424} -->
```

Invisible when rendered, and the pattern is already idiomatic here — `<!-- mw-fp:… -->` at `client.ts:719` does the same for inline fingerprints.

## Three details

**Both cost figures are separate fields.** The prose table switches sentence form once a PR is reviewed twice (`~$X this run · ~$Y total for PR`), which the regex has to special-case. The payload keeps `estimatedCostUsd` and `cumulativeCostUsd` distinct, so a consumer never has to know which form it is looking at.

**Emitted even when empty.** `{}` says *"this deployment emits payloads and this review genuinely had no cost"*; no payload at all says *"I could not tell"*. Those are different, and the ambiguity is precisely what #561 is about.

**`parseCostPayload` returns null rather than throwing.** Throwing would take down a whole grading step rather than one note — the same failure shape as the manifest-escaping bug caught on fixtures#2122. Null is also what lets a consumer fall back to the prose.

## Tests

10 added. The two that matter most assert **the payload agrees with the rendered table** — two representations of one number drift the first time someone edits one, and the grader will *prefer* the payload, so a disagreement would bill against numbers nobody can see.

Full forced gate: build 12/12, typecheck 20/20, test 21/21, all `Cached: 0`.

## Rollout

Phase 3 must land **after** this reaches production, and must **keep the prose fallback** until every deployment emits the payload — otherwise a review from an older stage reports unknown cost. The two repos cannot land atomically; the fallback is what makes the overlap safe.

Between the two, the payload exists and nothing reads it. Harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp