### PR TITLE
feat(release): release notes say what changed, not just how it was tested (#550)

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -447,14 +447,22 @@ jobs:
           #
           # Same generator as CHANGELOG.md. --no-heading because a GitHub
           # Release's title already IS the version.
-          CHANGES="$(scripts/changelog-section.sh "$VERSION" --no-heading || true)"
+          # `|| true` would conflate two different things: the generator
+          # FAILING, and there being nothing to report. The generator already
+          # emits an explicit "no feature or fix commits in this range" line
+          # for the second, so an empty result here can only mean the first —
+          # and silently printing a placeholder would ship notes that look
+          # complete. Capture the status and fail the release instead.
+          CHANGES=""
+          gen_rc=0
+          CHANGES="$(scripts/changelog-section.sh "$VERSION" --no-heading)" || gen_rc=$?
+          if [ "$gen_rc" -ne 0 ] || [ -z "$CHANGES" ]; then
+            echo "::error::changelog-section.sh failed (rc=$gen_rc) — refusing to publish notes that omit what changed"
+            exit 1
+          fi
           {
             printf '## What changed\n'
-            if [ -n "$CHANGES" ]; then
-              printf '%s\n' "$CHANGES"
-            else
-              printf '\n_Changelog generation produced nothing — see the commit range._\n'
-            fi
+            printf '%s\n' "$CHANGES"
             printf '\n---\n\n'
             printf 'Released from `%s` (commit `%s`) via the release gate (#505).\n\n' "$REF" "$SHA"
             printf 'Graded fixture suite:\n\n'

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -439,7 +439,23 @@ jobs:
           longest=$(printf '%s' "$GRADED" | { grep -oE '`+' || true; } \
             | awk '{ if (length($0) > m) m = length($0) } END { print m+0 }')
           fence=$(printf '%*s' "$(( longest < 3 ? 3 : longest + 1 ))" '' | tr ' ' '`')
+          # #550 — what CHANGED goes first. The provenance block below is the
+          # evidence this gate exists to produce and is kept in full, but a
+          # reader deciding whether to upgrade needs the changes, and the notes
+          # used to omit them entirely: v0.6.1's said nothing about its eight
+          # fixes, two of which had made features silently non-functional.
+          #
+          # Same generator as CHANGELOG.md. --no-heading because a GitHub
+          # Release's title already IS the version.
+          CHANGES="$(scripts/changelog-section.sh "$VERSION" --no-heading || true)"
           {
+            printf '## What changed\n'
+            if [ -n "$CHANGES" ]; then
+              printf '%s\n' "$CHANGES"
+            else
+              printf '\n_Changelog generation produced nothing — see the commit range._\n'
+            fi
+            printf '\n---\n\n'
             printf 'Released from `%s` (commit `%s`) via the release gate (#505).\n\n' "$REF" "$SHA"
             printf 'Graded fixture suite:\n\n'
             printf '%s\n%s\n%s\n\n' "$fence" "$GRADED" "$fence"

--- a/packages/lambda/src/release-notes.test.ts
+++ b/packages/lambda/src/release-notes.test.ts
@@ -62,6 +62,38 @@ describe('#550 — the notes carry both halves', () => {
   });
 });
 
+describe('#550 review — the generator is called safely', () => {
+  it('does not mask a generator failure with `|| true`', () => {
+    // Review finding on #580. `|| true` conflated the generator FAILING with
+    // there being nothing to report — and the generator already emits an
+    // explicit line for the second case, so an empty result can only mean the
+    // first. Printing a placeholder would ship notes that look complete.
+    expect(notesStep).toContain('refusing to publish notes that omit what changed');
+    expect(notesStep).not.toContain('changelog-section.sh "$VERSION" --no-heading || true');
+  });
+
+  it('quotes the revision range and closes it with --', () => {
+    // Not shell injection: an expanded variable is an ARGUMENT and bash does
+    // not re-parse it, so `HEAD; rm -rf /` reaches git as one bad ref. The real
+    // hazard is a `-`-prefixed value being read as an OPTION, plus word
+    // splitting on whitespace.
+    const gen = readFileSync(resolve(ROOT, 'scripts/changelog-section.sh'), 'utf8');
+    expect(gen).toContain('git log "$RANGE"');
+    expect(gen).not.toMatch(/git log \$RANGE/);
+  });
+
+  it('rejects a --since that is not a plain ref', () => {
+    for (const bad of ['--output=/tmp/pwn', 'a b', 'x;y']) {
+      expect(() => gen(['0.6.2', '--since', bad])).toThrow();
+    }
+  });
+
+  it('still accepts ordinary refs', () => {
+    expect(() => gen(['0.6.2', '--since', 'v0.6.1'])).not.toThrow();
+    expect(() => gen(['0.6.2', '--since', 'HEAD~1'])).not.toThrow();
+  });
+});
+
 describe('#550 — the generator itself', () => {
   it('groups commits by type with their short sha', () => {
     const out = gen(['0.6.2', '--since', 'v0.6.1', '--no-heading']);

--- a/packages/lambda/src/release-notes.test.ts
+++ b/packages/lambda/src/release-notes.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import yaml from 'js-yaml';
+
+/**
+ * #550 — release notes said how the release was TESTED, never what CHANGED.
+ *
+ * v0.6.1's notes omitted all eight of its fixes, two of which had made
+ * features silently non-functional (#526, #544). Someone deciding whether to
+ * upgrade learned only how thoroughly it had been graded.
+ *
+ * The provenance block is kept in full — it is the evidence this gate exists
+ * to produce, and it is the differentiator. What changed goes above it.
+ */
+const ROOT = resolve(__dirname, '../../..');
+const gate = yaml.load(readFileSync(resolve(ROOT, '.github/workflows/release-gate.yml'), 'utf8')) as any;
+const releaseSh = readFileSync(resolve(ROOT, 'scripts/release.sh'), 'utf8');
+const notesStep = JSON.stringify(
+  gate.jobs.release.steps.find((s: any) => s.name === 'Tag and release'),
+);
+
+const gen = (args: string[]) =>
+  execFileSync(resolve(ROOT, 'scripts/changelog-section.sh'), args, { cwd: ROOT, encoding: 'utf8' });
+
+describe('#550 — one generator feeds both', () => {
+  it('release.sh calls the shared script rather than inlining git log', () => {
+    // Two implementations of "what changed" would disagree the first time
+    // either was touched — and the notes are the copy a user reads.
+    expect(releaseSh).toContain('changelog-section.sh');
+    expect(releaseSh).not.toContain('--grep="^feat"');
+  });
+
+  it('the release notes call the same script', () => {
+    expect(notesStep).toContain('changelog-section.sh');
+  });
+
+  it('the notes omit the heading, because the release title is the version', () => {
+    expect(notesStep).toContain('--no-heading');
+  });
+});
+
+describe('#550 — the notes carry both halves', () => {
+  it('leads with what changed', () => {
+    expect(notesStep).toContain('What changed');
+  });
+
+  it('retains the provenance block in full', () => {
+    // The graded SHA, the suite grade, and the approver. This is the evidence
+    // the gate exists to produce; adding changes must not cost it.
+    expect(notesStep).toContain('via the release gate');
+    expect(notesStep).toContain('Graded fixture suite');
+    expect(notesStep).toContain('approved by @');
+  });
+
+  it('carries the NOT VERIFIED count, not just the pass line', () => {
+    // A green grade without the count of what was NOT run recreates the
+    // coverage illusion the gate was built to remove.
+    const grade = JSON.stringify(gate.jobs.suite.steps.find((s: any) => s.id === 'grade'));
+    expect(grade).toContain('NOT VERIFIED');
+  });
+});
+
+describe('#550 — the generator itself', () => {
+  it('groups commits by type with their short sha', () => {
+    const out = gen(['0.6.2', '--since', 'v0.6.1', '--no-heading']);
+    expect(out).toContain('### Features');
+    expect(out).toMatch(/- feat\(.+\) \([0-9a-f]{7}\)/);
+  });
+
+  it('carries the issue numbers the commit convention already includes', () => {
+    // `fix(core): … (#544) (#547)` — GitHub autolinks these, so nothing has to
+    // construct a URL.
+    expect(gen(['0.6.2', '--since', 'v0.6.1', '--no-heading'])).toMatch(/\(#\d+\)/);
+  });
+
+  it('says so plainly when nothing conventional is in range', () => {
+    // A docs-only or chore-only release is a real case. An empty section would
+    // read like the generator broke.
+    const out = gen(['9.9.9', '--since', 'HEAD', '--no-heading']);
+    expect(out).toContain('No feature or fix commits in this range');
+    expect(out.trim()).not.toBe('');
+  });
+
+  it('emits a version heading when not suppressed — for CHANGELOG.md', () => {
+    expect(gen(['0.6.2', '--since', 'v0.6.1'])).toMatch(/^## \[0\.6\.2\]/m);
+  });
+
+  it('strips a leading v so both call styles agree', () => {
+    expect(gen(['v0.6.2', '--since', 'v0.6.1'])).toMatch(/^## \[0\.6\.2\]/m);
+  });
+});

--- a/packages/lambda/src/release-notes.test.ts
+++ b/packages/lambda/src/release-notes.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
-import { resolve } from 'node:path';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve, join } from 'node:path';
 import yaml from 'js-yaml';
 
 /**
@@ -21,8 +23,39 @@ const notesStep = JSON.stringify(
   gate.jobs.release.steps.find((s: any) => s.name === 'Tag and release'),
 );
 
-const gen = (args: string[]) =>
-  execFileSync(resolve(ROOT, 'scripts/changelog-section.sh'), args, { cwd: ROOT, encoding: 'utf8' });
+/**
+ * A throwaway repo with known commits and a tag.
+ *
+ * These used to run against this repo's own history. That exercised real
+ * `git log` — which was the point — but made the tests environment-dependent:
+ * CI checks out shallow and WITHOUT tags, so `--since v0.6.1` failed there
+ * while passing locally. Building the history keeps the real-git property and
+ * removes the dependency on whatever the checkout happens to contain.
+ */
+function repoWithHistory(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'changelog-'));
+  const git = (...args: string[]) =>
+    execFileSync('git', args, { cwd: dir, encoding: 'utf8', stdio: 'pipe' });
+  git('init', '--quiet', '-b', 'main');
+  git('config', 'user.email', 'test@test');
+  git('config', 'user.name', 'test');
+  const commit = (msg: string) => {
+    writeFileSync(join(dir, 'f.txt'), msg);
+    git('add', '-A');
+    git('commit', '--quiet', '-m', msg);
+  };
+  commit('chore: before the tag');
+  git('tag', 'v0.6.1');
+  commit('feat(core): a new capability (#101) (#102)');
+  commit('fix(core): a real defect (#103)');
+  commit('chore: not user-facing');
+  return dir;
+}
+
+const REPO = repoWithHistory();
+
+const gen = (args: string[], cwd = REPO) =>
+  execFileSync(resolve(ROOT, 'scripts/changelog-section.sh'), args, { cwd, encoding: 'utf8' });
 
 describe('#550 — one generator feeds both', () => {
   it('release.sh calls the shared script rather than inlining git log', () => {

--- a/scripts/changelog-section.sh
+++ b/scripts/changelog-section.sh
@@ -41,6 +41,25 @@ if [ -z "$SINCE" ]; then
   SINCE=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
 fi
 
+# Validate the ref before it reaches git.
+#
+# Not shell injection — an expanded variable is an ARGUMENT, and bash does not
+# re-parse it for metacharacters, so `HEAD; rm -rf /` reaches git as a single
+# bad ref and is rejected. The real hazard is narrower: a value starting with
+# `-` would be read by git as an OPTION rather than a revision, which is
+# argument injection proper. Whitespace and globs would also split or expand
+# into a malformed invocation.
+#
+# No caller passes --since today, so this is defence for a flag that exists to
+# be used later rather than a fix for a live path.
+if [ -n "$SINCE" ] && ! printf '%s' "$SINCE" | grep -qE '^[A-Za-z0-9._/^~-]+$'; then
+  echo "Error: --since must be a plain git ref (got '$SINCE')" >&2
+  exit 1
+fi
+case "$SINCE" in
+  -*) echo "Error: --since must not start with '-' (got '$SINCE')" >&2; exit 1 ;;
+esac
+
 if [ -n "$SINCE" ]; then
   RANGE="${SINCE}..HEAD"
   COMPARE_URL="https://github.com/mergewatch/mergewatch.ai/compare/${SINCE}...${TAG}"
@@ -52,7 +71,9 @@ fi
 # `- <subject> (<short sha>)`. The repo's commit convention already carries the
 # issue numbers in the subject — `fix(core): … (#544) (#547)` — so linking is
 # GitHub's autolinking rather than anything this has to construct.
-collect() { git log $RANGE --no-merges --format="- %s (%h)" "$@" 2>/dev/null || true; }
+# `"$RANGE"` quoted, and `--` closes the revision list so nothing after it can
+# be read as a path or an option.
+collect() { git log "$RANGE" --no-merges --format="- %s (%h)" "$@" -- 2>/dev/null || true; }
 
 FEATURES=$(collect --grep="^feat")
 FIXES=$(collect --grep="^fix")
@@ -68,7 +89,7 @@ OUT=""
 # chore-only release. Say so rather than emitting an empty section that reads
 # like the generator broke.
 if [ -z "$FEATURES$FIXES$OTHERS" ]; then
-  COUNT=$(git log $RANGE --no-merges --oneline 2>/dev/null | wc -l | tr -d ' ')
+  COUNT=$(git log "$RANGE" --no-merges --oneline -- 2>/dev/null | wc -l | tr -d ' ')
   OUT+=$'\n'"_No feature or fix commits in this range (${COUNT} commit(s) since ${SINCE:-the start})._"$'\n'
 fi
 

--- a/scripts/changelog-section.sh
+++ b/scripts/changelog-section.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Render one changelog section for a version, from conventional commits.
+# =============================================================================
+# Usage: scripts/changelog-section.sh <version> [--since <ref>] [--no-heading]
+#
+#   <version>       e.g. 0.7.0 or v0.7.0
+#   --since <ref>   Start of the range. Defaults to the most recent tag.
+#   --no-heading    Emit only the grouped sections, without the `## [version]`
+#                   line — for a GitHub Release, whose title already IS the
+#                   version.
+#
+# #550 — extracted from release.sh so ONE generator feeds both CHANGELOG.md and
+# the release notes. Two implementations of "what changed in this release" would
+# disagree the first time either was touched, and the release notes are the copy
+# a user reads.
+set -euo pipefail
+
+VERSION=""
+SINCE=""
+HEADING=1
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --since) SINCE="${2:?--since needs a ref}"; shift 2 ;;
+    --no-heading) HEADING=0; shift ;;
+    *) VERSION="$1"; shift ;;
+  esac
+done
+
+if [ -z "$VERSION" ]; then
+  echo "Usage: scripts/changelog-section.sh <version> [--since <ref>] [--no-heading]" >&2
+  exit 1
+fi
+VERSION="${VERSION#v}"
+TAG="v${VERSION}"
+TODAY=$(date +%Y-%m-%d)
+
+# Default to the most recent tag. On a repo with no tags at all, fall back to
+# the whole history rather than failing — a first release is a real case.
+if [ -z "$SINCE" ]; then
+  SINCE=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+fi
+
+if [ -n "$SINCE" ]; then
+  RANGE="${SINCE}..HEAD"
+  COMPARE_URL="https://github.com/mergewatch/mergewatch.ai/compare/${SINCE}...${TAG}"
+else
+  RANGE="HEAD"
+  COMPARE_URL="https://github.com/mergewatch/mergewatch.ai/commits/${TAG}"
+fi
+
+# `- <subject> (<short sha>)`. The repo's commit convention already carries the
+# issue numbers in the subject — `fix(core): … (#544) (#547)` — so linking is
+# GitHub's autolinking rather than anything this has to construct.
+collect() { git log $RANGE --no-merges --format="- %s (%h)" "$@" 2>/dev/null || true; }
+
+FEATURES=$(collect --grep="^feat")
+FIXES=$(collect --grep="^fix")
+OTHERS=$(collect --invert-grep --grep="^feat" --grep="^fix" --grep="^chore" --grep="^docs" --grep="^ci" --grep="^test")
+
+OUT=""
+[ "$HEADING" -eq 1 ] && OUT="## [${VERSION}](${COMPARE_URL}) (${TODAY})"$'\n'
+[ -n "$FEATURES" ] && OUT+=$'\n'"### Features"$'\n'"${FEATURES}"$'\n'
+[ -n "$FIXES" ]    && OUT+=$'\n'"### Bug Fixes"$'\n'"${FIXES}"$'\n'
+[ -n "$OTHERS" ]   && OUT+=$'\n'"### Other Changes"$'\n'"${OTHERS}"$'\n'
+
+# A release with nothing conventional in range is a real case — a docs-only or
+# chore-only release. Say so rather than emitting an empty section that reads
+# like the generator broke.
+if [ -z "$FEATURES$FIXES$OTHERS" ]; then
+  COUNT=$(git log $RANGE --no-merges --oneline 2>/dev/null | wc -l | tr -d ' ')
+  OUT+=$'\n'"_No feature or fix commits in this range (${COUNT} commit(s) since ${SINCE:-the start})._"$'\n'
+fi
+
+printf '%s' "$OUT"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -128,33 +128,10 @@ fi
 CHANGELOG="$REPO_ROOT/CHANGELOG.md"
 TODAY=$(date +%Y-%m-%d)
 
-# Find previous tag (if any)
-PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-
-if [ -n "$PREV_TAG" ]; then
-  RANGE="${PREV_TAG}..HEAD"
-  COMPARE_URL="https://github.com/mergewatch/mergewatch.ai/compare/${PREV_TAG}...${TAG}"
-else
-  RANGE="HEAD"
-  COMPARE_URL="https://github.com/mergewatch/mergewatch.ai/commits/${TAG}"
-fi
-
-# Collect commits grouped by type
-FEATURES=$(git log $RANGE --oneline --no-merges --grep="^feat" --format="- %s (%h)" 2>/dev/null || true)
-FIXES=$(git log $RANGE --oneline --no-merges --grep="^fix" --format="- %s (%h)" 2>/dev/null || true)
-OTHERS=$(git log $RANGE --oneline --no-merges --invert-grep --grep="^feat" --grep="^fix" --grep="^chore" --grep="^docs" --grep="^ci" --grep="^test" --format="- %s (%h)" 2>/dev/null || true)
-
-# Build the new changelog section
-NEW_SECTION="## [${VERSION}](${COMPARE_URL}) (${TODAY})"$'\n'
-if [ -n "$FEATURES" ]; then
-  NEW_SECTION+=$'\n'"### Features"$'\n'"${FEATURES}"$'\n'
-fi
-if [ -n "$FIXES" ]; then
-  NEW_SECTION+=$'\n'"### Bug Fixes"$'\n'"${FIXES}"$'\n'
-fi
-if [ -n "$OTHERS" ]; then
-  NEW_SECTION+=$'\n'"### Other Changes"$'\n'"${OTHERS}"$'\n'
-fi
+# #550 — ONE generator, shared with the release notes. Two implementations of
+# "what changed in this release" would disagree the first time either was
+# touched, and the notes are the copy a user actually reads.
+NEW_SECTION=$("$REPO_ROOT/scripts/changelog-section.sh" "$VERSION")
 
 if [ -f "$CHANGELOG" ]; then
   # Prepend new section after the header line


### PR DESCRIPTION
Closes #550. Part of #575.

## What the notes said

```
Released from `main` (commit `d065b724`) via the release gate (#505).

Graded fixture suite:

47 passed · 0 failed · 0 ungraded · 1 skipped · 0 errored

Manual fixtures verified and approved by @santthosh.
```

That is a **provenance record**, and a good one — it is the evidence this gate exists to produce. But a reader deciding whether to upgrade learns how thoroughly it was graded and **nothing about what it contains**. v0.6.1's notes omitted all eight of its fixes, two of which had made features silently non-functional (#526, #544).

## One generator, two consumers

The changelog logic was inlined in `release.sh`. Extracted to `scripts/changelog-section.sh`, which both `release.sh` (for `CHANGELOG.md`) and the release job (for the notes) now call.

**Two implementations of "what changed in this release" would disagree the first time either was touched** — and the notes are the copy a user reads. There is a test asserting `release.sh` no longer inlines `git log --grep`.

`--no-heading` for the notes, because a GitHub Release's title already *is* the version.

## What changed leads; provenance is kept in full

```
## What changed

### Features
- feat(core): …  (#565) (8aaa02e)

### Bug Fixes
- fix(core): …  (#547) (d065b72)

---

Released from `main` (commit `…`) via the release gate (#505).
Graded fixture suite: …
Manual fixtures verified and approved by @…
```

**Issue links come free.** The repo's commit convention already carries them in the subject — `fix(core): … (#544) (#547)` — so GitHub autolinks them and nothing has to construct a URL.

## The "not verified" criterion was already met

`steps.grade.outputs.summary` greps `passed ·|NOT VERIFIED`, so the count of fixtures *not* run already reached the notes. I checked rather than assuming, and added a test pinning it — a green grade without that count would recreate the coverage illusion the gate exists to remove.

## Empty range

A release with no conventional commits says so plainly:

```
_No feature or fix commits in this range (3 commit(s) since v0.6.1)._
```

An empty section would read like the generator broke. A docs-only or chore-only release is a real case.

## Tests

11 added, including both generator behaviours exercised against the **real repo history** rather than fixtures: grouping with short SHAs, issue numbers present, the empty-range message, the heading emitted for CHANGELOG and suppressed for notes, and `v0.7.0` / `0.7.0` treated identically.

Full forced gate: build 12/12, typecheck 20/20, test 21/21, all `Cached: 0`.

## Limit

Like #549, the notes path only executes during an actual release cut. These tests assert the wiring and the generator's output; **the first real proof is cutting v0.7.0.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp