### PR TITLE
fix(release): fail on a range that does not resolve (#580 review follow-up)

### DIFF
--- a/packages/lambda/src/release-notes.test.ts
+++ b/packages/lambda/src/release-notes.test.ts
@@ -140,6 +140,17 @@ describe('#550 — the generator itself', () => {
     expect(gen(['0.6.2', '--since', 'v0.6.1', '--no-heading'])).toMatch(/\(#\d+\)/);
   });
 
+  it('fails on a range that does not resolve, rather than reporting "no changes"', () => {
+    // Review finding on #580. `collect()` ends in `|| true`, so a git failure
+    // returned empty and a WRONG RANGE rendered identically to an uneventful
+    // release — which in a release means notes claiming nothing changed.
+    //
+    // A bad ref did already fail, but only because the empty-range branch ran
+    // git again under pipefail: correct by accident, and one edit from silently
+    // losing it.
+    expect(() => gen(['0.7.0', '--since', 'v9.9.9'])).toThrow(/does not resolve/);
+  });
+
   it('says so plainly when nothing conventional is in range', () => {
     // A docs-only or chore-only release is a real case. An empty section would
     // read like the generator broke.

--- a/scripts/changelog-section.sh
+++ b/scripts/changelog-section.sh
@@ -68,6 +68,23 @@ else
   COMPARE_URL="https://github.com/mergewatch/mergewatch.ai/commits/${TAG}"
 fi
 
+# Confirm the range resolves BEFORE collecting.
+#
+# Review finding on #580 (clustered warning): `collect()` ends in
+# `2>/dev/null || true`, so a git failure there returns empty and the script
+# reports "no feature or fix commits in this range" — a wrong range and an
+# uneventful release rendering identically. In a release that means notes
+# claiming nothing changed.
+#
+# Today a bad ref does still fail, but only because the empty-range branch runs
+# `git log` again under pipefail. That is correct by ACCIDENT: one edit to that
+# line removes the protection with nothing to say so. Checking here makes it
+# intentional.
+if ! git rev-list --max-count=1 "$RANGE" >/dev/null 2>&1; then
+  echo "Error: range '$RANGE' does not resolve — refusing to report an empty changelog for it" >&2
+  exit 1
+fi
+
 # `- <subject> (<short sha>)`. The repo's commit convention already carries the
 # issue numbers in the subject — `fix(core): … (#544) (#547)` — so linking is
 # GitHub's autolinking rather than anything this has to construct.


### PR DESCRIPTION
Follow-up to the review on #580, which merged before I read its verdict. Both findings are addressed here — one fixed, one shown to be a false positive.

## Process error worth stating

**#580 merged at 3/5 without me reading the finding.** I printed the verdict and ran `gh pr merge --auto` in the same command block, so the merge did not depend on what the verdict said. The check was green — `MergeWatch Review` passes at 3/5 because unverified concerns are advisory — but "green check" and "clean review" are different signals, which is a distinction I have been making all session and then did not apply to my own work.

Nothing shipped that needed reverting; the fix is forward.

## The warning was real

`collect()` ends in `2>/dev/null || true`, so a git failure returns empty and the script reports:

```
_No feature or fix commits in this range (0 commit(s) since v9.9.9)._
```

**A wrong range and an uneventful release rendered identically** — and in a release that means notes claiming nothing changed.

A bad ref *did* already fail, but only because the empty-range branch runs `git log` again under `pipefail`. That is correct **by accident**: one edit to that line removes the protection with nothing to say so. The range is now checked explicitly, before collecting:

```
Error: range 'v9.9.9..HEAD' does not resolve — refusing to report an empty changelog for it
```

## The critical was a false positive

It claimed `$RANGE` is still unquoted and that this "remains unfixed in this diff". Both call sites are quoted on `main`:

```
76: collect() { git log "$RANGE" --no-merges --format="- %s (%h)" "$@" -- 2>/dev/null || true; }
92:   COUNT=$(git log "$RANGE" --no-merges --oneline -- 2>/dev/null | wc -l | tr -d ' ')
```

That is precisely why W2 could not confirm it and downgraded it to advisory rather than blocking. **The system did the right thing** — the finding was stale, the verifier caught that it did not match the source, and the clustered warning underneath it was the part worth acting on.

## Tests

16 (up from 15). One added, asserting a non-resolving range throws rather than reporting "no changes".

Forced gate green — build 12/12, typecheck 20/20, test 21/21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp