### PR TITLE
fix(trace): a cross-agent representative is surfaced, not merged into itself

### DIFF
--- a/packages/core/src/filter-trace.test.ts
+++ b/packages/core/src/filter-trace.test.ts
@@ -373,3 +373,77 @@ describe('isUsableOutcome / usableOutcomes (#482 review)', () => {
     expect(total).toBe(1);
   });
 });
+
+describe('#594 — a cross-agent representative is recorded as surfaced, not merged', () => {
+  const f = (title: string, over: Partial<TraceableFinding> = {}): TraceableFinding => ({
+    file: 'src/admin-endpoint.ts',
+    line: 4,
+    title,
+    severity: 'critical',
+    confidence: 95,
+    ...over,
+  }) as TraceableFinding;
+
+  it('does not spend a row\'s terminal verdict on a merge into itself', () => {
+    // The exact shape from mergewatch/fixtures#2550: three agents independently
+    // raise the SAME title, so enter() files them under one row. FP-C then
+    // merges them and hands back a renamed representative.
+    const t = new TraceRecorder();
+    const finding = f('Missing authorization check for admin endpoint');
+    for (const agent of ['security', 'bug', 'test-coverage']) t.enter(finding, agent);
+
+    const primaryAfter = f('Missing authorization check for admin endpoint — and 2 related cross-agent concerns');
+    const into = outcomeKey(primaryAfter);
+    t.alias(outcomeKey(finding), into);
+    // The absorbed sibling shares the representative's row by design.
+    t.record(finding, 'merged', 'fp-c-line-dedup', { mergedInto: into });
+
+    t.finalize([primaryAfter]);
+
+    const outs = t.outcomes();
+    expect(outs).toHaveLength(1);
+    // Before the fix this was 'merged': a finding the reader SAW, filed as
+    // merged away, with no way for a later stage to correct it.
+    expect(outs[0].outcome).toBe('surfaced');
+  });
+
+  it('still records a genuine absorption of a different finding', () => {
+    const t = new TraceRecorder();
+    const rep = f('Missing authorization check for admin endpoint');
+    const other = f('Admin endpoint lacks authorization check');
+    t.enter(rep, 'security');
+    t.enter(other, 'bug');
+
+    const primaryAfter = f('Missing authorization check for admin endpoint — and 1 related concern');
+    const into = outcomeKey(primaryAfter);
+    t.alias(outcomeKey(rep), into);
+    t.record(other, 'merged', 'fp-c-line-dedup', { mergedInto: into });
+    t.finalize([primaryAfter]);
+
+    const byTitle = Object.fromEntries(t.outcomes().map((o) => [o.title, o.outcome]));
+    expect(byTitle['Admin endpoint lacks authorization check']).toBe('merged');
+    expect(byTitle['Missing authorization check for admin endpoint']).toBe('surfaced');
+  });
+
+  it('lets a stage after the merge record that it dropped the representative', () => {
+    // The other half of the same defect: with the row's verdict spent on a
+    // self-merge, a later drop was unrecordable — so a critical could vanish
+    // between clustering and the comment with nothing in the ledger to explain it.
+    const t = new TraceRecorder();
+    const finding = f('Missing authorization check for admin endpoint');
+    t.enter(finding, 'security');
+    t.enter(finding, 'bug');
+
+    const primaryAfter = f('Missing authorization check for admin endpoint — and 1 related concern');
+    const into = outcomeKey(primaryAfter);
+    t.alias(outcomeKey(finding), into);
+    t.record(finding, 'merged', 'fp-c-line-dedup', { mergedInto: into });
+
+    t.record(primaryAfter, 'dropped', 'finding-verify', { reason: 'verifier refuted it' });
+
+    const outs = t.outcomes();
+    expect(outs).toHaveLength(1);
+    expect(outs[0].outcome).toBe('dropped');
+    expect(outs[0].stage).toBe('finding-verify');
+  });
+});

--- a/packages/core/src/filter-trace.ts
+++ b/packages/core/src/filter-trace.ts
@@ -189,6 +189,25 @@ export class TraceRecorder {
       // path this fallback exists to handle.
       e = this.entries.get(outcomeKey(f))!;
     }
+    // #594 — a "merge" whose target resolves to the finding's OWN row is a
+    // rename, not an absorption. `enter()` deliberately files identically
+    // titled findings from different agents under ONE row (the cross-agent
+    // convergence signal), and FP-C then merges exactly those findings — so an
+    // absorbed sibling can resolve to the very row its representative lives in.
+    //
+    // Writing 'merged' there spends the row's single terminal verdict on
+    // itself. `finalize()` later calls record(rep, 'surfaced'), which resolves
+    // to the same row, sees an outcome, and returns — so a finding the reader
+    // DID see is filed as merged-away, and any later stage that drops it
+    // cannot record that either.
+    //
+    // The failure is worst exactly where the ledger matters most: the more
+    // agents that independently converge on a finding, the more certain it is
+    // to be mis-recorded. On mergewatch/fixtures#2550 both the prod and dev
+    // reviews produced zero `surfaced` rows while prod rendered two criticals.
+    if (outcome === 'merged' && extra?.mergedInto && this.resolve(extra.mergedInto) === key) {
+      return;
+    }
     // First verdict wins: a later stage never rewrites an earlier one's record.
     if (e.outcome) return;
     e.outcome = outcome;


### PR DESCRIPTION
Part of #594.

## The bug

`enter()` deliberately files identically titled findings from different agents under **one row** — that is the cross-agent convergence signal, and the comment there says it must be captured because "the merge downstream is what destroys it."

FP-C then merges exactly those findings and hands back a renamed representative, aliased to that same row. So:

```
record(absorbed, 'merged', { mergedInto })   → writes a terminal verdict to the
                                               representative's OWN row
finalize([representative])
  → record(rep, 'surfaced')
  → resolve(renamed key) → same row
  → `if (e.outcome) return`  ← discarded
```

A finding the reader **did see** is filed as merged-away. Worse, the row's single verdict is now spent, so **any later stage that drops that finding cannot record it either.**

## Why it matters more than it looks

The failure scales with how trustworthy the finding is. **The more agents that independently converge on a finding, the more certain the ledger is to be wrong about it** — and convergence is exactly what makes a finding worth trusting.

Evidence from [mergewatch/fixtures#2550](https://github.com/mergewatch/fixtures/pull/2550): **both** the prod and dev traces contain **zero `surfaced` rows**, while prod rendered two criticals. The ledger was not describing the review.

That is also why #470 could not answer the question it exists for. A missing-authorization critical, raised at confidence 95 by `security`, `bug` and `test-coverage`, appears in the ledger only as `merged`.

## The fix

A merge whose target resolves to the finding's own row is a **rename**, not an absorption, so it no longer consumes the verdict.

Genuine absorptions of distinct findings are unchanged — there is a test for that which passes both before and after, specifically to catch over-correction.

## Tests

Three, and I verified the two that should fail actually **do** fail without the fix rather than trusting a green run:

- representative is recorded `surfaced`, not `merged` ← fails without the fix
- a later stage can record that it dropped the representative ← fails without the fix
- a genuine absorption of a *different* finding still records `merged` ← passes either way, by design

## Scope — what this does not do

**This repairs the instrument, not the open question behind it.** Why dev rendered nothing while prod rendered two criticals on the same commit, same `CodeSha256`, same model is still unexplained. The difference is now *recordable*, so the next occurrence can be read off the ledger instead of inferred from absence — which is what sent the first diagnosis of #594 in the wrong direction twice.

`build`, `typecheck`, and all 1,798 tests pass.