### PR TITLE
fix(trace): a survivor that reached a decided row via an alias gets its own row

### DIFF
--- a/packages/core/src/filter-trace.test.ts
+++ b/packages/core/src/filter-trace.test.ts
@@ -447,3 +447,64 @@ describe('#594 — a cross-agent representative is recorded as surfaced, not mer
     expect(outs[0].stage).toBe('finding-verify');
   });
 });
+
+describe('#594 second half — `surfaced` is authoritative for a row', () => {
+  const f = (title: string, over: Partial<TraceableFinding> = {}): TraceableFinding => ({
+    file: 'src/admin-endpoint.ts',
+    line: 4,
+    title,
+    severity: 'critical',
+    confidence: 95,
+    ...over,
+  }) as TraceableFinding;
+
+  it('reports a rendered finding as surfaced even when a same-keyed sibling was dropped', () => {
+    // mergewatch/fixtures#2597: the orchestrator dropped one instance as a
+    // duplicate; another survived, was renamed by FP-C, and aliased back to
+    // the same row. The row read `dropped` for a critical the reader SAW.
+    const t = new TraceRecorder();
+    const base = f('Missing authorization check for admin endpoint');
+    t.enter(base, 'security');
+    t.enter(base, 'bug');
+
+    t.record(base, 'dropped', 'orchestrator', { reason: 'duplicate of a stronger finding' });
+
+    const renamed = f('Missing authorization check for admin endpoint — and 6 related cross-agent concerns');
+    t.alias(outcomeKey(base), outcomeKey(renamed));
+    t.finalize([renamed]);
+
+    // Two instances, two fates, two rows — the drop keeps its reasoning and
+    // the rendered finding is recorded as what the reader saw.
+    const outs = t.outcomes();
+    expect(outs).toHaveLength(2);
+    const by = Object.fromEntries(outs.map((o) => [o.outcome, o]));
+    expect(by.surfaced).toBeTruthy();
+    expect(by.dropped.stage).toBe('orchestrator');
+    expect(by.dropped.reason).toBe('duplicate of a stronger finding');
+  });
+
+  it('still refuses to let one filter rewrite another filter\'s verdict', () => {
+    // Only `surfaced` is a fact about the published comment. Everything else
+    // is a stage's opinion and keeps first-verdict-wins.
+    const t = new TraceRecorder();
+    const finding = f('Missing authorization check for admin endpoint');
+    t.enter(finding, 'security');
+    t.record(finding, 'dropped', 'confidence-floor', { reason: 'below floor' });
+    t.record(finding, 'dropped', 'min-severity', { reason: 'under threshold' });
+
+    const outs = t.outcomes();
+    expect(outs[0].stage).toBe('confidence-floor');
+    expect(outs[0].reason).toBe('below floor');
+  });
+
+  it('does not let a later drop overwrite a surfaced row', () => {
+    const t = new TraceRecorder();
+    const finding = f('Missing authorization check for admin endpoint');
+    t.enter(finding, 'security');
+    t.record(finding, 'surfaced');
+    t.record(finding, 'dropped', 'min-severity', { reason: 'late' });
+
+    expect(t.outcomes()).toHaveLength(1);
+    expect(t.outcomes()[0].outcome).toBe('surfaced');
+  });
+});

--- a/packages/core/src/filter-trace.ts
+++ b/packages/core/src/filter-trace.ts
@@ -208,8 +208,26 @@ export class TraceRecorder {
     if (outcome === 'merged' && extra?.mergedInto && this.resolve(extra.mergedInto) === key) {
       return;
     }
-    // First verdict wins: a later stage never rewrites an earlier one's record.
-    if (e.outcome) return;
+    // #594, second half. `enter()` files same-(file,title) findings from
+    // different agents under ONE row, and those instances can have DIFFERENT
+    // fates: the orchestrator drops one as a duplicate while another survives,
+    // is renamed by a merge, and aliases back to that same row.
+    //
+    // First-verdict-wins then makes the row say `dropped` for a finding the
+    // reader actually SAW. Observed on mergewatch/fixtures#2597.
+    //
+    // Overwriting would fix the lie by telling a different one — it would erase
+    // the earlier stage's reasoning, which the one-terminal-outcome rule exists
+    // to protect. Two instances with two fates deserve two rows, so a survivor
+    // that only reached this row THROUGH AN ALIAS gets filed under its own key
+    // instead. A finding recorded directly against an already-decided row is
+    // unchanged: same key in, first verdict still wins.
+    if (e.outcome) {
+      const ownKey = outcomeKey(f);
+      if (outcome !== 'surfaced' || ownKey === key || this.entries.get(ownKey)?.outcome) return;
+      this.enter(f, 'orchestrator');
+      e = this.entries.get(ownKey)!;
+    }
     e.outcome = outcome;
     e.stage = stage;
     e.reason = extra?.reason;


### PR DESCRIPTION
#594, second half. Follows #595 — which was necessary and, as the very next gate run showed, insufficient.

## What #595 fixed, and what it did not

#595 stopped a merge-into-self from consuming a row's single terminal verdict. That worked: the self-merge record is gone from the ledger.

But on the next gate run ([fixtures#2597](https://github.com/mergewatch/fixtures/pull/2597)) the same lie arrived through a different door:

```
dropped  orchestrator  src/admin-endpoint.ts::T::Missing authorization check for admin endpoint
```

That critical **was rendered** — `28b` passed, meaning the check failed and changes were requested on it. The ledger said it was dropped.

## Root cause, generalised

`enter()` files same-`(file, title)` findings from different agents under **one row** — the cross-agent convergence signal. Those instances can have **different fates**: the orchestrator drops one as a duplicate while another survives, is renamed by FP-C, and aliases back to that same row. First-verdict-wins then reports the survivor as dropped.

#595 addressed one instance of this (a merge). This is the general form: any stage's terminal verdict on one instance can shadow the outcome of another that shares its row.

## Why not just let `surfaced` win

That was my first attempt, and it was wrong. It trades this lie for a different one — erasing the earlier stage's reasoning — and **two existing tests encode that rule deliberately**:

> `first verdict wins — a later stage cannot rewrite history`

Needing to edit those to land a fix was the signal that the fix was wrong. They pass unmodified here.

## The fix

Two instances with two fates deserve two rows. A survivor that reached a decided row **only through an alias** is filed under its own key. So the drop keeps its stage and reason, and the rendered finding is recorded as what the reader saw.

A finding recorded directly against an already-decided row is untouched — same key in, first verdict still wins. The discriminator is whether the finding arrived via an alias, which is exactly the case where two distinct instances got conflated.

## Tests

40 pass, including both pre-existing invariant tests, unmodified. The new test is confirmed to fail without the fix rather than assumed to.

## What this still does not answer

The original #594 symptom — prod rendering two criticals while dev rendered none on the same commit — remains unexplained. Both fixes so far repair the **instrument**. With the ledger now able to record a survivor and a post-merge drop distinctly, the next divergence should be readable off the trace instead of inferred from absence, which is what sent the first two diagnoses the wrong way.

`build`, `typecheck`, full suite green.