### PR TITLE
fix(release): validate the version before prepare mutates main

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -117,10 +117,14 @@ jobs:
           # `release.sh` strips a leading `v`, so this job accepted an input
           # `suite` would refuse. Validate first, and accept both spellings so
           # the two jobs cannot disagree again.
-          case "$VERSION" in
-            v[0-9]*.[0-9]*.[0-9]*|[0-9]*.[0-9]*.[0-9]*) ;;
-            *) echo "::error::version must look like v1.2.3 or 1.2.3 (got '$VERSION')"; exit 1 ;;
-          esac
+          # A `case` glob is too loose to gate a mutation: `*` spans anything,
+          # so v1.2.3.4 and v1.2.3junk both matched and would have produced a
+          # bad tag. Anchored regex — optional `v`, exactly three numeric
+          # components, nothing else.
+          if [[ ! "$VERSION" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::version must look like v1.2.3 or 1.2.3 (got '$VERSION')"
+            exit 1
+          fi
 
           # Only `main` can be prepared: the bump commit is pushed there, and
           # pushing it while grading a different ref would tag a tree that was
@@ -203,10 +207,14 @@ jobs:
           # Same two spellings `prepare` accepts. If these ever diverge again,
           # a run can mutate main and then be rejected here for the input that
           # mutation was based on.
-          case "$VERSION" in
-            v[0-9]*.[0-9]*.[0-9]*|[0-9]*.[0-9]*.[0-9]*) ;;
-            *) echo "::error::version must look like v1.2.3 or 1.2.3 (got '$VERSION')"; exit 1 ;;
-          esac
+          # A `case` glob is too loose to gate a mutation: `*` spans anything,
+          # so v1.2.3.4 and v1.2.3junk both matched and would have produced a
+          # bad tag. Anchored regex — optional `v`, exactly three numeric
+          # components, nothing else.
+          if [[ ! "$VERSION" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::version must look like v1.2.3 or 1.2.3 (got '$VERSION')"
+            exit 1
+          fi
           echo "candidate: $REF"
           echo "version:   $VERSION"
 

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -108,6 +108,20 @@ jobs:
           # succeeded. The job would go GREEN having pushed nothing, and `suite`
           # would then try to grade a commit that exists on no remote.
           set -euo pipefail
+          # The version format is validated HERE, before anything is written.
+          # It used to be checked only in `suite`, which runs AFTER this job has
+          # already committed and pushed the bump — so `-f version=0.6.2`
+          # (no `v`) left main carrying a "chore: release 0.6.2" commit for a
+          # release that was then rejected on format and never tagged.
+          #
+          # `release.sh` strips a leading `v`, so this job accepted an input
+          # `suite` would refuse. Validate first, and accept both spellings so
+          # the two jobs cannot disagree again.
+          case "$VERSION" in
+            v[0-9]*.[0-9]*.[0-9]*|[0-9]*.[0-9]*.[0-9]*) ;;
+            *) echo "::error::version must look like v1.2.3 or 1.2.3 (got '$VERSION')"; exit 1 ;;
+          esac
+
           # Only `main` can be prepared: the bump commit is pushed there, and
           # pushing it while grading a different ref would tag a tree that was
           # never prepared.
@@ -186,9 +200,12 @@ jobs:
           REF: ${{ inputs.candidate_ref }}
         run: |
           set -uo pipefail
+          # Same two spellings `prepare` accepts. If these ever diverge again,
+          # a run can mutate main and then be rejected here for the input that
+          # mutation was based on.
           case "$VERSION" in
-            v[0-9]*.[0-9]*.[0-9]*) ;;
-            *) echo "::error::version must look like v1.2.3 (got '$VERSION')"; exit 1 ;;
+            v[0-9]*.[0-9]*.[0-9]*|[0-9]*.[0-9]*.[0-9]*) ;;
+            *) echo "::error::version must look like v1.2.3 or 1.2.3 (got '$VERSION')"; exit 1 ;;
           esac
           echo "candidate: $REF"
           echo "version:   $VERSION"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,5 @@
 # Changelog
 
-## [0.6.2](https://github.com/mergewatch/mergewatch.ai/compare/v0.6.1...v0.6.2) (2026-09-09)
-
-### Features
-- feat(docs): pre-release factual audit of every doc page against the codebase (#588) (aaa94f6)
-- feat(release): release notes say what changed, not just how it was tested (#550) (#580) (d639337)
-- feat(release): the gate bumps versions and the changelog (#549) (#578) (cb6204c)
-- feat(core): emit a machine-readable cost payload (#561, phase 2) (#574) (ba41837)
-- feat(core): cache_control breakpoints and verifier reorder (#490, phase B) (#568) (d9626a6)
-- feat(core): cache-aware token accounting and pricing (#490, phase A) (#567) (a9a6c11)
-- feat(core): reorder prompt segments so six agents share a cacheable prefix (#564) (#566) (98958e4)
-- feat(core): prompts become ordered segments with stability labels (#489) (#565) (8aaa02e)
-
-### Bug Fixes
-- fix(trace): a survivor that reached a decided row via an alias gets its own row (#598) (3aaf228)
-- fix(trace): a cross-agent representative is surfaced, not merged into itself (#595) (f2d65f4)
-- fix(deps): patch Next.js to 15.5.24 for two RCE advisories (#589) (93a7e0a)
-- fix(release): fail on a range that does not resolve (#580 review follow-up) (#581) (118e221)
-- docs: document the release process outside the workflow file (#552) (#579) (9327622)
-- feat(core): emit a machine-readable cost payload (#561, phase 2) (#574) (ba41837)
-- fix(billing): bill a re-review of the same commit (#563) (#573) (88c0b6a)
-- fix(bedrock): send cache breakpoints on the structured path too (#490) (#572) (ea4c4df)
-- fix(core): enforce maxFindings in code, not just in the prompt (#569) (#571) (b3a52da)
-- fix(core): handle check_suite.rerequested so the Re-run button works (#558) (#562) (6ce1f5a)
-- fix(release): grant actions:write so the gate can dispatch docker-publish (#559) (79016fa)
 ## [v0.6.1](https://github.com/mergewatch/mergewatch.ai/commits/v0.6.1) (2026-09-04)
 
 Backfilled — the release gate did not update the changelog at the time (#549). 12 commits.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   mergewatch:
-    image: ghcr.io/mergewatch/mergewatch:0.6.2
+    image: ghcr.io/mergewatch/mergewatch:0.5.0
     build: .
     restart: unless-stopped
     environment:
@@ -35,7 +35,7 @@ services:
       start_period: 30s
 
   dashboard:
-    image: ghcr.io/mergewatch/mergewatch-dashboard:0.6.2
+    image: ghcr.io/mergewatch/mergewatch-dashboard:0.5.0
     build:
       context: .
       dockerfile: Dockerfile.dashboard

--- a/docs-site/reference/troubleshooting.mdx
+++ b/docs-site/reference/troubleshooting.mdx
@@ -41,7 +41,7 @@ description: "Fixes for reviews not posting, webhooks not arriving, Docker conta
   **Fix:**
   1. Confirm the Postgres container is running: `docker compose ps`
   2. Check that `DATABASE_URL` matches your Postgres container's hostname, port, user, and password
-  3. If using the default `docker-compose.yml`, the Postgres service is named `db` — the connection string should use `postgres` as the hostname (e.g. `postgresql://mergewatch:password@postgres:5432/mergewatch`)
+  3. If using the default `docker-compose.yml`, the Postgres service is named `db` — the connection string should use `db` as the hostname (e.g. `postgresql://mergewatch:password@db:5432/mergewatch`)
   4. Restart the stack: `docker compose down && docker compose up -d`
 </Accordion>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mergewatch",
-  "version": "0.6.2",
+  "version": "0.5.0",
   "private": true,
   "description": "AI-powered GitHub PR review tool — runs in your AWS account via Amazon Bedrock",
   "license": "AGPL-3.0",

--- a/packages/billing/package.json
+++ b/packages/billing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergewatch/billing",
-  "version": "0.6.2",
+  "version": "0.5.0",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergewatch/core",
-  "version": "0.6.2",
+  "version": "0.5.0",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergewatch/dashboard",
-  "version": "0.6.2",
+  "version": "0.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergewatch/lambda",
-  "version": "0.6.2",
+  "version": "0.5.0",
   "private": true,
   "scripts": {
     "build": "tsc -p tsconfig.build.json",

--- a/packages/lambda/src/release-gate.test.ts
+++ b/packages/lambda/src/release-gate.test.ts
@@ -241,3 +241,45 @@ describe('release gate — the release step cannot strand a tag', () => {
     }
   });
 });
+
+describe('release gate — the version is validated before anything is written', () => {
+  const prep = JSON.stringify(wf.jobs.prepare);
+  const suite = JSON.stringify(wf.jobs.suite);
+
+  /**
+   * Comments in this run block mention both `release.sh` and `git push` while
+   * EXPLAINING the ordering, so a naive indexOf matches prose and asserts the
+   * opposite of what it means. Compare executable lines only.
+   */
+  const code = (jobStepId: string) =>
+    (wf.jobs.prepare.steps.find((s: any) => s.id === jobStepId).run as string)
+      .split('\n')
+      .filter((l: string) => !/^\s*#/.test(l))
+      .join('\n');
+
+  it('prepare rejects a malformed version before it commits or pushes', () => {
+    // The v0.6.2 cut was dispatched as `0.6.2` (no `v`). `prepare` accepted it
+    // — release.sh strips a leading `v` — bumped every package.json, wrote a
+    // CHANGELOG section, committed and PUSHED to main. `suite` then rejected
+    // the same input on format. main was left carrying "chore: release 0.6.2"
+    // for a release that was never tagged.
+    const run = code('commit');
+    const validateAt = run.indexOf('version must look like');
+    const mutateAt = run.indexOf('scripts/release.sh');
+    expect(validateAt).toBeGreaterThan(-1);
+    expect(validateAt).toBeLessThan(mutateAt);
+  });
+
+  it('nothing is pushed before the version has been checked', () => {
+    const run = code('commit');
+    expect(run.indexOf('version must look like')).toBeLessThan(run.indexOf('git push'));
+  });
+
+  it('prepare and suite accept exactly the same spellings', () => {
+    // If they diverge, a run can mutate main and then be rejected downstream
+    // for the very input that mutation was based on.
+    const pattern = 'v[0-9]*.[0-9]*.[0-9]*|[0-9]*.[0-9]*.[0-9]*';
+    expect(prep).toContain(pattern);
+    expect(suite).toContain(pattern);
+  });
+});

--- a/packages/lambda/src/release-gate.test.ts
+++ b/packages/lambda/src/release-gate.test.ts
@@ -251,11 +251,18 @@ describe('release gate — the version is validated before anything is written',
    * EXPLAINING the ordering, so a naive indexOf matches prose and asserts the
    * opposite of what it means. Compare executable lines only.
    */
-  const code = (jobStepId: string) =>
-    (wf.jobs.prepare.steps.find((s: any) => s.id === jobStepId).run as string)
+  const code = (jobStepId: string) => {
+    const step = wf.jobs.prepare.steps.find((s: any) => s.id === jobStepId);
+    // Assert the step exists before reading it. Renaming or removing the id
+    // would otherwise throw a TypeError that reads as a broken test rather
+    // than as "the step this guards is gone" — and these assertions are the
+    // only thing standing between a typo'd version and a push to main.
+    expect(step, `no step with id '${jobStepId}' in the prepare job`).toBeTruthy();
+    return (step.run as string)
       .split('\n')
       .filter((l: string) => !/^\s*#/.test(l))
       .join('\n');
+  };
 
   it('prepare rejects a malformed version before it commits or pushes', () => {
     // The v0.6.2 cut was dispatched as `0.6.2` (no `v`). `prepare` accepted it

--- a/packages/lambda/src/release-gate.test.ts
+++ b/packages/lambda/src/release-gate.test.ts
@@ -278,8 +278,30 @@ describe('release gate — the version is validated before anything is written',
   it('prepare and suite accept exactly the same spellings', () => {
     // If they diverge, a run can mutate main and then be rejected downstream
     // for the very input that mutation was based on.
-    const pattern = 'v[0-9]*.[0-9]*.[0-9]*|[0-9]*.[0-9]*.[0-9]*';
-    expect(prep).toContain(pattern);
-    expect(suite).toContain(pattern);
+    // Compare the actual validation lines rather than a hand-escaped literal:
+    // the point is that the two are IDENTICAL, whatever they say.
+    const check = (job: any) =>
+      JSON.stringify(job).match(/=~ \^v\?[^"]*?\$/)?.[0];
+    expect(check(wf.jobs.prepare)).toBeTruthy();
+    expect(check(wf.jobs.prepare)).toBe(check(wf.jobs.suite));
+  });
+
+  it('rejects versions a `case` glob would have let through', () => {
+    // A glob is too loose to gate a mutation of main: `*` spans anything, so
+    // v1.2.3.4 and v1.2.3junk matched and would have produced a bad tag.
+    const re = /^v?[0-9]+\.[0-9]+\.[0-9]+$/;
+    for (const ok of ['v1.2.3', '0.6.2', 'v0.6.2', '10.20.30']) {
+      expect(re.test(ok), `${ok} should be accepted`).toBe(true);
+    }
+    for (const bad of ['v1.2.3.4', 'v1.2.3junk', 'v1..2', '1.2', 'vX.Y.Z', '', 'v1.2.3-rc1']) {
+      expect(re.test(bad), `${bad} should be rejected`).toBe(false);
+    }
+  });
+
+  it('uses an anchored regex, not a case glob, at both sites', () => {
+    for (const job of [prep, suite]) {
+      expect(job).toContain('=~ ^v?[0-9]+');
+      expect(job).not.toContain('v[0-9]*.[0-9]*.[0-9]*');
+    }
   });
 });

--- a/packages/llm-anthropic/package.json
+++ b/packages/llm-anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergewatch/llm-anthropic",
-  "version": "0.6.2",
+  "version": "0.5.0",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/llm-bedrock/package.json
+++ b/packages/llm-bedrock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergewatch/llm-bedrock",
-  "version": "0.6.2",
+  "version": "0.5.0",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/llm-litellm/package.json
+++ b/packages/llm-litellm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergewatch/llm-litellm",
-  "version": "0.6.2",
+  "version": "0.5.0",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/llm-ollama/package.json
+++ b/packages/llm-ollama/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergewatch/llm-ollama",
-  "version": "0.6.2",
+  "version": "0.5.0",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergewatch/mcp",
-  "version": "0.6.2",
+  "version": "0.1.0",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergewatch/server",
-  "version": "0.6.2",
+  "version": "0.5.0",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -113,7 +113,7 @@ async function main() {
 
     res.status(statusCode).json({
       status,
-      version: '0.6.2',
+      version: '0.5.0',
       db: dbStatus,
       llmProvider: process.env.LLM_PROVIDER || 'anthropic',
     });

--- a/packages/storage-dynamo/package.json
+++ b/packages/storage-dynamo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergewatch/storage-dynamo",
-  "version": "0.6.2",
+  "version": "0.5.0",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/storage-postgres/package.json
+++ b/packages/storage-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergewatch/storage-postgres",
-  "version": "0.6.2",
+  "version": "0.5.0",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Unblocks the v0.6.2 cut, and fixes the defect that broke it.

## What happened

The cut was dispatched as `-f version=0.6.2`. `prepare` **accepted** it — `scripts/release.sh` strips a leading `v` — bumped root and all 12 `package.json` files, wrote a CHANGELOG section, committed, and **pushed to main**. `suite` then rejected the *same input* for not matching `v1.2.3`:

```
##[error]version must look like v1.2.3 (got '0.6.2')
```

`main` was left carrying `chore: release 0.6.2` for a release that was never tagged — the inverse of the v0.6.0 defect #549 fixed, reached from the other direction, and triggerable by a typo in a dispatch.

## Two faults

**1. Ordering.** The only version validation lived in `suite`, which runs *after* `prepare` has written and pushed. Validation is now the first thing `prepare` does — before `release.sh`, long before `git push`.

**2. Disagreement.** `prepare` accepted an input `suite` refused. Both now accept the same two spellings (`v0.6.2` and `0.6.2`), with a test asserting the patterns stay identical so they cannot drift apart again.

## Also in here

- **Reverts the orphaned bump** — main is back to `0.5.0` / `mcp 0.1.0` with no `0.6.2` changelog section, so `prepare` has a clean tree to work from. Without this the re-cut fails on `release.sh changed nothing — is 0.6.2 already the current version?`
- **One finding from the docs audit's first CI run.** I changed *"the Postgres service is named `postgres`"* to `db` earlier today and left the rest of the same sentence telling readers to use `postgres` as the hostname. The audit caught the half-fix — the sentence contradicted itself mid-line.

## On the tests

The first version passed for the wrong reason. The run block's comments mention both `release.sh` and `git push` **while explaining the ordering**, so `indexOf` matched prose and the assertion compared comment positions. They strip comment lines and compare executable order now. Confirmed to fail without the fix.

## What the failed run did prove

Worth recording, because two things ran for the first time and both worked:

- **`prepare` (#549) is correct.** It bumped root + all 12 manifests to `0.6.2`, including `packages/mcp` (`0.1.0` → `0.6.2`, the drift #549's derived list was meant to catch), and wrote a proper CHANGELOG section. Its output was right; only its input validation was missing.
- **The docs audit (#576) works in CI.** 64/64 pages, OIDC → Bedrock succeeded in the gate's context, 22 findings refuted and 4 upheld, **$1.78**. Its `status=findings` path is the one that reached the approval checklist, exactly as designed.

`build`, `typecheck`, full suite, and docs structure all pass.