### PR TITLE
feat(core): let a repo declare which of its files are not worth reviewing

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,9 +164,17 @@ rules:
   reviewOnMention: true
   skipDrafts: true
 
+# Files whose contents are dropped from the diff sent to the agents.
 excludePatterns:
   - "**/*.lock"
   - "**/dist/**"
+
+# Files that count as trivial, so a PR touching only these is skipped without
+# a review at all. Adds to the built-in list; `includePatterns` overrides both.
+# Use it for the non-code files only your repo knows about.
+skipPatterns:
+  - ".mergewatch.yml"
+  - "skills/**"
 
 # Review tone: collaborative | direct | advisory
 tone: collaborative

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -175,6 +175,12 @@ export interface MergeWatchConfig {
    * PR gets reviewed at all when every file is otherwise trivial.
    */
   includePatterns: string[];
+  /**
+   * Patterns that ADD to the built-in trivial list. Decides whether a PR is
+   * reviewed at all; `excludePatterns` decides what reaches the agents once it
+   * is. `includePatterns` overrides both.
+   */
+  skipPatterns: string[];
   /** Minimum severity to report: 'info' | 'warning' | 'critical' */
   minSeverity: 'info' | 'warning' | 'critical';
   /**
@@ -259,6 +265,7 @@ export const DEFAULT_CONFIG: MergeWatchConfig = {
     '**/*.wasm',
   ],
   includePatterns: [],
+  skipPatterns: [],
   minSeverity: 'info',
   minConfidence: 75,
   maxFindings: 25,

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -1411,6 +1411,9 @@ export function parseRepoConfigYaml(content: string): Partial<MergeWatchConfig> 
     if (Array.isArray(parsed.includePatterns)) {
       config.includePatterns = parsed.includePatterns.filter((p: unknown) => typeof p === 'string');
     }
+    if (Array.isArray(parsed.skipPatterns)) {
+      config.skipPatterns = parsed.skipPatterns.filter((p: unknown) => typeof p === 'string');
+    }
     if (parsed.agents && typeof parsed.agents === 'object') {
       const a = parsed.agents as Record<string, unknown>;
       config.agents = {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -254,7 +254,7 @@ export { invokeWithFileFetching, FILE_REQUEST_INSTRUCTION } from './context/agen
 export type { FileFetchOptions, AgenticInvokeResult } from './context/agentic-fetcher.js';
 
 // ─── Skip logic ─────────────────────────────────────────────────────────────
-export { shouldSkipPR, shouldSkipByRules, isAutoReviewOff, extractIncludePatterns, SKIP_PATTERNS } from './skip-logic.js';
+export { shouldSkipPR, shouldSkipByRules, isAutoReviewOff, extractIncludePatterns, extractSkipPatterns, SKIP_PATTERNS } from './skip-logic.js';
 export type { RulesSkipKind, RulesSkipResult } from './skip-logic.js';
 
 // ─── Agent-authored PR detection ────────────────────────────────────────────

--- a/packages/core/src/skip-logic.test.ts
+++ b/packages/core/src/skip-logic.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { shouldSkipPR, shouldSkipByRules, isAutoReviewOff, extractIncludePatterns, SKIP_PATTERNS } from './skip-logic.js';
+import { shouldSkipPR, shouldSkipByRules, isAutoReviewOff, extractIncludePatterns, extractSkipPatterns, SKIP_PATTERNS } from './skip-logic.js';
 import { DEFAULT_RULES_CONFIG } from './config/defaults.js';
 import type { RulesConfig } from './config/defaults.js';
 
@@ -173,6 +173,52 @@ describe('shouldSkipPR', () => {
   it('omitted includePatterns argument falls back to default skip behaviour', () => {
     const result = shouldSkipPR(['README.md']);
     expect(result).not.toBeNull();
+  });
+
+  // ─── skipPatterns (user-configured trivial files) ───────────────────
+  it('skips a PR whose only file matches a configured skipPattern', () => {
+    const result = shouldSkipPR(['.mergewatch.yml'], [], ['.mergewatch.yml']);
+    expect(result).not.toBeNull();
+  });
+
+  it('reviews the same PR when skipPatterns is not configured', () => {
+    expect(shouldSkipPR(['.mergewatch.yml'])).toBeNull();
+  });
+
+  it('matches inside a dot-directory, which a bare glob would not', () => {
+    const result = shouldSkipPR(['.compound-engineering/config.json'], [], ['**/*.json']);
+    expect(result).not.toBeNull();
+  });
+
+  it('reviews a PR mixing a skipPattern file with real code', () => {
+    const result = shouldSkipPR(['skills/run.py', 'src/app.ts'], [], ['skills/**']);
+    expect(result).toBeNull();
+  });
+
+  it('includePatterns wins over skipPatterns for the same file', () => {
+    const result = shouldSkipPR(['skills/run.py'], ['skills/**'], ['skills/**']);
+    expect(result).toBeNull();
+  });
+
+  it('treats a lowercase pull_request_template as trivial', () => {
+    const result = shouldSkipPR(['.github/pull_request_template.md']);
+    expect(result).not.toBeNull();
+  });
+});
+
+describe('extractSkipPatterns', () => {
+  it('returns [] when yamlConfig is null or undefined', () => {
+    expect(extractSkipPatterns(null)).toEqual([]);
+    expect(extractSkipPatterns(undefined)).toEqual([]);
+  });
+
+  it('returns [] when skipPatterns is missing or not an array', () => {
+    expect(extractSkipPatterns({})).toEqual([]);
+    expect(extractSkipPatterns({ skipPatterns: 'skills/**' } as never)).toEqual([]);
+  });
+
+  it('drops non-string entries', () => {
+    expect(extractSkipPatterns({ skipPatterns: ['skills/**', 42, null] } as never)).toEqual(['skills/**']);
   });
 });
 

--- a/packages/core/src/skip-logic.ts
+++ b/packages/core/src/skip-logic.ts
@@ -67,6 +67,8 @@ export const SKIP_PATTERNS = [
   // repositories to review. See #455.
   '**/.github/ISSUE_TEMPLATE/**',
   '**/.github/PULL_REQUEST_TEMPLATE*',
+  // minimatch is case-sensitive; lowercase is the form `gh` scaffolds.
+  '**/.github/pull_request_template*',
   '**/.github/FUNDING.yml',
 ];
 
@@ -95,20 +97,32 @@ export function extractIncludePatterns(
   return raw.filter((p): p is string => typeof p === 'string');
 }
 
+/** Sanitized `skipPatterns` from a parsed YAML config. Mirrors {@link extractIncludePatterns}. */
+export function extractSkipPatterns(
+  yamlConfig: Partial<MergeWatchConfig> | null | undefined,
+): string[] {
+  const raw = (yamlConfig as { skipPatterns?: unknown } | null | undefined)?.skipPatterns;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((p): p is string => typeof p === 'string');
+}
+
 export function shouldSkipPR(
   files: string[],
   includePatterns: string[] = [],
+  skipPatterns: string[] = [],
 ): string | null {
   if (files.length === 0) return 'No changed files';
 
   const isForceIncluded = (file: string) =>
     includePatterns.some((pattern) => minimatch(file, pattern));
 
-  const nonTrivialFiles = files.filter(
-    (file) =>
-      isForceIncluded(file) ||
-      !SKIP_PATTERNS.some((pattern) => minimatch(file, pattern)),
-  );
+  // `dot: true` on the user list only: without it a configured `**/*.yml`
+  // cannot match `.github/workflows/ci.yml`.
+  const isTrivial = (file: string) =>
+    SKIP_PATTERNS.some((pattern) => minimatch(file, pattern)) ||
+    skipPatterns.some((pattern) => minimatch(file, pattern, { dot: true }));
+
+  const nonTrivialFiles = files.filter((file) => isForceIncluded(file) || !isTrivial(file));
 
   if (nonTrivialFiles.length === 0) {
     // Categorize what the PR contains for the skip reason

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -35,6 +35,7 @@ import {
   mergeConfig,
   shouldSkipPR,
   extractIncludePatterns,
+  extractSkipPatterns,
   shouldSkipByRules,
   isAutoReviewOff,
   filterDiff,
@@ -452,9 +453,10 @@ export async function handler(
   const prNumberCommitSha = `${prNumber}#${shortSha}`;
 
   const includePatterns = extractIncludePatterns(yamlConfig);
+  const skipPatterns = extractSkipPatterns(yamlConfig);
 
   // ── Smart skip — bypass when user explicitly requested a review via @mergewatch ────
-  const skipReason = event.mentionTriggered ? null : shouldSkipPR(prContext.files, includePatterns);
+  const skipReason = event.mentionTriggered ? null : shouldSkipPR(prContext.files, includePatterns, skipPatterns);
   if (skipReason) {
     console.log(`Skipping ${repoFullName}#${prNumber}: ${skipReason}`);
 

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -3,7 +3,7 @@ import {
   getPRDiff, getPRContext, addPRReaction, removePRReaction, postReviewComment, updateReviewComment,
   findExistingBotComment, getCommentReactions, createCheckRun,
   resolveWithdrawnFindingThreads, withdrawnThreadKey, isStillPRHead,
-  formatReviewComment, countBlockingCriticals, buildCheckTitle, isThrottleError, computeDiffStats, runReviewPipeline, shouldSkipPR, shouldSkipByRules, isAutoReviewOff, extractIncludePatterns,
+  formatReviewComment, countBlockingCriticals, buildCheckTitle, isThrottleError, computeDiffStats, runReviewPipeline, shouldSkipPR, shouldSkipByRules, isAutoReviewOff, extractIncludePatterns, extractSkipPatterns,
   loadCategoryDisputeRates,
   filterDiff,
   DEFAULT_CONFIG, mergeConfig,
@@ -392,11 +392,12 @@ export async function processReviewJob(
   // yamlConfig was fetched earlier for the autoReview silent-skip gate and
   // is reused below for includePatterns + runtimeConfig — no second round-trip.
   const includePatterns = extractIncludePatterns(yamlConfig);
+  const skipPatterns = extractSkipPatterns(yamlConfig);
 
   // Smart skip check — bypass when user explicitly requested a review via @mergewatch
   const skipReason = job.mentionTriggered
     ? null
-    : shouldSkipPR(prContext.files || [], includePatterns);
+    : shouldSkipPR(prContext.files || [], includePatterns, skipPatterns);
   if (skipReason) {
     await deps.reviewStore.updateStatus(repoFullName, prNumberCommitSha, 'skipped', { completedAt: now, skipReason });
     await deps.prLifecycleStore?.markSkipped(instId, repoFullName, prNumber, now);


### PR DESCRIPTION
> **As a maintainer of a repository with non-code files MergeWatch can't know about,**
> **I want** to declare which paths are trivial,
> **so that** editing tooling config or agent skills doesn't cost a full review.

Opening upstream at Santthosh's suggestion — this has been running through review on a downstream fork.

## The gap

Every CI system lets a repository say which paths don't warrant a given job — don't run the unit suite for a README edit, don't build an image for a docs change. That judgement is always repository-specific, because only the repository knows which of its files can affect the thing being built.

MergeWatch already accepts that reviews shouldn't run on everything — that is what `SKIP_PATTERNS` is for. But the list is hardcoded, so it can only encode a global guess: lock files, docs, editor config. It cannot know that in a given repository the review tooling's own config file, an agent-skills directory, or a generated inventory are equally not code. PRs touching only those get a full review and a bill for it.

## What already exists, and why none of it covers this

| Existing lever | What it does | Why it doesn't fit |
|---|---|---|
| `SKIP_PATTERNS` | The built-in trivial list | Hardcoded — a repo can't add to it |
| `includePatterns` | Overrides `SKIP_PATTERNS` | Opts files back **in**; the opposite direction |
| `excludePatterns` | Drops files from the diff sent to agents | The PR is still reviewed, and still billed |
| `rules.ignorePatterns` | Deprecated; folds into `excludePatterns` | Same layer, not a skip |
| `maxFileDiffKB` (#423) | Drops one oversized file's diff section | Diff-filter, and size-based rather than path-based |
| `rules.ignoreLabels` (`skip-review`) | Skips a labelled PR | Manual and per-PR — you must remember, every time |
| `rules.maxFiles` | Skips very large PRs | Size, not path |
| `rules.skipDrafts` | Skips drafts | Unrelated axis |

So the skip decision is reachable by size, by label, by draft status, and by a hardcoded pattern list — but not by a path list the repository controls. #423's reasoning is the closest neighbour and points the same way: *"a pattern list only catches artifacts we have already met."* That argument applies to the skip layer too, and this is the other half of it.

I also confirmed `shouldSkipPR` receives the raw PR file list — `excludePatterns` is not applied beforehand — so there is no indirect route where excluding every file in a PR causes it to be skipped.

## 1. `skipPatterns`

A user list that adds to the built-in one, mirroring `includePatterns` in shape, parsing and precedence:

```yaml
skipPatterns:
  - ".mergewatch.yml"
  - "skills/**"
```

- Adds to `SKIP_PATTERNS` rather than replacing it.
- `includePatterns` still wins, so a file can be forced back into review after being skipped.
- Operates at the PR-skip layer, not the diff-filter layer — it decides whether there is a review, where `excludePatterns` decides what reaches the agents once there is one.

Matched with **`dot: true` for the user list only**. Without it a configured `**/*.yml` silently fails to match `.github/workflows/ci.yml`, because minimatch will not let a wildcard cross a dot-directory by default — exactly the class of file someone would reach for this setting to skip. The built-in list keeps its current matching, so no existing behaviour moves.

## 2. `**/.github/PULL_REQUEST_TEMPLATE*` never matched `.github/pull_request_template.md`

minimatch is case-sensitive, and the lowercase form is what `gh` scaffolds and what most repositories actually commit. The effect is that editing a PR template — prose and forms, not automation, and explicitly intended to be trivial by the pattern above it (#455) — draws a full review.

I added the lowercase entry rather than making the whole list case-insensitive, which would have changed matching for every other pattern too.

## Where this came from

Wiring MergeWatch into a repository whose CI already declares which paths cannot affect the build — docs, agent skills, tooling config. Those two lists answer the same question, and there was no way to reuse the answer. The template-casing bug surfaced from the same work: a one-line edit to a PR template kept pulling reviews nobody wanted.

## Testing

Tests added in `skip-logic.test.ts` cover: a configured pattern skipping a PR; the same PR being reviewed when unconfigured; the dot-directory case; a mixed skip-pattern-plus-real-code PR still being reviewed; `includePatterns` winning over `skipPatterns`; the lowercase template; and `extractSkipPatterns` rejecting malformed input.

These ran green on a downstream fork's CI, including `Build & Test`, on the same commit content.

## Files

- `packages/core/src/skip-logic.ts` — `extractSkipPatterns`, third parameter on `shouldSkipPR`, lowercase template pattern
- `packages/core/src/config/defaults.ts` — field + default
- `packages/core/src/github/client.ts` — YAML parsing
- `packages/core/src/index.ts` — export
- `packages/server/src/review-processor.ts`, `packages/lambda/src/handlers/review-agent.ts` — both transports pass it through
- `README.md` — documents `skipPatterns` next to `excludePatterns`, and labels what `excludePatterns` actually does, since the distinction is easy to miss
