### PR TITLE
fix(release): make dry_run actually dry — prepare must not push

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -101,6 +101,7 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           REF: ${{ inputs.candidate_ref }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           # -e matters here. Without it a failed `git push` does NOT abort:
           # execution continues, SHA is captured from a local-only commit, the
@@ -132,6 +133,33 @@ jobs:
           if [ "$REF" != "main" ]; then
             echo "::error::candidate_ref must be 'main' to prepare a release (got '$REF')"
             exit 1
+          fi
+
+          # #592 — a dry run must be DRY. `dry_run` guarded `verify` and
+          # `release`, but not this job, so a dry run bumped every
+          # package.json, wrote a CHANGELOG section, committed and PUSHED to
+          # main — then skipped the jobs that would have turned that into a
+          # release. main was left claiming a version that was never tagged:
+          # the inverse of the v0.6.0 defect #549 fixed.
+          #
+          # Bail out BEFORE release.sh touches anything, and hand downstream
+          # the SHA main already has, so `suite` and `audit` still grade the
+          # real candidate rather than being skipped.
+          if [ "$DRY_RUN" = "true" ]; then
+            SHA="$(git rev-parse HEAD)"
+            echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+            echo "dry run — nothing prepared; grading main as-is at $SHA"
+            {
+              echo "## Dry run — nothing prepared"
+              echo ""
+              echo "- Requested version: \`$VERSION\` (**not** applied)"
+              echo "- Grading: \`$SHA\` — main as it stands"
+              echo ""
+              echo "No version bump, no CHANGELOG entry, no commit, no push. The suite and"
+              echo "the documentation audit run against the candidate; \`verify\` and"
+              echo "\`release\` are skipped, so no tag is cut."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
           fi
 
           git config user.name  "mergewatch-release-gate"
@@ -167,7 +195,7 @@ jobs:
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "prepared $VERSION at $SHA"
           {
-            echo "## Prepared"
+            echo "## Prepared for release"
             echo ""
             echo "- Version: \`$VERSION\`"
             echo "- Commit: \`$SHA\`"

--- a/packages/lambda/src/release-gate.test.ts
+++ b/packages/lambda/src/release-gate.test.ts
@@ -365,11 +365,26 @@ describe('#592 — a dry run must be dry', () => {
   });
 
   it('summaries distinguish a dry run from a real preparation', () => {
-    // A dry run's output must not read like a cut. These are the two strings a
-    // human sees in the job summary.
+    // Asserting both strings merely EXIST would pass if they were swapped, or
+    // if both sat in the same branch. Check placement: the dry-run summary
+    // must be inside the guard (before `exit 0`), and the prepared summary
+    // after it — on the path a dry run never reaches.
     const run = prepareRun();
-    expect(run).toContain('## Dry run — nothing prepared');
-    expect(run).toContain('## Prepared for release');
+    const guardStart = run.indexOf('DRY_RUN');
+    const guardEnd = run.indexOf('exit 0');
+    expect(guardStart).toBeGreaterThan(-1);
+    expect(guardEnd).toBeGreaterThan(guardStart);
+
+    const dryAt = run.indexOf('## Dry run — nothing prepared');
+    const prepAt = run.indexOf('## Prepared for release');
+    expect(dryAt, 'dry-run summary missing').toBeGreaterThan(-1);
+    expect(prepAt, 'prepared summary missing').toBeGreaterThan(-1);
+
+    // dry-run summary lives INSIDE the guard
+    expect(dryAt).toBeGreaterThan(guardStart);
+    expect(dryAt).toBeLessThan(guardEnd);
+    // prepared summary lives AFTER the guard exits — unreachable on a dry run
+    expect(prepAt).toBeGreaterThan(guardEnd);
   });
 
   it('verify and release remain guarded, so a dry run still cuts no tag', () => {

--- a/packages/lambda/src/release-gate.test.ts
+++ b/packages/lambda/src/release-gate.test.ts
@@ -312,3 +312,68 @@ describe('release gate — the version is validated before anything is written',
     }
   });
 });
+
+describe('#592 — a dry run must be dry', () => {
+  const prepareRun = () => {
+    const step = wf.jobs.prepare.steps.find((s: any) => s.id === 'commit');
+    expect(step, "no step with id 'commit' in the prepare job").toBeTruthy();
+    // Comments in this block describe the ordering they enforce, so an
+    // indexOf over the raw text matches prose. Compare executable lines only.
+    return (step.run as string)
+      .split('\n')
+      .filter((l: string) => !/^\s*#/.test(l))
+      .join('\n');
+  };
+
+  it('receives dry_run at all — the guard cannot fire without it', () => {
+    // The original defect was not a wrong branch; it was that this job never
+    // saw the input. `verify` and `release` had the guard, `prepare` did not.
+    const step = wf.jobs.prepare.steps.find((s: any) => s.id === 'commit');
+    expect(JSON.stringify(step.env)).toContain('inputs.dry_run');
+  });
+
+  it('bails out before release.sh edits anything', () => {
+    const run = prepareRun();
+    const at = run.indexOf('DRY_RUN');
+    // Assert PRESENCE first. Without the guard indexOf returns -1, and
+    // -1 < anything holds — the ordering assertion would pass on the very
+    // code it exists to reject.
+    expect(at, 'the prepare step never mentions DRY_RUN').toBeGreaterThan(-1);
+    expect(at).toBeLessThan(run.indexOf('scripts/release.sh'));
+  });
+
+  it('bails out before the push — main must stay byte-identical', () => {
+    const run = prepareRun();
+    const at = run.indexOf('DRY_RUN');
+    expect(at, 'the prepare step never mentions DRY_RUN').toBeGreaterThan(-1);
+    expect(at).toBeLessThan(run.indexOf('git push'));
+  });
+
+  it('still hands downstream a SHA, so suite and audit grade the candidate', () => {
+    // Exiting without an output would leave `suite` grading an empty string —
+    // the gate would go green having checked nothing, which is worse than the
+    // bug being fixed.
+    const run = prepareRun();
+    const guard = run.slice(run.indexOf('DRY_RUN'), run.indexOf('git config'));
+    expect(guard).toContain('sha=$SHA');
+    expect(guard).toContain('exit 0');
+  });
+
+  it('suite and audit still depend on prepare, so the SHA is actually used', () => {
+    expect(wf.jobs.suite.needs).toBe('prepare');
+    expect(wf.jobs.audit.needs).toBe('prepare');
+  });
+
+  it('summaries distinguish a dry run from a real preparation', () => {
+    // A dry run's output must not read like a cut. These are the two strings a
+    // human sees in the job summary.
+    const run = prepareRun();
+    expect(run).toContain('## Dry run — nothing prepared');
+    expect(run).toContain('## Prepared for release');
+  });
+
+  it('verify and release remain guarded, so a dry run still cuts no tag', () => {
+    expect(JSON.stringify(wf.jobs.verify.if)).toContain('dry_run');
+    expect(JSON.stringify(wf.jobs.release.if)).toContain('dry_run');
+  });
+});


### PR DESCRIPTION
Closes #592. PR 1 of 2; #601's drift test follows.

## The defect

`dry_run` guarded `verify` and `release`. **`prepare` never received the input at all** — so a dry run bumped root and all 12 `package.json` files, wrote a CHANGELOG section, committed, and **pushed to `main`**, then skipped the jobs that would have made it a release.

`main` was left claiming a version that was never tagged — the inverse of the v0.6.0 defect #549 fixed, reachable from the one flag whose entire purpose is to change nothing. **The cautious path was the destructive one.**

## The fix

Bail out before `release.sh` touches a file, and long before the push:

```bash
if [ "$DRY_RUN" = "true" ]; then
  SHA="$(git rev-parse HEAD)"
  echo "sha=$SHA" >> "$GITHUB_OUTPUT"
  …
  exit 0
fi
```

**Still emitting `sha` matters.** Exiting without it would leave `suite` grading an empty string — the gate would go green having checked nothing, which is a worse bug than the one being fixed. `suite` and `audit` both still `needs: prepare`, so they grade `main` as it stands.

The two summaries now say which happened — **"Prepared for release"** vs **"Dry run — nothing prepared"**. A dry run's output could otherwise be mistaken for a cut, which is the same confusion relocated.

## On the tests, and a mistake worth naming

Seven tests. Initially only three failed without the fix — and **two of the ordering tests passed on the broken code**:

```ts
expect(run.indexOf('DRY_RUN')).toBeLessThan(run.indexOf('git push'));
```

With the guard absent, `indexOf` returns `-1`, and `-1 < anything` holds. They asserted the ordering on code that had **no guard at all**. They assert presence first now:

```ts
expect(at, 'the prepare step never mentions DRY_RUN').toBeGreaterThan(-1);
```

**Five of seven now fail without the fix** — verified by reverting it and re-running, not assumed. The remaining two are back-stops (`verify`/`release` still guarded; `suite`/`audit` still depend on `prepare`) which should hold either way.

## What this does not do

It does not make `dry_run` exercise the tag or release path — by definition. What it now gives you is a **safe rehearsal of `prepare`, `suite` and `audit`**, which is what you actually want before a real cut, and what was unavailable when the v0.6.2 cut needed it.

## Verified

`build`, `typecheck`, and the full suite with `TURBO_FORCE=true` (**`Cached: 0`**) all pass.