### PR TITLE
feat(release): fail loudly when the App's subscriptions drift from the code

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -446,6 +446,39 @@ jobs:
       - name: Structural checks
         run: node scripts/check-docs-structure.mjs
 
+      # #601 — the App's subscribed events live in a settings UI with no API,
+      # so nothing in the repo can see them drift from what webhook.ts
+      # dispatches on. When they drift the handler is never reached: no error,
+      # no log. #558 shipped the check_suite handler inert for exactly this
+      # reason, and the Re-run button stayed dead in production.
+      #
+      # Reported, not blocking — same discipline as the docs audit. Drift means
+      # a feature is dead, which a human should see before cutting a release;
+      # it does not mean the release is wrong. Exit 2 (could not check) is also
+      # not a failure here, because a release must not hinge on an external API
+      # being reachable — but it is printed, so it cannot pass for a clean run.
+      - name: App subscription drift (#601)
+        continue-on-error: true
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: |
+          set -uo pipefail
+          rc=0
+          node scripts/check-app-subscriptions.mjs --stage prod | tee /tmp/drift.txt || rc=$?
+          {
+            echo "## App subscription drift"
+            echo ""
+            case "$rc" in
+              0) echo "✅ Every event \`webhook.ts\` dispatches on is subscribed." ;;
+              1) echo "⚠️ **Drift.** Handlers exist for events the App will never receive — see below. Fix in the App settings UI; there is no API." ;;
+              *) echo "❓ **Could not check.** The subscriptions were NOT compared — this is not a pass." ;;
+            esac
+            echo ""
+            echo '```'
+            cat /tmp/drift.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Audit the docs against the codebase
         id: audit
         env:

--- a/packages/lambda/src/app-subscriptions.test.ts
+++ b/packages/lambda/src/app-subscriptions.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import yaml from 'js-yaml';
+
+/**
+ * #601 — guards on the subscription-drift check itself.
+ *
+ * The check compares two lists that live in different systems: the `case`
+ * labels `webhook.ts` dispatches on, and the events the App is actually
+ * subscribed to. Only the first is in this repo.
+ *
+ * That asymmetry is the whole value, and it is the thing most likely to be
+ * quietly removed. A version comparing the dispatch cases to a hardcoded list
+ * in this repo would pass today — while `check_suite` and `installation` are
+ * dispatched and unsubscribed in production — and would catch nothing ever.
+ * These tests exist to make that regression loud.
+ */
+const REPO = resolve(__dirname, '../../..');
+const SCRIPT = join(REPO, 'scripts/check-app-subscriptions.mjs');
+const src = readFileSync(SCRIPT, 'utf8');
+
+describe('subscription drift — the check reads LIVE state, not the repo', () => {
+  it('asks GitHub what the App is subscribed to', () => {
+    // If this ever becomes a constant in the repo, the check is theatre.
+    expect(src).toContain('https://api.github.com/app');
+    expect(src).toMatch(/app\.events/);
+  });
+
+  it('authenticates as the App, which is the only way to read its events', () => {
+    expect(src).toContain('RSA-SHA256');
+    expect(src).toMatch(/github-private-key/);
+  });
+
+  it('derives the dispatched list from webhook.ts rather than restating it', () => {
+    expect(src).toContain('packages/lambda/src/handlers/webhook.ts');
+    expect(src).toMatch(/case "\(\[a-z_\]\+\)":/);
+  });
+
+  it('has no hardcoded expected-events list to compare against', () => {
+    // The failure mode this file exists to prevent: a literal array of event
+    // names that makes the check self-referential.
+    const literals = src.match(/'(check_suite|installation|pull_request)'/g) ?? [];
+    // The only permitted mention is inside the documented other-channel map.
+    const inExemption = src.slice(src.indexOf('OTHER_CHANNEL'), src.indexOf('/* ── compare'));
+    for (const lit of literals) {
+      expect(inExemption.includes(lit), `${lit} appears outside the exemption map`).toBe(true);
+    }
+  });
+});
+
+describe('subscription drift — outcomes stay distinguishable', () => {
+  it('exits 2 when it cannot check, and says that is not a pass', () => {
+    const r = spawnSync('node', [SCRIPT, '--stage', 'definitely-not-a-stage'], {
+      cwd: REPO, encoding: 'utf8',
+    });
+    expect(r.status).toBe(2);
+    expect(`${r.stdout}${r.stderr}`).toMatch(/not a pass/i);
+  });
+
+  it('treats only missing subscriptions as drift, not extra ones', () => {
+    // A subscribed event we do not handle is answered 200 and ignored. Calling
+    // that drift would make the check red for a non-defect, and a permanently
+    // red check is one people stop reading.
+    expect(src).toMatch(/harmless/);
+    expect(src).toMatch(/missing\s*=\s*dispatched\.filter/);
+  });
+
+  it('every other-channel exemption carries a reason', () => {
+    const map = src.slice(src.indexOf('const OTHER_CHANNEL'), src.indexOf('/* ── compare'));
+    const entries = [...map.matchAll(/\['([a-z_]+)',\s*'([^']+)'\]/g)];
+    expect(entries.length).toBeGreaterThan(0);
+    for (const [, event, reason] of entries) {
+      expect(reason.length, `${event} exemption has no reason`).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe('subscription drift — wired where it will actually be seen', () => {
+  const wf = yaml.load(
+    readFileSync(join(REPO, '.github/workflows/release-gate.yml'), 'utf8'),
+  ) as any;
+  const step = wf.jobs.audit.steps.find((s: any) =>
+    typeof s.name === 'string' && s.name.includes('subscription drift'));
+
+  it('runs in the release gate, before a release is cut', () => {
+    expect(step, 'no subscription-drift step in the audit job').toBeTruthy();
+    expect(JSON.stringify(step)).toContain('check-app-subscriptions.mjs');
+  });
+
+  it('reports without blocking, and says which of the three outcomes it saw', () => {
+    expect(step['continue-on-error']).toBe(true);
+    const run = step.run as string;
+    for (const s of ['Every event', 'Drift', 'Could not check']) expect(run).toContain(s);
+  });
+});

--- a/scripts/check-app-subscriptions.mjs
+++ b/scripts/check-app-subscriptions.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+/**
+ * #601 — does the GitHub App actually receive the events the code dispatches on?
+ *
+ * `webhook.ts` has a `case` for every event it handles. GitHub delivers only
+ * events the App is SUBSCRIBED to. Those two lists are maintained in different
+ * places — one in the repo, one in a settings UI with no API to change it —
+ * and nothing compares them.
+ *
+ * When they drift, the handler is simply never reached. No error, no log, no
+ * failing test. #558 fixed the `check_suite` handler and shipped it inert
+ * because the App was never subscribed; the "Re-run all checks" button stayed
+ * dead in production for every user. #545 (a permission) and #602 (a handler
+ * never reached) are the same shape.
+ *
+ * This compares the two lists. It CANNOT be satisfied by reading the repo
+ * alone: one side comes from `GET /app`, authenticated as the App with a JWT
+ * signed by its private key. A version that compared the dispatch cases to a
+ * hardcoded list in this repo would pass today and catch nothing.
+ *
+ * Exit 0 = subscriptions cover every dispatched event.
+ * Exit 1 = drift.
+ * Exit 2 = could not check (missing credentials, API failure) — never silence.
+ */
+import { readFileSync } from 'node:fs';
+import { createSign } from 'node:crypto';
+import { resolve, dirname } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const REPO = resolve(dirname(process.argv[1]), '..');
+const argv = process.argv.slice(2);
+const arg = (n, d) => { const i = argv.indexOf(n); return i === -1 ? d : argv[i + 1]; };
+const STAGE = arg('--stage', 'prod');
+
+const cannotCheck = (msg) => {
+  console.error(`\n✗ COULD NOT CHECK — ${msg}`);
+  console.error('  This is not a pass. The subscriptions were not compared.');
+  process.exit(2);
+};
+
+/* ── side A: what the code dispatches on ─────────────────────────────────── */
+const WEBHOOK = resolve(REPO, 'packages/lambda/src/handlers/webhook.ts');
+let src;
+try { src = readFileSync(WEBHOOK, 'utf8'); } catch { cannotCheck(`cannot read ${WEBHOOK}`); }
+const dispatched = [...new Set([...src.matchAll(/case "([a-z_]+)":/g)].map((m) => m[1]))].sort();
+if (!dispatched.length) cannotCheck('no dispatch cases found — has the switch been refactored?');
+
+/* ── side B: what GitHub will actually deliver ───────────────────────────── */
+function ssm(name) {
+  return execFileSync('aws', [
+    'ssm', 'get-parameter', '--name', name, '--with-decryption',
+    '--query', 'Parameter.Value', '--output', 'text',
+  ], { encoding: 'utf8' }).trim();
+}
+
+let appId, pem;
+try {
+  appId = ssm(`/mergewatch/${STAGE}/github-app-id`);
+  pem = ssm(`/mergewatch/${STAGE}/github-private-key`);
+} catch (e) {
+  cannotCheck(`could not read App credentials from SSM for stage "${STAGE}": ${e.message}`);
+}
+
+const b64 = (o) => Buffer.from(JSON.stringify(o)).toString('base64url');
+const now = Math.floor(Date.now() / 1000);
+const head = b64({ alg: 'RS256', typ: 'JWT' });
+const body = b64({ iat: now - 60, exp: now + 540, iss: appId });
+const jwt = `${head}.${body}.${createSign('RSA-SHA256').update(`${head}.${body}`).sign(pem, 'base64url')}`;
+
+let app;
+try {
+  const res = await fetch('https://api.github.com/app', {
+    headers: { Authorization: `Bearer ${jwt}`, Accept: 'application/vnd.github+json' },
+  });
+  if (!res.ok) cannotCheck(`GET /app returned ${res.status}`);
+  app = await res.json();
+} catch (e) {
+  cannotCheck(`GET /app failed: ${e.message}`);
+}
+
+const subscribed = [...(app.events ?? [])].sort();
+if (!subscribed.length) cannotCheck('GET /app returned no events — refusing to report that as drift');
+
+/* ── events delivered by a channel other than App subscriptions ──────────── */
+// `marketplace_purchase` is configured on the Marketplace LISTING's own
+// webhook, not in the App's event subscriptions, so it is correctly absent
+// from GET /app. Its delivery was confirmed separately by an observed ping
+// (#596). Flagging it would make this check permanently red for a non-defect,
+// and a check that is always red is one people learn to ignore — which is the
+// failure this exists to prevent.
+//
+// Anything added here needs a reason and evidence that the other channel
+// works. It is an exemption, not a mute button.
+const OTHER_CHANNEL = new Map([
+  ['marketplace_purchase', 'Marketplace listing webhook (#596) — ping confirmed reaching prod'],
+]);
+
+/* ── compare ─────────────────────────────────────────────────────────────── */
+// Only one direction is a defect. A subscribed event we do not dispatch is
+// merely noise: the webhook answers 200 and ignores it. A DISPATCHED event we
+// are not subscribed to is a feature that cannot run.
+const missing = dispatched.filter((e) => !subscribed.includes(e) && !OTHER_CHANNEL.has(e));
+const exempt = dispatched.filter((e) => !subscribed.includes(e) && OTHER_CHANNEL.has(e));
+const extra = subscribed.filter((e) => !dispatched.includes(e));
+
+console.log(`App: ${app.slug} (stage ${STAGE})`);
+console.log(`  dispatched by webhook.ts : ${dispatched.join(', ')}`);
+console.log(`  subscribed on the App    : ${subscribed.join(', ')}`);
+if (extra.length) console.log(`  subscribed but unhandled : ${extra.join(', ')}  (harmless — answered 200 and ignored)`);
+for (const e of exempt) console.log(`  delivered elsewhere      : ${e} — ${OTHER_CHANNEL.get(e)}`);
+
+if (!missing.length) {
+  console.log('\n✓ Every dispatched event is subscribed.');
+  process.exit(0);
+}
+
+console.log(`\n✗ DRIFT — ${missing.length} dispatched event(s) the App will never receive:\n`);
+for (const e of missing) console.log(`    ${e}`);
+console.log('\n  The handlers for these exist and cannot run. No error will be logged,');
+console.log('  because GitHub simply never delivers them.');
+console.log(`\n  Fix in the App settings UI (there is no API): Settings → Developer settings`);
+console.log(`  → GitHub Apps → ${app.slug} → Permissions & events → Subscribe to events.`);
+process.exit(1);


### PR DESCRIPTION
Part of #601. **PR 2 of 2** — stacked on #612, which it shares `release-gate.yml` with. Retarget to `main` once #612 merges.

## What this does not do

It does **not** subscribe the App to the missing events. GitHub exposes no API for that — the events are set in the App settings UI or at creation via a manifest — so those checkboxes remain a human's to tick, on both prod and dev.

This is the tripwire that makes the *next* drift visible instead of silent.

## The gap it closes

`webhook.ts` has a `case` for every event it handles. GitHub delivers only events the App is **subscribed** to. Those two lists live in different systems, and nothing compared them.

When they drift the handler is never reached — no error, no log, no failing test. **#558 fixed the `check_suite` handler and shipped it inert for exactly this reason**, and the "Re-run all checks" button stayed dead in production for every user, on every PR. #545 (a permission) and #602 (a handler never reached) are the same shape. That is three in a fortnight.

## It fails today, which is the point

```
App: mergewatch (stage prod)
  dispatched by webhook.ts : check_run, check_suite, installation, issue_comment,
                             marketplace_purchase, pull_request, pull_request_review_comment
  subscribed on the App    : check_run, issue_comment, pull_request,
                             pull_request_review, pull_request_review_comment,
                             pull_request_review_thread
  delivered elsewhere      : marketplace_purchase — Marketplace listing webhook (#596)

✗ DRIFT — 2 dispatched event(s) the App will never receive:
    check_suite
    installation
```

Exit **1**. Dev is worse — `check_run` is missing there too, so even a single-check re-run cannot work.

A check that passed on day one against a known-broken production would not be testing anything.

## The exemption, and why it is not a mute button

`marketplace_purchase` is configured on the **Marketplace listing's own webhook**, not App subscriptions, so its absence from `GET /app` is correct. Delivery was confirmed separately by an observed ping (#596).

Without the exemption this check would be **permanently red for a non-defect** — and a check that is always red is one people learn to ignore, which is precisely the failure it exists to prevent. Entries require a reason string, and a test enforces that.

## CI or on demand — the decision

**In the release gate's `audit` job**, reported but not blocking.

- That job **already has AWS credentials via OIDC**, so no new secret reaches PR CI. Putting the App private key in every PR job would widen the blast radius of a compromised workflow for a check that does not change per-PR.
- Per-PR is also the wrong cadence: the App's settings do not change when a PR does. Before a release is exactly when someone should learn a feature is dead.
- **Not blocking**, because drift means a feature is dead — not that this release is wrong. The human sees it in the approval checklist and decides.
- **Could-not-check is its own outcome** and is never rendered as a pass, so an unreachable API cannot look clean.

On-demand alone was the alternative and I rejected it: a script nobody runs is how this drifted for three releases.

## Tests

Nine, aimed at the way this would most plausibly be weakened — someone replacing the live lookup with a constant in the repo. That version would pass today, while production is broken, and catch nothing ever. The tests assert it queries `api.github.com/app`, signs as the App, derives the dispatched list from `webhook.ts`, and carries no hardcoded event list outside the documented exemption.

Also covered: exit 2 on cannot-check, extra subscriptions not counted as drift, and the gate wiring reporting all three outcomes.

## Verified

`build`, `typecheck`, and the full suite with `TURBO_FORCE=true` (**`Cached: 0`**).