### PR TITLE
fix(drift-check): address the #614 review findings I merged past

### DIFF
--- a/packages/lambda/src/app-subscriptions.test.ts
+++ b/packages/lambda/src/app-subscriptions.test.ts
@@ -50,6 +50,31 @@ describe('subscription drift — the check reads LIVE state, not the repo', () =
   });
 });
 
+describe('subscription drift — review findings from #614', () => {
+  it('refuses a stage name that could escape the SSM path', () => {
+    // STAGE is interpolated into `/mergewatch/${STAGE}/github-app-id`.
+    const r = spawnSync('node', [SCRIPT, '--stage', '../../elsewhere'], { cwd: REPO, encoding: 'utf8' });
+    expect(r.status).toBe(2);
+    expect(`${r.stdout}${r.stderr}`).toMatch(/invalid stage name/i);
+  });
+
+  it('does not count a case label that appears inside a comment', () => {
+    // webhook.ts carries explanatory comments naming events. Counting one as
+    // dispatched would report drift for something nothing handles — a false
+    // drift report discredits the check as surely as a missed one.
+    expect(src).toMatch(/\\\/\\\*\[\\s\\S\]\*\?\\\*\\\//);
+    expect(src).toContain("replace(/\\/\\/.*$/, '')");
+    const stripIdx = src.indexOf('const code = src');
+    const matchIdx = src.indexOf('code.matchAll');
+    expect(stripIdx).toBeGreaterThan(-1);
+    expect(stripIdx).toBeLessThan(matchIdx);
+  });
+
+  it('sends the App ID as a number in the JWT, as GitHub documents', () => {
+    expect(src).toContain('iss: Number(appId)');
+  });
+});
+
 describe('subscription drift — outcomes stay distinguishable', () => {
   it('exits 2 when it cannot check, and says that is not a pass', () => {
     const r = spawnSync('node', [SCRIPT, '--stage', 'definitely-not-a-stage'], {

--- a/scripts/check-app-subscriptions.mjs
+++ b/scripts/check-app-subscriptions.mjs
@@ -31,6 +31,15 @@ const REPO = resolve(dirname(process.argv[1]), '..');
 const argv = process.argv.slice(2);
 const arg = (n, d) => { const i = argv.indexOf(n); return i === -1 ? d : argv[i + 1]; };
 const STAGE = arg('--stage', 'prod');
+// STAGE is interpolated into an SSM parameter path, so an unconstrained value
+// (`../../something`) would read a parameter this script has no business
+// reading. Today every caller passes a literal, which is exactly when a guard
+// is cheap to add and nobody notices it is missing.
+if (!/^[a-z0-9-]+$/.test(STAGE)) {
+  console.error(`\n✗ COULD NOT CHECK — invalid stage name ${JSON.stringify(STAGE)}`);
+  console.error('  Expected something like "prod" or "dev".');
+  process.exit(2);
+}
 
 const cannotCheck = (msg) => {
   console.error(`\n✗ COULD NOT CHECK — ${msg}`);
@@ -42,7 +51,17 @@ const cannotCheck = (msg) => {
 const WEBHOOK = resolve(REPO, 'packages/lambda/src/handlers/webhook.ts');
 let src;
 try { src = readFileSync(WEBHOOK, 'utf8'); } catch { cannotCheck(`cannot read ${WEBHOOK}`); }
-const dispatched = [...new Set([...src.matchAll(/case "([a-z_]+)":/g)].map((m) => m[1]))].sort();
+// Strip comments first. A `case "check_suite":` written inside a comment —
+// including the explanatory ones in webhook.ts about which events exist —
+// would otherwise be counted as dispatched, and the check would report drift
+// for an event nothing handles. A false drift report is as corrosive here as
+// a missed one: both teach people to disregard the output.
+const code = src
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .split('\n')
+  .map((l) => l.replace(/\/\/.*$/, ''))
+  .join('\n');
+const dispatched = [...new Set([...code.matchAll(/case "([a-z_]+)":/g)].map((m) => m[1]))].sort();
 if (!dispatched.length) cannotCheck('no dispatch cases found — has the switch been refactored?');
 
 /* ── side B: what GitHub will actually deliver ───────────────────────────── */
@@ -64,7 +83,9 @@ try {
 const b64 = (o) => Buffer.from(JSON.stringify(o)).toString('base64url');
 const now = Math.floor(Date.now() / 1000);
 const head = b64({ alg: 'RS256', typ: 'JWT' });
-const body = b64({ iat: now - 60, exp: now + 540, iss: appId });
+// `iss` is the App ID; GitHub documents it as a number. A string works today,
+// which is the kind of thing that quietly stops working.
+const body = b64({ iat: now - 60, exp: now + 540, iss: Number(appId) });
 const jwt = `${head}.${body}.${createSign('RSA-SHA256').update(`${head}.${body}`).sign(pem, 'base64url')}`;
 
 let app;


### PR DESCRIPTION
**I merged #614 at 3/5 without reading the verdict.** The watcher ran `gh pr merge` unconditionally once the checks settled — and checks green is not the same as review clean. That is the same mistake I made on #580 earlier today, which makes it a process failure rather than an oversight. Fixing forward.

The findings were real.

## 1. `--stage` could escape the SSM path

`STAGE` came from `process.argv` and was interpolated into `/mergewatch/${STAGE}/github-app-id`. `--stage ../../something` would read a parameter this script has no business reading.

Every caller passes a literal today — which is precisely when the guard is cheap and its absence goes unnoticed. Now constrained to `^[a-z0-9-]+$`, refused with exit 2.

## 2. A case label inside a comment counted as dispatched

`webhook.ts` carries explanatory comments naming events. A `case "check_suite":` written in one was matched by the regex, so the check could report drift for an event nothing handles.

**A false drift report discredits this check as thoroughly as a missed one** — both teach people to disregard the output, which is the exact failure it exists to prevent. Comments are stripped before matching, and a test asserts the stripping happens before the match.

## 3. JWT `iss` sent a string

GitHub documents `iss` as the numeric App ID. A string works today, which is the kind of thing that quietly stops working. Now `Number(appId)`.

## Not changed: private key in the heap

Signing requires the key in the process. Reducing the window would mean zeroing a `Buffer` that Node's `crypto` signing API does not accept — real cost, no real reduction in exposure. Justifying rather than fixing.

## Verified

```
prod:       exit 1   (drift — check_suite, installation — unchanged)
traversal:  exit 2   (refused)
```

Three new tests. `build`, `typecheck`, full suite with `TURBO_FORCE=true` (`Cached: 0`).