### PR TITLE
fix(seo): list the blog sitemap in robots.txt

### DIFF
--- a/packages/dashboard/app/robots.ts
+++ b/packages/dashboard/app/robots.ts
@@ -33,7 +33,12 @@ export default function robots(): MetadataRoute.Robots {
         disallow: ["/dashboard", "/api/", "/signin", "/signout", "/onboarding"],
       },
     ],
-    sitemap: `${SITE_URL}/sitemap.xml`,
+    // The blog is a separate Next app proxied at /blog, so it has its own
+    // sitemap that this one does not include. Crawlers read robots.txt from
+    // the host root only, and that root is served by THIS app — so without
+    // this line the blog's sitemap is undiscoverable at its canonical host,
+    // and the posts are effectively unpublished (mergewatch/blog#5).
+    sitemap: [`${SITE_URL}/sitemap.xml`, `${SITE_URL}/blog/sitemap.xml`],
     host: SITE_URL,
   };
 }

--- a/packages/dashboard/lib/robots.test.ts
+++ b/packages/dashboard/lib/robots.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import robots from "../app/robots";
+
+/**
+ * mergewatch/blog#5 — the blog is a separate Next app proxied at /blog with its
+ * own sitemap. Crawlers read robots.txt from the host root only, and that root
+ * is served by THIS app. If it does not list the blog's sitemap, the posts are
+ * undiscoverable at their canonical host — published and invisible.
+ */
+describe("robots.txt", () => {
+  const result = robots();
+  const sitemaps = [result.sitemap].flat().filter(Boolean) as string[];
+
+  it("lists both the product and the blog sitemaps", () => {
+    expect(sitemaps).toContain("https://mergewatch.ai/sitemap.xml");
+    expect(sitemaps).toContain("https://mergewatch.ai/blog/sitemap.xml");
+  });
+
+  it("does not block /blog", () => {
+    // /blog is proxied through this app, so a disallow here would hide the
+    // blog even though the blog's own robots.txt permits it.
+    const disallowed = [result.rules]
+      .flat()
+      .flatMap((rule) => [rule?.disallow ?? []].flat());
+    for (const path of disallowed) {
+      expect(path.startsWith("/blog"), `${path} would hide the blog`).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
Part of [mergewatch/blog#5](https://github.com/mergewatch/blog/issues/5). This is the half that lives in this repo.

## Why this repo owns it

The blog is a separate Next app proxied at `/blog`. It has its own sitemap at `/blog/sitemap.xml` and its own `robots.ts` that advertises it — but with `basePath=/blog`, that file is served at `/blog/robots.txt`, and **crawlers only read a host root**.

The host root of `mergewatch.ai` is served by **this** app. So the blog's sitemap is undiscoverable at its canonical host unless this file lists it:

```
Sitemap: https://mergewatch.ai/sitemap.xml
Sitemap: https://mergewatch.ai/blog/sitemap.xml   ← added
```

Without it the posts would be published and unfindable. Nothing errors; the sitemap simply is not found.

## Two tests

**The sitemap list** — verified to fail without the change rather than assumed:

```
× lists both the product and the blog sitemaps
```

**Nothing disallows `/blog`** — `/blog` is proxied *through* this app, so a disallow here would hide the blog regardless of what the blog's own robots.txt permits. That is a plausible future edit (someone tightening the disallow list) with a non-obvious consequence in another repo.

The test lives in `lib/` because this package's vitest config only includes `lib/**/*.test.ts`; widening the config for one file seemed the larger change.

## The other half

In `mergewatch/blog`: the origin hostnames (`blog.mergewatch.ai`, `development-blog.mergewatch.ai`) need a host-root robots.txt that disallows crawling, so the proxy's source is not indexed as a duplicate of the canonical site.

Worth noting the two halves point opposite ways — this one opens discovery of the canonical URLs, that one closes discovery of the origin copy — and neither is sufficient alone.

## Verified

`build`, `typecheck`, full suite with `TURBO_FORCE=true` (`Cached: 0`).