### PR TITLE
feat(site): add Blog to navigation, drop the personal attribution

### DIFF
--- a/packages/dashboard/app/about/page.tsx
+++ b/packages/dashboard/app/about/page.tsx
@@ -56,23 +56,12 @@ export default function AboutPage() {
         keeps running.
       </p>
 
-      <h2>Who builds it</h2>
+      <h2>Why it exists</h2>
       <p>
-        MergeWatch is built and maintained by{" "}
-        <a
-          href="https://github.com/santthosh"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Santthosh
-        </a>
-        , a software engineer who has spent the last decade-plus building and
-        shipping developer tooling, web infrastructure, and SaaS products at
-        small startups and large platform teams. MergeWatch is an opinionated
-        response to a recurring frustration: every code review tool on the
-        market either locks you into a closed model, prices per seat so that
-        growing teams pay more for the same thing, or ships as a thin wrapper
-        around a single LLM vendor.
+        MergeWatch is an opinionated response to a recurring frustration:
+        every code review tool on the market either locks you into a closed
+        model, prices per seat so that growing teams pay more for the same
+        thing, or ships as a thin wrapper around a single LLM vendor.
       </p>
       <p>
         The project is developed in public. Every design decision, prompt

--- a/packages/dashboard/app/open-source/page.tsx
+++ b/packages/dashboard/app/open-source/page.tsx
@@ -64,6 +64,12 @@ export default function OpenSourcePage() {
             Pricing
           </Link>
           <Link
+            href="/blog"
+            className="hidden text-sm text-primer-muted transition hover:text-fg-primary sm:inline"
+          >
+            Blog
+          </Link>
+          <Link
             href="/open-source"
             className="hidden text-sm font-medium text-fg-primary sm:inline"
           >

--- a/packages/dashboard/app/page.tsx
+++ b/packages/dashboard/app/page.tsx
@@ -142,6 +142,12 @@ export default async function LandingPage() {
             Pricing
           </Link>
           <Link
+            href="/blog"
+            className="hidden text-sm text-primer-muted transition hover:text-fg-primary sm:inline"
+          >
+            Blog
+          </Link>
+          <Link
             href="/open-source"
             className="hidden text-sm text-primer-muted transition hover:text-fg-primary sm:inline"
           >
@@ -755,6 +761,14 @@ export default async function LandingPage() {
                 </Link>
               </li>
               <li>
+                <Link
+                  href="/blog"
+                  className="transition hover:text-fg-primary"
+                >
+                  Blog
+                </Link>
+              </li>
+              <li>
                 <a
                   href="https://github.com/mergewatch/mergewatch.ai"
                   target="_blank"
@@ -809,16 +823,7 @@ export default async function LandingPage() {
           </div>
         </div>
         <p className="mt-8 text-center text-xs text-primer-muted">
-          Built by{" "}
-          <a
-            href="https://github.com/santthosh"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="transition hover:text-fg-primary"
-          >
-            Santthosh
-          </a>{" "}
-          &middot; Open source under AGPL-3.0 &copy; {new Date().getFullYear()}{" "}
+            Open source under AGPL-3.0 &copy; {new Date().getFullYear()}{" "}
           mergewatch.ai
         </p>
       </footer>

--- a/packages/dashboard/app/pricing/page.tsx
+++ b/packages/dashboard/app/pricing/page.tsx
@@ -42,6 +42,12 @@ export default function PricingPage() {
             Pricing
           </Link>
           <Link
+            href="/blog"
+            className="hidden text-sm text-primer-muted transition hover:text-fg-primary sm:inline"
+          >
+            Blog
+          </Link>
+          <Link
             href="/open-source"
             className="hidden text-sm text-primer-muted transition hover:text-fg-primary sm:inline"
           >

--- a/packages/dashboard/components/LegalPage.tsx
+++ b/packages/dashboard/components/LegalPage.tsx
@@ -20,6 +20,9 @@ export function LegalPage({
           <Link href="/pricing" className="transition hover:text-fg-primary">
             Pricing
           </Link>
+          <Link href="/blog" className="transition hover:text-fg-primary">
+            Blog
+          </Link>
           <Link href="/signin" className="transition hover:text-fg-primary">
             Sign in
           </Link>
@@ -46,6 +49,9 @@ export function LegalPage({
           <Link href="/about" className="hover:text-fg-primary">
             About
           </Link>
+          <Link href="/blog" className="hover:text-fg-primary">
+            Blog
+          </Link>
           <Link href="/privacy" className="hover:text-fg-primary">
             Privacy
           </Link>
@@ -62,16 +68,7 @@ export function LegalPage({
           </a>
         </div>
         <p className="mt-4">
-          Built by{" "}
-          <a
-            href="https://github.com/santthosh"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="hover:text-fg-primary"
-          >
-            Santthosh
-          </a>{" "}
-          &middot; Open source under AGPL-3.0 &copy; {new Date().getFullYear()}{" "}
+            Open source under AGPL-3.0 &copy; {new Date().getFullYear()}{" "}
           mergewatch.ai
         </p>
       </footer>


### PR DESCRIPTION
Closes #618.

## Blog in navigation

`mergewatch.ai/blog` has been live since blog#1 with **nothing on the site linking to it** — reachable only by typing the URL, and with no internal link for a crawler to follow.

There is no shared marketing nav component, so this is the same edit four times:

| File | top nav | footer nav |
|---|---|---|
| `app/page.tsx` | ✅ | ✅ Company group |
| `components/LegalPage.tsx` | ✅ | ✅ link strip |
| `app/pricing/page.tsx` | ✅ | — (no footer nav) |
| `app/open-source/page.tsx` | ✅ | — (no footer nav) |

Uses `Link`, not an anchor — `/blog` is same-origin through the rewrite, unlike Docs which is external and stays an `<a>`.

Four copies of a nav is how navs drift. Extracting a shared component is a larger change and is **not** bundled here.

## Personal attribution

Two footer lines lost the `Built by …` clause and kept the licence and copyright:

```
before:  Built by Santthosh · Open source under AGPL-3.0 © 2026 mergewatch.ai
after:   Open source under AGPL-3.0 © 2026 mergewatch.ai
```

The third was **not** a find-and-replace. `app/about/page.tsx` had a whole `## Who builds it` section; deleting it would have left a heading with no body, and the paragraph carried real positioning.

The heading is now **Why it exists** and the section keeps the argument — closed models, per-seat pricing, thin wrappers around one vendor — with the biographical clause removed. I renamed the heading because the section no longer answers "who", and leaving it would have posed a question the page didn't answer.

**I did not invent anything to fill the gap** — no claim about team size or composition I can't substantiate. Flagging that as a judgment call: if you'd rather the page say something specific about who maintains it, that's a one-line follow-up.

**Left alone:** `santthosh` as a GitHub login in `packages/core/**/*.test.ts`. That's test data, not site content — changing it churns assertions for nothing a visitor sees.

## Verification

Asserted on the **emitted HTML**, not the source:

| Page | `/blog` links | `Santthosh` |
|---|---|---|
| `/` | 2 | 0 |
| `/about` | 2 | 0 |
| `/privacy` | 2 | 0 |
| `/terms` | 2 | 0 |
| `/pricing`, `/open-source` | server-rendered; link present in source | — |

About renders six coherent headings: What it does · Two ways to run it · Why open source · **Why it exists** · Status and roadmap · Get involved.

| | |
|---|---|
| `pnpm run typecheck` (workspace) | pass |
| `pnpm run build` (dashboard) | pass |
| `pnpm run lint` (dashboard) | **fails on `main` too** — `next lint` is deprecated and drops into an interactive ESLint config prompt. Pre-existing, not run by CI, untouched here. |
