### PR TITLE
fix(core): a dropped FP-C representative no longer takes its siblings with it

### DIFF
--- a/docs/false-positive-reduction-plan.md
+++ b/docs/false-positive-reduction-plan.md
@@ -74,6 +74,35 @@ W3's `partitionDisputed` runs **after** the orchestrator. So the orchestrator ha
 **Code targets:** `packages/core/src/agents/reviewer.ts` (`runReviewPipeline` orchestrator setup) + reuse `packages/core/src/finding-clustering.ts`.
 **E2E target:** [E2E-32](./../e2e/RUNBOOK.md#e2e-32-fp-c--pre-orchestrator-cross-agent-dedup-target).
 
+**Amended by #600 — a merge must not make findings share a fate.** As shipped, a
+representative that the orchestrator dropped took every sibling merged into it.
+The orchestrator judges the representative's *text*; FP-C had already collapsed
+the siblings, so it never saw them, and its verdict was being applied to
+findings it had not read.
+
+The effect was inverted: convergence is what puts a finding into a cluster, and
+being in a cluster is what made it vanish — so **the more agents independently
+agreed, the more likely the finding was to disappear.** On
+`mergewatch/fixtures#2699` five findings merged into *"Missing authorization
+check for admin endpoint"*; the representative was dropped, all six went with
+it, and the review rendered a confident "No issues found in the diff" over an
+unauthenticated admin endpoint.
+
+Now the `merged` verdicts are **deferred**: FP-C still aliases the renamed
+survivor immediately (later stages resolve through it), but siblings are
+recorded as merged only once the representative is known to have survived the
+orchestrator. When it did not, they re-enter the pipeline and earn their own
+terminal outcome like any unmerged finding.
+
+Survival is key match **or** same `(file, line)`. Findings carry no fingerprint
+until after the orchestrator, so `outcomeKey` is the title form and a rename
+changes it — matching on key alone would read every rename as a drop and
+resurrect siblings under a representative that is still there.
+
+**Cost:** a cluster the orchestrator meant to reject wholesale can return. That
+is bounded rather than eliminated — `capFindings` (`max-findings`) runs
+downstream, so reinstated siblings are still capped.
+
 ---
 
 ### FP-D — Diagram path validation  ✅ SHIPPED

--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -2110,6 +2110,145 @@ describe('runReviewPipeline', () => {
 
 // ─── agentAuthored flag (AGENT_MODE_SUFFIX injection) ───────────────
 
+// ─── #600 — a dropped FP-C representative must not take its siblings ────────
+
+describe('FP-C reinstatement when the orchestrator drops a representative (#600)', () => {
+  const allAgents: ReviewPipelineOptions['enabledAgents'] = {
+    security: true, bugs: true, style: true, summary: true, diagram: true,
+    errorHandling: true, testCoverage: true, commentAccuracy: true,
+  };
+
+  // Two agents independently raise the SAME (file, line) with overlapping
+  // wording — the convergence signal. FP-C merges them into one
+  // representative before the orchestrator ever sees them.
+  const converging = {
+    security: validFindingsJson([{
+      line: 2, severity: 'critical', confidence: 95,
+      title: 'Missing authorization check for admin endpoint',
+      description: 'The admin endpoint performs no authorization check.',
+    }]),
+    bug: validFindingsJson([{
+      line: 2, severity: 'critical', confidence: 95,
+      title: 'Missing authorization check for admin endpoint',
+      description: 'Admin endpoint missing an authorization check before use.',
+    }]),
+  };
+
+  const empty = validFindingsJson([]);
+  const summaryResponse = JSON.stringify({ summary: 'Adds an admin endpoint.' });
+  const diagramResponse = '%% overview\nflowchart TD\n  A-->B';
+
+  function pipelineWith(orchestratorResponse: string) {
+    return createMockLLM([
+      converging.security, converging.bug, empty, // security, bug, style
+      empty, empty, empty,                        // errorHandling, testCoverage, commentAccuracy
+      summaryResponse, diagramResponse, orchestratorResponse,
+    ]);
+  }
+
+  const run = (llm: ReturnType<typeof createMockLLM>) =>
+    runReviewPipeline(
+      {
+        diff: sampleDiff,
+        context: sampleContext,
+        modelId: 'heavy-model',
+        lightModelId: 'light-model',
+        maxFindings: 25,
+        enabledAgents: allAgents,
+      },
+      { llm },
+    );
+
+  it('returns the absorbed siblings when the representative is dropped', async () => {
+    // The orchestrator returns nothing. Before #600 every merged finding went
+    // with the representative and the review rendered "No issues found in the
+    // diff" — on a diff with an unauthenticated admin endpoint, raised at
+    // confidence 95 by two independent agents.
+    const result = await run(pipelineWith(JSON.stringify({
+      findings: [], mergeScore: 5, mergeScoreReason: 'No issues.',
+    })));
+
+    expect(result.findings.length).toBeGreaterThan(0);
+    expect(result.findings.some((f) => /authorization/i.test(f.title))).toBe(true);
+  });
+
+  it('does not duplicate the siblings when the representative survives', async () => {
+    // The merge held, so the siblings stay merged — reinstating here would
+    // render the same defect twice.
+    const result = await run(pipelineWith(JSON.stringify({
+      findings: [{
+        file: 'foo.ts', line: 2, severity: 'critical', category: 'security',
+        title: 'Missing authorization check for admin endpoint',
+        description: 'The admin endpoint performs no authorization check.',
+        suggestion: 'Add an authorization check.',
+      }],
+      mergeScore: 1,
+      mergeScoreReason: 'Critical.',
+    })));
+
+    const auth = result.findings.filter((f) => /authorization/i.test(f.title));
+    expect(auth).toHaveLength(1);
+  });
+
+  it('treats a renamed representative as surviving, not dropped', async () => {
+    // Findings carry no fingerprint this early, so outcomeKey is the title
+    // form and an orchestrator rename changes it. Matching on key alone would
+    // read this as a drop and resurrect the siblings underneath a
+    // representative that is still there.
+    const result = await run(pipelineWith(JSON.stringify({
+      findings: [{
+        file: 'foo.ts', line: 2, severity: 'critical', category: 'security',
+        title: 'Admin endpoint is reachable without authorization',
+        description: 'Reworded by the orchestrator, same defect and same line.',
+        suggestion: 'Add an authorization check.',
+      }],
+      mergeScore: 1,
+      mergeScoreReason: 'Critical.',
+    })));
+
+    const auth = result.findings.filter((f) => /authoriz/i.test(f.title));
+    expect(auth).toHaveLength(1);
+  });
+
+  it('gives a reinstated sibling its own terminal outcome, not "merged"', async () => {
+    // The ledger must not still claim the finding was merged away when the
+    // reader can see it — the failure #594 exists to prevent, arriving by a
+    // different route.
+    const result = await run(pipelineWith(JSON.stringify({
+      findings: [], mergeScore: 5, mergeScoreReason: 'No issues.',
+    })));
+
+    const surfacedTitles = new Set(result.findings.map((f) => f.title));
+    // Assert the population is non-empty BEFORE looping over it. Without this
+    // the checks below pass vacuously on a build where nothing is reinstated —
+    // which is exactly the broken state, so the test would have certified it.
+    const surfacedRows = result.filterOutcomes.filter(
+      (o) => /authorization/i.test(o.title) && surfacedTitles.has(o.title),
+    );
+    expect(surfacedRows.length).toBeGreaterThan(0);
+    for (const row of surfacedRows) {
+      expect(row.outcome).toBeDefined();
+      expect(row.outcome).not.toBe('merged');
+    }
+  });
+
+  it('explains an orchestrator drop instead of recording a bare stage', async () => {
+    // #600 — the one stage that can delete six findings was the only stage
+    // exempt from saying anything.
+    const result = await run(pipelineWith(JSON.stringify({
+      findings: [], mergeScore: 5, mergeScoreReason: 'No issues.',
+    })));
+
+    const drops = result.filterOutcomes.filter(
+      (o) => o.outcome === 'dropped' && o.stage === 'orchestrator',
+    );
+    for (const d of drops) {
+      expect(d.reason).toBeTruthy();
+      expect(d.reason).toContain("orchestrator's returned set");
+    }
+  });
+});
+
 describe('agentAuthored flag', () => {
   const allAgentsEnabled: ReviewPipelineOptions['enabledAgents'] = {
     security: true,
@@ -4163,9 +4302,17 @@ describe('filter outcome ledger (#470)', () => {
     expect(result.filterOutcomes.filter((o) => o.outcome === 'surfaced')).toHaveLength(1);
   });
 
-  it('attributes an orchestrator drop to its stage, with no reason', async () => {
-    // #473 would let the orchestrator explain itself; until then its drops are
-    // attributable but not explained, and the ledger should not invent a reason.
+  it('attributes an orchestrator drop to its stage AND says what is known (#600)', async () => {
+    // This asserted `reason` was undefined, on the #473 grounds that the
+    // orchestrator cannot explain itself and the ledger should not invent a
+    // rationale. The second half still holds; the first did not survive #600,
+    // where a silent orchestrator drop deleted five findings merged into one
+    // representative and the review rendered "No issues found in the diff".
+    //
+    // The reason below invents nothing. It states what IS observable — the
+    // finding was absent from the returned set — and names why nothing finer
+    // exists. That is strictly more than silence, and it is the difference
+    // between a drop a reader can interrogate and one they cannot see.
     const orchestrator = JSON.stringify({ findings: [], mergeScore: 5, mergeScoreReason: 'Clean.' });
     const result = await run([
       twoFindings, empty, empty, empty, empty, empty,
@@ -4176,7 +4323,9 @@ describe('filter outcome ledger (#470)', () => {
     expect(dropped).toHaveLength(2);
     for (const o of dropped) {
       expect(o.stage).toBe('orchestrator');
-      expect(o.reason).toBeUndefined();
+      expect(o.reason).toContain("orchestrator's returned set");
+      // Still no invented rationale: it cites #473 rather than guessing why.
+      expect(o.reason).toContain('#473');
     }
   });
 

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -3173,14 +3173,9 @@ export async function runReviewPipeline(
         tokens: extractSignificantTokens(`${m.primaryAfter.title} ${m.primaryAfter.description}`),
       });
     }
-    const into = outcomeKey(m.primaryAfter);
-    trace.alias(outcomeKey(m.primaryBefore), into);
-    for (const a of m.absorbed) {
-      trace.record(a, 'merged', 'fp-c-line-dedup', {
-        mergedInto: into,
-        reason: 'same file and line as a stronger finding, with overlapping wording',
-      });
-    }
+    // The alias must land NOW — later stages resolve through it. Only the
+    // `merged` verdicts on the absorbed siblings are deferred (#600, below).
+    trace.alias(outcomeKey(m.primaryBefore), outcomeKey(m.primaryAfter));
   }
   if (fpCResult.dedupedCount > 0) {
     console.warn(
@@ -3202,15 +3197,100 @@ export async function runReviewPipeline(
   );
 
   // #470 — the orchestrator is an LLM: it returns a new set, so what it
-  // dropped is only knowable by difference. It cannot explain itself without a
-  // schema change and extra output tokens (#473), so these record with a stage
-  // and no reason — attributable, but not explained. A finding whose title the
+  // dropped is only knowable by difference. A finding whose title the
   // orchestrator reworded reads here as a drop plus a new entry; that is what
   // is actually observable, and inventing a link would be a guess.
+  //
+  // #600 — these used to record with no reason at all, on the grounds that the
+  // orchestrator cannot explain itself without a schema change (#473). True,
+  // but it left the one stage that can delete six findings as the only stage
+  // exempt from saying anything. The reason below does not invent a rationale:
+  // it states what IS known — that the finding was absent from the returned
+  // set, and why no finer reason exists — which is strictly more than silence.
+  // Where a drop sent siblings back, it says that too, because that is the
+  // reader's only clue that one verdict moved more than one finding.
+  // #600 — a dropped FP-C representative used to take its absorbed siblings
+  // with it. FP-C merges same-(file,line) cross-agent findings into one
+  // representative; the orchestrator then judges that representative's TEXT. It
+  // never sees the siblings, so treating its verdict as a judgement on all of
+  // them attributes an opinion it did not form.
+  //
+  // The effect was inverted: convergence is what puts a finding into a cluster,
+  // and being in a cluster is what made it vanish — the more agents agreed, the
+  // more certain the finding was to disappear. On mergewatch/fixtures#2699 five
+  // findings were merged into "Missing authorization check for admin endpoint";
+  // the orchestrator dropped the representative and all six went, including a
+  // critical raised at confidence 95 by three independent agents. The review
+  // rendered "No issues found in the diff".
+  //
+  // So the siblings come back and earn their own terminal outcome. This is the
+  // issue's Option 1; Option 2 (forbid the drop) constrains the stage whose
+  // whole purpose is that judgement, and keeps a representative the
+  // orchestrator explicitly rejected.
+  //
+  // Cost, stated rather than waved at: a cluster the orchestrator meant to
+  // reject wholesale can return. It is bounded, not eliminated — capFindings
+  // ('max-findings', below) runs downstream, so reinstated siblings are still
+  // capped and cannot flood a review.
+  //
+  // Survival is key match OR same (file, line). Findings carry no fingerprint
+  // until after the orchestrator, so outcomeKey is the title form and a rename
+  // changes it; matching on key alone would read every rename as a drop and
+  // resurrect siblings under a representative that actually survived. The union
+  // is deliberately conservative about resurrecting.
+  /** #600 — representative key → how many siblings its drop sent back. */
+  const reinstatedFromRep = new Map<string, number>();
+  {
+    const survivingKeys = new Set(orchestratorResult.findings.map(outcomeKey));
+    const survivingSites = new Set(
+      orchestratorResult.findings.map((f) => `${f.file}:${f.line}`),
+    );
+    const reinstated: OrchestratedFinding[] = [];
+    for (const m of fpCResult.merges) {
+      if (!m.absorbed.length) continue;
+      const rep = m.primaryAfter;
+      const survived =
+        survivingKeys.has(outcomeKey(rep)) || survivingSites.has(`${rep.file}:${rep.line}`);
+      if (survived) {
+        // Deferred from FP-C: only now is the merge known to have held.
+        const into = outcomeKey(rep);
+        for (const a of m.absorbed as OrchestratedFinding[]) {
+          trace.record(a, 'merged', 'fp-c-line-dedup', {
+            mergedInto: into,
+            reason: 'same file and line as a stronger finding, with overlapping wording',
+          });
+        }
+        continue;
+      }
+      // Representative gone. The siblings were never judged, so they are not
+      // recorded here at all — they re-enter the pipeline and pick up whatever
+      // verdict a later stage gives them, exactly like any unmerged finding.
+      reinstatedFromRep.set(
+        outcomeKey(rep),
+        (reinstatedFromRep.get(outcomeKey(rep)) ?? 0) + m.absorbed.length,
+      );
+      reinstated.push(...(m.absorbed as OrchestratedFinding[]));
+    }
+    if (reinstated.length) {
+      console.warn(
+        '[fp-c] reinstated %d finding%s whose merge representative the orchestrator dropped',
+        reinstated.length,
+        reinstated.length === 1 ? '' : 's',
+      );
+      orchestratorResult.findings = [...orchestratorResult.findings, ...reinstated];
+    }
+  }
+
   recordDrops(
     dedupedTaggedFindings.flatMap((t) => (t.findings ?? []) as OrchestratedFinding[]),
     orchestratorResult.findings,
     'orchestrator',
+    (f) => {
+      const sent = reinstatedFromRep.get(outcomeKey(f));
+      return sent
+        ? `not in the orchestrator's returned set; the ${sent} finding${sent === 1 ? '' : 's'} merged into it ${sent === 1 ? 'was' : 'were'} reinstated`
+        : "not in the orchestrator's returned set (it does not emit per-finding reasons — #473)";
+    },
   );
 
   // #385 — W10 runs BEFORE the deleting filters below.


### PR DESCRIPTION
Closes #600. First P0 of v0.6.3.

## The defect

FP-C merges same-`(file,line)` cross-agent findings into one representative. The
orchestrator then judges **that representative's text** — it never sees the
siblings, because FP-C collapsed them upstream. Applying its verdict to all of
them attributes an opinion it never formed.

The effect is inverted: **convergence is what puts a finding into a cluster, and
being in a cluster is what made it vanish.** The more agents independently
agreed, the more certain the finding was to disappear.

On `mergewatch/fixtures#2699`, five findings merged into *"Missing authorization
check for admin endpoint"*. The orchestrator dropped the representative, all six
went with it — including a critical raised at **confidence 95 by three
independent agents** — and the review rendered a confident **"No issues found in
the diff"** over an unauthenticated admin endpoint.

## Decision: Option 1 (reinstate), and what it costs

The issue offers two options. Taking **Option 1**: the orchestrator judged one
finding's text, not six findings' merits. Option 2 (forbid the drop) constrains
the stage whose entire purpose is that judgement, and keeps a representative the
orchestrator explicitly rejected.

**Cost, stated plainly:** a cluster the orchestrator meant to reject wholesale
can come back. That is bounded rather than eliminated — `capFindings`
(`max-findings`) runs downstream, so reinstated siblings are still capped and
cannot flood a review.

## Implementation: deferred recording, not record-then-undo

Un-recording a `merged` verdict would mutate a terminal outcome — the invariant
**#594 exists to protect**. So the verdicts are deferred instead:

- FP-C still **aliases** the renamed survivor immediately; later stages resolve through it
- siblings are recorded `merged` only once the representative is known to have survived
- when it did not, they re-enter the pipeline and earn their own terminal outcome

**Survival = key match OR same `(file, line)`.** Findings carry no fingerprint
until after the orchestrator, so `outcomeKey` is the title form and a rename
changes it. Matching on key alone would read every rename as a drop and
resurrect siblings under a representative that is still there. The union is
deliberately conservative about resurrecting.

## Orchestrator drops now explain themselves

They recorded no reason, on the #473 grounds that the orchestrator cannot
explain itself. True — but it left the one stage that can delete six findings as
the only stage exempt from saying anything.

The reason invents no rationale. It states what **is** observable (absent from
the returned set), cites #473 for why nothing finer exists, and where a drop
sent siblings back, it says so — the reader's only clue that one verdict moved
more than one finding.

An existing #470 test asserted drops had **no** reason. That assertion is
**updated, not deleted**: it now asserts the new contract, including that the
reason still cites #473 rather than guessing.

## Tests — and which ones actually prove anything

5 added. Verified by stashing the fix and re-running:

| Test | Without the fix |
|---|---|
| returns the absorbed siblings when the representative is dropped | **fails** |
| gives a reinstated sibling its own terminal outcome, not "merged" | **fails** |
| explains an orchestrator drop instead of recording a bare stage | **fails** |
| does not duplicate siblings when the representative survives | passes — regression guard |
| treats a renamed representative as surviving | passes — regression guard |

The last two are guards, not evidence of the fix. Saying so rather than
presenting five passing tests as five proofs.

**One of them was vacuous on first write.** The ledger test looped over
reinstated siblings without asserting the set was non-empty — so on the broken
build, where nothing is reinstated, it passed by iterating over nothing. It now
asserts the population before iterating, and fails correctly.

## Verification

| | |
|---|---|
| `pnpm run build` | pass |
| `pnpm run typecheck` | pass |
| `pnpm run test` | **2307 tests, 21/21 tasks, `Cached: 0`** |
| `check-docs-structure` | pass |

## Acceptance

- [x] A dropped representative no longer silently removes its absorbed siblings
- [x] The chosen behaviour is recorded with its rationale, **including what it costs** — in `docs/false-positive-reduction-plan.md` under FP-C, and in the code comment
- [x] Orchestrator drops record a reason, like every other stage
- [ ] `28b-single-comment-critical` passes consistently across repeated runs — reported from the E2E gate after merge, not asserted here
