### PR TITLE
fix(core): keep test-coverage findings out of W10 so W11 can still suppress them

### DIFF
--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -2249,6 +2249,88 @@ describe('FP-C reinstatement when the orchestrator drops a representative (#600)
   });
 });
 
+// ─── #600 follow-up — W10 must not absorb a finding W11 will suppress ───────
+
+describe('test-coverage findings are held back from W10 when no harness is declared', () => {
+  const allAgents: ReviewPipelineOptions['enabledAgents'] = {
+    security: true, bugs: true, style: true, summary: true, diagram: true,
+    errorHandling: true, testCoverage: true, commentAccuracy: true,
+  };
+
+  it('keeps the "lacks test coverage" wording out of a cluster audit trail (E2E-27)', async () => {
+    // Caught by the E2E gate on #621. W11 collapses test-coverage findings into
+    // one info note when the conventions declare no harness — but if W10
+    // absorbed one first it was no longer top-level, W11 never saw it, and its
+    // wording still rendered inside the representative's "Related concerns"
+    // block. E2E-27 asserts that wording is absent, and it failed.
+    const securityResponse = validFindingsJson([{
+      line: 2, severity: 'critical', confidence: 90,
+      title: 'Path traversal risk in migration directory parameter',
+      description: 'The dir parameter accepts arbitrary directory paths.',
+    }]);
+    // Same region and a shared significant token ("migration"), so W10 would
+    // absorb this into the critical above if it were allowed to.
+    const testCoverageResponse = validFindingsJson([{
+      line: 3, severity: 'warning', confidence: 80,
+      title: 'Migration startup function lacks test coverage',
+      description: 'The migration bootstrap path has no test coverage.',
+    }]);
+    const empty = validFindingsJson([]);
+
+    const llm = createMockLLM([
+      securityResponse, empty, empty,         // security, bug, style
+      empty, testCoverageResponse, empty,     // errorHandling, testCoverage, commentAccuracy
+      JSON.stringify({ summary: 'Adds migrations.' }),
+      '%% overview\nflowchart TD\n  A-->B',
+      JSON.stringify({
+        findings: [
+          {
+            file: 'foo.ts', line: 2, severity: 'critical', category: 'security',
+            title: 'Path traversal risk in migration directory parameter',
+            description: 'The dir parameter accepts arbitrary directory paths.',
+            suggestion: 'Validate the path.',
+          },
+          {
+            file: 'foo.ts', line: 3, severity: 'warning', category: 'test-coverage',
+            title: 'Migration startup function lacks test coverage',
+            description: 'The migration bootstrap path has no test coverage.',
+            suggestion: 'Add a test.',
+          },
+        ],
+        mergeScore: 1,
+        mergeScoreReason: 'Critical.',
+      }),
+    ]);
+
+    const result = await runReviewPipeline(
+      {
+        diff: sampleDiff,
+        context: sampleContext,
+        modelId: 'heavy-model',
+        lightModelId: 'light-model',
+        maxFindings: 25,
+        enabledAgents: allAgents,
+        // W11 only fires on an explicit declaration.
+        conventions: 'This project has no unit test suite currently.',
+      },
+      { llm },
+    );
+
+    // The assertion E2E-27 makes, against the same surface: the nag wording
+    // must not appear anywhere the reader can see it — including inside
+    // another finding's clustered audit trail.
+    const rendered = result.findings
+      .map((f) => `${f.title}\n${f.description ?? ''}`)
+      .join('\n');
+    expect(rendered).not.toContain('lacks test coverage');
+
+    // And W11 actually ran rather than the finding simply vanishing.
+    expect(
+      result.findings.some((f) => /no test harness|test-coverage findings suppressed/i.test(f.title)),
+    ).toBe(true);
+  });
+});
+
 describe('agentAuthored flag', () => {
   const allAgentsEnabled: ReviewPipelineOptions['enabledAgents'] = {
     security: true,

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -3315,9 +3315,31 @@ export async function runReviewPipeline(
   // and a cluster-size cap keep over-clustering risk low. The absorbed
   // count rolls into the downstream suppressedCount math.
   {
-    const { findings: clustered, clusteredCount, merges } = clusterFindings(
-      orchestratorResult.findings,
-    );
+    // #600 follow-up — W11 (below) collapses every test-coverage finding into
+    // one info note when the repo's conventions declare no test harness. If
+    // W10 absorbs one FIRST it stops being a top-level finding, W11 never sees
+    // it, and its "lacks coverage" wording still renders inside the
+    // representative's audit trail. E2E-27 asserts exactly that wording is
+    // absent, and it caught this.
+    //
+    // This is the same shape as the bug #600 fixed: a merge making findings
+    // share a fate, so a downstream stage can no longer act on the absorbed
+    // ones. Reinstatement widened the exposure by putting more findings in
+    // front of W10, but the hole predates it — any test-coverage finding W10
+    // happened to absorb escaped W11 the same way.
+    //
+    // Held out rather than reordering the pipeline: #385 put W10 ahead of the
+    // deleting filters deliberately, so a region-spread cluster could not be
+    // dismantled by the confidence floor before consolidation saw it. That
+    // reasoning is about confidence, not category, and still holds.
+    const holdForW11 = detectNoTestHarness(conventions);
+    const clusterInput = holdForW11
+      ? orchestratorResult.findings.filter((f) => f.category !== 'test-coverage')
+      : orchestratorResult.findings;
+    const heldTestCoverage = holdForW11
+      ? orchestratorResult.findings.filter((f) => f.category === 'test-coverage')
+      : [];
+    const { findings: clustered, clusteredCount, merges } = clusterFindings(clusterInput);
     for (const m of merges) {
       const into = outcomeKey(m.primaryAfter);
       trace.alias(outcomeKey(m.primaryBefore), into);
@@ -3334,7 +3356,10 @@ export async function runReviewPipeline(
         clusteredCount,
         clusteredCount === 1 ? '' : 's',
       );
-      orchestratorResult.findings = clustered;
+      // Held findings rejoin here; W11 collapses them into its single note a
+      // few stages down. When nothing clustered, `orchestratorResult.findings`
+      // is left untouched and already contains them.
+      orchestratorResult.findings = [...clustered, ...heldTestCoverage];
     }
   }
 


### PR DESCRIPTION
Part of #600. Fixes the E2E gate failure #621 introduced — forward, not by revert.

## What broke

`27-no-harness` failed on #621's gate run. The nag wording it forbids appeared
inside a **W10 cluster audit trail**, not as its own row:

```
- src/migrations.ts:2 — Path traversal risk … — and 2 related concerns
  **Related concerns clustered into this finding (W10):**
  - src/migrations.ts:5 (warning) — … lacks test coverage for critical bootstrap path
```

**Confirmed from the dev logs for that exact review**, rather than inferred from
timing — I had already misattributed one gate failure in this cycle and was not
going to do it twice:

```
15:59:43  Starting review for mergewatch/fixtures#3064
16:00:06  [fp-c] merged 6 cross-agent findings at the same (file, line)
16:00:13  [fp-c] reinstated 2 findings whose representative the orchestrator dropped
16:00:13  [clustering] merged 3 related findings into existing clusters
```

## Root cause — the same shape as #600 itself

W11 collapses every test-coverage finding into one info note when the repo's
conventions declare no test harness. It filters **top-level** findings by
category. A finding W10 has already absorbed is no longer top-level, so W11
never sees it — but the audit trail still prints its text.

That is a merge making findings share a fate so a downstream stage cannot act on
the absorbed ones, which is precisely the defect #600 described. #621 widened the
exposure by putting more findings in front of W10; **the hole predates it** —
any test-coverage finding W10 happened to absorb escaped W11 the same way.

## The fix

When no harness is declared, hold test-coverage findings out of the clustering
input and rejoin them after. They stay top-level, and W11 collapses them as
designed.

**Held out rather than reordered.** #385 put W10 ahead of the deleting filters
deliberately, so a region-spread cluster could not be dismantled by the
confidence floor before consolidation saw it. That reasoning is about
*confidence*, not category, and still holds — so reordering would trade this bug
for the one #385 fixed.

## Test

Reproduces the gate failure at unit level: a critical and a test-coverage warning
in the same region sharing a significant token, with conventions declaring no
harness. Against the unfixed W10:

```
AssertionError: expected 'Path traversal risk in migration dire…'
  not to contain 'lacks test coverage'
```

Proven by stashing the fix and re-running, not assumed from a green run.

## Verification

| | |
|---|---|
| `pnpm run build` | pass |
| `pnpm run typecheck` | pass |
| `pnpm run test` | **2308 tests, 21/21 tasks, `Cached: 0`** |

## Note on what is still blocked

Production is on the Sep 10 stack. Both #620 (all 17 Dependabot alerts,
including a `js-yaml` CPU-exhaustion path reachable from untrusted
`.mergewatch.yml`) and #621 are merged to `main` and undeployed behind this gate.
This PR is what unblocks them.
