### PR TITLE
fix(core): attach the staleness note to the verdict, and drop a dangling quote

### DIFF
--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -19,6 +19,7 @@ import {
   runOrchestratorAgent,
   runDeltaCaptionAgent,
   runReviewPipeline,
+  stripDanglingQuote,
   extractFindingIdentifiers,
   groundFinding,
   describesAbsence,
@@ -2328,6 +2329,31 @@ describe('test-coverage findings are held back from W10 when no harness is decla
     expect(
       result.findings.some((f) => /no test harness|test-coverage findings suppressed/i.test(f.title)),
     ).toBe(true);
+  });
+});
+
+describe('stripDanglingQuote (#617)', () => {
+  it('drops a trailing quote the JSON salvage left behind', () => {
+    // Observed verbatim in production, in the most-read line of the product.
+    expect(stripDanglingQuote('Review recommended before merging."'))
+      .toBe('Review recommended before merging.');
+  });
+
+  it('preserves a reason that legitimately quotes an identifier', () => {
+    // Even count — balanced, so the trailing quote is real content. Stripping
+    // blind would corrupt this, which is why the rule is parity, not suffix.
+    const reason = 'The parameter is named "dir"';
+    expect(stripDanglingQuote(reason)).toBe(reason);
+  });
+
+  it('handles an odd count that is not a simple suffix', () => {
+    expect(stripDanglingQuote('He called it "safe to merge"" '))
+      .toBe('He called it "safe to merge"');
+  });
+
+  it('leaves an empty or quote-free reason untouched', () => {
+    expect(stripDanglingQuote('')).toBe('');
+    expect(stripDanglingQuote('No issues.')).toBe('No issues.');
   });
 });
 

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -1560,8 +1560,27 @@ export async function runOrchestratorAgent(
   return {
     findings: parsed.findings,
     mergeScore: Math.max(1, Math.min(5, mergeScore)),
-    mergeScoreReason: parsed.mergeScoreReason ?? '',
+    mergeScoreReason: stripDanglingQuote(parsed.mergeScoreReason ?? ''),
   };
+}
+
+/**
+ * #617 — drop a trailing `"` the JSON salvage path left behind.
+ *
+ * Observed verbatim on a real review, in the single most-read line of the
+ * product: `… Review recommended before merging."`. The reason survives
+ * truncation repair as a string value whose closing quote ends up inside the
+ * text rather than terminating it.
+ *
+ * Only an ODD number of quotes is unbalanced. A reason that legitimately
+ * quotes an identifier — `the "foo" parameter` — has an even count and is left
+ * exactly as written; stripping blind would corrupt it.
+ */
+export function stripDanglingQuote(reason: string): string {
+  const trimmed = reason.trimEnd();
+  if (!trimmed.endsWith('"')) return reason;
+  const quoteCount = (trimmed.match(/"/g) ?? []).length;
+  return quoteCount % 2 === 1 ? trimmed.slice(0, -1).trimEnd() : reason;
 }
 
 // ─── Full pipeline ─────────────────────────────────────────────────────────

--- a/packages/core/src/comment-formatter.test.ts
+++ b/packages/core/src/comment-formatter.test.ts
@@ -433,6 +433,47 @@ describe('formatReviewComment', () => {
   });
 
   // ─── FP-J L3 — dispute-rate disclosure ─────────────────────────────────
+  describe('#617 — a multi-paragraph reason stays inside the verdict blockquote', () => {
+    // FP-L appends a staleness note after a blank line when the orchestrator's
+    // prose names more findings than render. The verdict renders inside a
+    // `> ` blockquote, where a blank line ends the quote — so the note landed
+    // as detached body text below the verdict, severed from the enumeration it
+    // was correcting.
+    const reason =
+      'Three substantive warnings present — one on React key uniqueness, one on error-handling opacity, and one on missing test coverage.\n\n' +
+      'Note: 2 findings were dropped or clustered by post-orchestrator filtering — the rendered list is authoritative.';
+
+    it('keeps the note attached to the verdict line', () => {
+      const result = formatReviewComment(baseOptions({ mergeScore: 3, mergeScoreReason: reason }));
+      const noteLine = result
+        .split('\n')
+        .find((l) => l.includes('rendered list is authoritative'));
+      expect(noteLine).toBeDefined();
+      // The assertion that actually bites: the note must be quoted. Before
+      // this fix it rendered as a bare line, which is the whole defect.
+      expect(noteLine!.startsWith('>')).toBe(true);
+    });
+
+    it('keeps the verdict sentence itself on the badge line', () => {
+      const result = formatReviewComment(baseOptions({ mergeScore: 3, mergeScoreReason: reason }));
+      const badge = result.split('\n').find((l) => l.includes('3/5'))!;
+      expect(badge).toContain('Three substantive warnings present');
+      // …and the note must NOT be jammed onto the badge line, which would be
+      // the other way to "fix" this and would bury the caveat mid-sentence.
+      expect(badge).not.toContain('rendered list is authoritative');
+    });
+
+    it('leaves an ordinary single-paragraph reason unchanged', () => {
+      const result = formatReviewComment(baseOptions({
+        mergeScore: 3,
+        mergeScoreReason: 'Several warnings need attention',
+      }));
+      const badge = result.split('\n').find((l) => l.includes('3/5'))!;
+      expect(badge).toContain('Several warnings need attention');
+      expect(result).not.toContain('<sub>Several warnings');
+    });
+  });
+
   describe('FP-J L3 disputeDisclosure', () => {
     it('renders the disclosure as a quieter sub-line beneath the merge-score badge', () => {
       const result = formatReviewComment(baseOptions({

--- a/packages/core/src/comment-formatter.ts
+++ b/packages/core/src/comment-formatter.ts
@@ -306,6 +306,21 @@ export function mergeScoreMeta(
 export const REVIEW_SCOPE_NOTE =
   'Reviewed the diff only — MergeWatch does not build, run tests, or read other checks.';
 
+/**
+ * Split a merge-score reason into its verdict sentence and any trailing notes.
+ *
+ * #617 — reasons are single-paragraph in the common case. FP-L appends a
+ * staleness note after a blank line, and the verdict renders inside a
+ * blockquote, where a blank line silently ends the quote.
+ */
+function splitReasonParagraphs(reason: string | undefined): string[] {
+  if (!reason) return [];
+  return reason
+    .split(/\n\s*\n/)
+    .map((p) => p.replace(/\s+/g, ' ').trim())
+    .filter(Boolean);
+}
+
 /** Render the merge score as a prominent badge line. */
 function renderMergeScore(score: number, hasNotes: boolean): string {
   const { emoji, label, score: clamped } = mergeScoreMeta(score, hasNotes);
@@ -710,8 +725,22 @@ export function formatReviewComment(options: FormatOptions): string {
     // happened to the ones there were.
     const hasNotes = findings.length > 0 || Boolean(mergeScoreReason);
     const scoreDisplay = renderMergeScore(mergeScore, hasNotes);
-    const reasonSuffix = mergeScoreReason ? ` \u2014 ${mergeScoreReason}` : '';
+    // #617 — the reason can carry trailing paragraphs: FP-L's narrative
+    // staleness note is appended after a blank line when the orchestrator's
+    // prose names more findings than render. Interpolating that straight into
+    // a `> ` line ends the blockquote at the blank line, so the note landed as
+    // detached body text underneath the verdict — a correction severed from
+    // the claim it corrects, which reads as unrelated prose rather than as a
+    // caveat on the enumeration directly above it.
+    //
+    // First paragraph stays the verdict sentence; the rest render as quoted
+    // sub-lines, the same shape the dispute disclosure below already uses.
+    const [verdictSentence, ...reasonNotes] = splitReasonParagraphs(mergeScoreReason);
+    const reasonSuffix = verdictSentence ? ` — ${verdictSentence}` : '';
     score.push(`> ${scoreDisplay}${reasonSuffix}`);
+    for (const note of reasonNotes) {
+      score.push(`> <sub>${note}</sub>`);
+    }
     // FP-J L3 \u2014 dispute-rate disclosure renders as a quieter sub-line so the
     // primary verdict stays the most visible signal. Only emitted when the
     // reconcile pass identified at least one action finding from a


### PR DESCRIPTION
Closes #617. Two defects on the single most-read line of the product.

## 1. The mitigation existed — it just wasn't visible

I filed this issue as *"the summary describes findings the reader cannot see"*,
implying nothing guarded against it. **Something does.**
`reconcileNarrativeStaleness` (#185 follow-up) already fires on the partial-filter
path and appends:

> Note: N findings were dropped or clustered by post-orchestrator filtering — the
> rendered list is authoritative.

Verified by driving `reconcileMergeScore` directly with 3 orchestrator warnings
and 1 surviving finding.

**The real defect:** it is appended after a blank line, and the verdict renders
inside a `> ` blockquote — where a blank line *ends the quote*. So it landed as
bare body text, detached from the enumeration it corrects:

```
> 🟡 **3/5 — Review recommended** — Three substantive warnings present — one on
  React key uniqueness, one on error-handling opacity, and one on missing test coverage.
Note: 2 findings were dropped or clustered by post-orchestrator filtering — …
```

A correction severed from its claim is close to no correction. The reader sees an
authoritative-sounding enumeration in the verdict and an unrelated-looking
sentence below it.

Now the first paragraph stays the verdict sentence and the rest render as quoted
sub-lines — the same shape the dispute disclosure already uses.

**Deliberately not done:** replacing the orchestrator's prose when counts
mismatch. #185 chose append-over-replace on purpose, the prose carries the score
rationale, and partial filtering is common. Overturning that is a real
behavioural change and deserves its own decision rather than riding along with a
rendering fix. Recorded on the issue.

## 2. A dangling quote reaching the verdict

Observed verbatim in production: `… Review recommended before merging."`

Stripped only when the quote count is **odd**. A reason that legitimately quotes
an identifier — `the "dir" parameter` — has an even count and is left exactly as
written. Parity, not suffix: the blind version corrupts real content.

## Tests — which ones actually bite

7 added. Proven by stashing the fix and re-running:

| Test | Without the fix |
|---|---|
| keeps the note attached to the verdict line | **fails** |
| keeps the verdict sentence on the badge line | passes — guard |
| leaves a single-paragraph reason unchanged | passes — guard |
| 4 × `stripDanglingQuote` cases | fail, but only because the symbol is absent |

The last four are weaker evidence than a behavioural failure — they lock the
parity rule going forward rather than demonstrating a fixed bug. Saying so rather
than presenting seven passing tests as seven proofs.

## Verification

| | |
|---|---|
| `pnpm run build` | pass |
| `pnpm run typecheck` | pass |
| `pnpm run test` | **2315 tests, 21/21 tasks, `Cached: 0`** |
