### PR TITLE
fix(core): make stripDanglingQuote depend on quote parity alone

### DIFF
--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -2355,6 +2355,17 @@ describe('stripDanglingQuote (#617)', () => {
     expect(stripDanglingQuote('')).toBe('');
     expect(stripDanglingQuote('No issues.')).toBe('No issues.');
   });
+
+  it('normalises trailing whitespace on every path, not just the stripping one', () => {
+    // Review finding on #623. The odd branch returned the trimmed string while
+    // the other two returned the original, so the result depended on which
+    // branch ran rather than on the quote parity this function exists to
+    // decide. Harmless today because the formatter re-normalises downstream —
+    // which is exactly how an inconsistency survives long enough to matter.
+    expect(stripDanglingQuote('foo "bar"  ')).toBe('foo "bar"');   // even
+    expect(stripDanglingQuote('plain text  ')).toBe('plain text'); // no quotes
+    expect(stripDanglingQuote('ends dangling."  ')).toBe('ends dangling.'); // odd
+  });
 });
 
 describe('agentAuthored flag', () => {

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -1578,9 +1578,14 @@ export async function runOrchestratorAgent(
  */
 export function stripDanglingQuote(reason: string): string {
   const trimmed = reason.trimEnd();
-  if (!trimmed.endsWith('"')) return reason;
+  if (!trimmed.endsWith('"')) return trimmed;
   const quoteCount = (trimmed.match(/"/g) ?? []).length;
-  return quoteCount % 2 === 1 ? trimmed.slice(0, -1).trimEnd() : reason;
+  // Review finding on #623: the odd branch returned `trimmed`, the others
+  // returned the original `reason`, so identical inputs differing only in
+  // trailing whitespace left by the same function in different states. Always
+  // returning `trimmed` makes the result depend on the quote parity alone,
+  // which is the only thing this function is deciding.
+  return quoteCount % 2 === 1 ? trimmed.slice(0, -1).trimEnd() : trimmed;
 }
 
 // ─── Full pipeline ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Addresses the review finding on #623 — which **I merged without addressing**.

## The finding was right

`stripDanglingQuote` returned `trimmed` on the odd-count branch and the original `reason` on the even-count and no-quote branches. The result therefore depended on *which branch ran* rather than on the quote parity the function exists to decide:

```
'foo "bar"  '        → 'foo "bar"  '   (even — trailing spaces kept)
'ends dangling."  '  → 'ends dangling.' (odd  — trimmed)
```

Latent, not live: the formatter re-normalises whitespace downstream. Which is exactly how this kind of inconsistency survives long enough to eventually matter.

All paths now return `trimmed`.

## Why this is a follow-up and not part of #623

I merged #623 on a **🟢 4/5** verdict carrying this warning. My merge gate matched on the green emoji, so it treated 4/5-with-a-finding the same as 5/5-no-action-items — the precise distinction I have been relying on all session to avoid merging unclean reviews. The gate encoded "is it green", not "is it clean".

Recorded plainly rather than quietly fixed, because the automation flaw is more interesting than the one-character bug it let through.

## Test

Asserts all three branches. Against the merged version it fails with:

```
AssertionError: expected 'foo "bar"  ' to be 'foo "bar"'
```

## Verification

| | |
|---|---|
| `pnpm run build` | pass |
| `pnpm run typecheck` | pass |
| `pnpm run test` | **2316 tests, 21/21 tasks, `Cached: 0`** |